### PR TITLE
Add more color support: `--color=always`, `$FORCE_COLOR`

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -8,9 +8,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type ColorOutput int
+
+const (
+	Auto ColorOutput = iota
+	Always
+	Never
+)
+
 var (
-	// NoColor disables color output when true
-	NoColor bool
+	Color ColorOutput
 	// UsePager enables pager for long output
 	UsePager bool
 )
@@ -27,15 +34,39 @@ const (
 	colorDim    = "\033[2m"
 )
 
+func parseColor(s string) ColorOutput {
+	switch s {
+	case "always":
+		return Always
+	case "never":
+		return Never
+	default:
+		return Auto
+	}
+}
+
 // IsColorEnabled returns true if color output should be used
+//
+// precedence:
+// - current command config `--color=always` / `--color=never`
+// - `$NO_COLOR` https://no-color.org/
+// - `$FORCE_COLOR` https://force-color.org/
+// - `$TERM` / stdout detection
 func IsColorEnabled() bool {
-	if NoColor {
+	switch Color {
+	case Always:
+		return true
+	case Never:
 		return false
+	case Auto:
 	}
 
 	// Check NO_COLOR environment variable (standard)
 	if os.Getenv("NO_COLOR") != "" {
 		return false
+	}
+	if os.Getenv("FORCE_COLOR") != "" {
+		return true
 	}
 
 	// Check TERM for dumb terminals

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,12 +17,8 @@ var rootCmd = &cobra.Command{
 	Long: `git-pkgs indexes package dependencies from manifest files across your git history,
 enabling you to query what packages were used, when they changed, and identify
 potential security vulnerabilities.`,
-	SilenceUsage: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		// Update global flags
-		NoColor, _ = cmd.Flags().GetBool("no-color")
-		UsePager, _ = cmd.Flags().GetBool("pager")
-	},
+	SilenceUsage:     true,
+	PersistentPreRun: preRun,
 }
 
 func Execute() error {
@@ -36,15 +32,10 @@ func NewRootCmd() *cobra.Command {
 		Long: `git-pkgs indexes package dependencies from manifest files across your git history,
 enabling you to query what packages were used, when they changed, and identify
 potential security vulnerabilities.`,
-		SilenceUsage: true,
-		PersistentPreRun: func(c *cobra.Command, args []string) {
-			NoColor, _ = c.Flags().GetBool("no-color")
-			UsePager, _ = c.Flags().GetBool("pager")
-		},
+		SilenceUsage:     true,
+		PersistentPreRun: preRun,
 	}
-	cmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-essential output")
-	cmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
-	cmd.PersistentFlags().BoolP("pager", "p", false, "Use pager for output")
+	addPersistentFlags(cmd)
 
 	// Add all subcommands
 	addInitCmd(cmd)
@@ -86,8 +77,19 @@ potential security vulnerabilities.`,
 	return cmd
 }
 
+func preRun(cmd *cobra.Command, args []string) {
+	c, _ := cmd.Flags().GetString("color")
+	Color = parseColor(c)
+	UsePager, _ = cmd.Flags().GetBool("pager")
+}
+
+func addPersistentFlags(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+	flags.BoolP("quiet", "q", false, "Suppress non-essential output")
+	flags.BoolP("pager", "p", false, "Use pager for output")
+	flags.String("color", "auto", "When to colorize output: auto, always, never")
+}
+
 func init() {
-	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Suppress non-essential output")
-	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
-	rootCmd.PersistentFlags().BoolP("pager", "p", false, "Use pager for output")
+	addPersistentFlags(rootCmd)
 }

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -19,7 +19,7 @@ internal/
 
 ## Entry Point
 
-The CLI uses [cobra](https://github.com/spf13/cobra). Each command is registered in `cmd/` via `init()` functions. The root command handles global flags (`--quiet`, `--no-color`, `--no-pager`) and dispatches to subcommands.
+The CLI uses [cobra](https://github.com/spf13/cobra). Each command is registered in `cmd/` via `init()` functions. The root command handles global flags (`--quiet`, `--color=auto`, `--no-pager`) and dispatches to subcommands.
 
 ## Database
 


### PR DESCRIPTION
Previously, there was a way to _disable_ color output, but no way to _force_ it. This makes it annoying to use in cases where the output is externally paged, such as a `jj`
[diff tool](https://www.jj-vcs.dev/latest/config/#generating-diffs-by-external-command).

Now, the user can specify `--color=always` to force color, or `--color=never` for the old behaviour of `--no-color`.

Precedence rules:

> User-level configuration files and per-instance command-line arguments
> should override the NO_COLOR environment variable.
https://no-color.org

1. Current command line arguments, i.e. `--color=always`.
2. `$NO_COLOR`
3. `$FORCE_COLOR`
4. various terminal detection methods