### PR TITLE
Add `init()` for reindex, use `reindex` instead of `update` in hooks

### DIFF
--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -14,7 +14,7 @@ const hookScript = `#!/bin/sh
 # git-pkgs post-commit/post-merge hook
 # Updates the dependency database after commits/merges
 
-git pkgs update --quiet 2>/dev/null || true
+git pkgs reindex --quiet 2>/dev/null || true
 `
 
 var hookNames = []string{"post-commit", "post-merge"}
@@ -87,7 +87,7 @@ func doInstallHooks(cmd *cobra.Command, hooksDir string) error {
 				return fmt.Errorf("opening %s hook: %w", hookName, openErr)
 			}
 
-			_, writeErr := f.WriteString("\n# git-pkgs hook\ngit pkgs update --quiet 2>/dev/null || true\n")
+			_, writeErr := f.WriteString("\n# git-pkgs hook\ngit pkgs reindex --quiet 2>/dev/null || true\n")
 			_ = f.Close()
 			if writeErr != nil {
 				return fmt.Errorf("appending to %s hook: %w", hookName, writeErr)
@@ -145,7 +145,7 @@ func doUninstallHooks(cmd *cobra.Command, hooksDir string) error {
 					skipNext = true
 					continue
 				}
-				if strings.Contains(line, "git pkgs update") {
+				if strings.Contains(line, "git pkgs reindex") {
 					continue
 				}
 				newLines = append(newLines, line)
@@ -219,7 +219,7 @@ func installHooks(repo *git.Repository) error {
 			if openErr != nil {
 				return openErr
 			}
-			_, writeErr := f.WriteString("\n# git-pkgs hook\ngit pkgs update --quiet 2>/dev/null || true\n")
+			_, writeErr := f.WriteString("\n# git-pkgs hook\ngit pkgs reindex --quiet 2>/dev/null || true\n")
 			_ = f.Close()
 			if writeErr != nil {
 				return writeErr

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -9,6 +9,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	addReindexCmd(rootCmd)
+}
+
 func addReindexCmd(parent *cobra.Command) {
 	reindexCmd := &cobra.Command{
 		Use:   "reindex",


### PR DESCRIPTION
As it is, `git pkgs reindex` is not available from the command line, due to missing an `init()` method.

Additionally, the hooks were still using the old command for updating the database (`git pkgs update`), even though the docs had the new version?