### PR TITLE
Use the same `cobra.Command` for tests and main

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addAddCmd(rootCmd)
-}
-
 const defaultAddTimeout = 5 * time.Minute
 
 func addAddCmd(parent *cobra.Command) {

--- a/cmd/bisect.go
+++ b/cmd/bisect.go
@@ -12,10 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addBisectCmd(rootCmd)
-}
-
 func addBisectCmd(parent *cobra.Command) {
 	bisectCmd := &cobra.Command{
 		Use:   "bisect",

--- a/cmd/blame.go
+++ b/cmd/blame.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addBlameCmd(rootCmd)
-}
-
 func addBlameCmd(parent *cobra.Command) {
 	blameCmd := &cobra.Command{
 		Use:   "blame",

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addBranchCmd(rootCmd)
-}
-
 func addBranchCmd(parent *cobra.Command) {
 	branchCmd := &cobra.Command{
 		Use:   "branch",

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -26,10 +26,6 @@ func (e *PathNotSupportedError) ExitCode() int {
 	return 2
 }
 
-func init() {
-	addBrowseCmd(rootCmd)
-}
-
 const defaultBrowseTimeout = 30 * time.Second
 
 func addBrowseCmd(parent *cobra.Command) {

--- a/cmd/completions.go
+++ b/cmd/completions.go
@@ -7,10 +7,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addCompletionsCmd(rootCmd)
-}
-
 func addCompletionsCmd(parent *cobra.Command) {
 	completionCmd := &cobra.Command{
 		Use:   "completion [shell]",

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addDiffCmd(rootCmd)
-}
-
 func addDiffCmd(parent *cobra.Command) {
 	diffCmd := &cobra.Command{
 		Use:   "diff [from..to]",

--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -33,10 +33,6 @@ var lockfilePatterns = []string{
 	"*.resolved",
 }
 
-func init() {
-	addDiffDriverCmd(rootCmd)
-}
-
 func addDiffDriverCmd(parent *cobra.Command) {
 	diffDriverCmd := &cobra.Command{
 		Use:   "diff-driver [file]",

--- a/cmd/diff_file.go
+++ b/cmd/diff_file.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addDiffFileCmd(rootCmd)
-}
-
 func addDiffFileCmd(parent *cobra.Command) {
 	diffFileCmd := &cobra.Command{
 		Use:   "diff-file [from] [to]",

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addHistoryCmd(rootCmd)
-}
-
 func addHistoryCmd(parent *cobra.Command) {
 	historyCmd := &cobra.Command{
 		Use:   "history [package]",

--- a/cmd/hooks.go
+++ b/cmd/hooks.go
@@ -19,10 +19,6 @@ git pkgs reindex --quiet 2>/dev/null || true
 
 var hookNames = []string{"post-commit", "post-merge"}
 
-func init() {
-	addHooksCmd(rootCmd)
-}
-
 func addHooksCmd(parent *cobra.Command) {
 	hooksCmd := &cobra.Command{
 		Use:   "hooks",

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addInfoCmd(rootCmd)
-}
-
 func addInfoCmd(parent *cobra.Command) {
 	infoCmd := &cobra.Command{
 		Use:   "info",

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addInitCmd(rootCmd)
-}
-
 func addInitCmd(parent *cobra.Command) {
 	initCmd := &cobra.Command{
 		Use:   "init",

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addInstallCmd(rootCmd)
-}
-
 const defaultInstallTimeout = 10 * time.Minute
 
 func addInstallCmd(parent *cobra.Command) {

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -15,10 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addIntegrityCmd(rootCmd)
-}
-
 func addIntegrityCmd(parent *cobra.Command) {
 	integrityCmd := &cobra.Command{
 		Use:   "integrity",

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -17,10 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addLicensesCmd(rootCmd)
-}
-
 func addLicensesCmd(parent *cobra.Command) {
 	licensesCmd := &cobra.Command{
 		Use:   "licenses",

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addListCmd(rootCmd)
-}
-
 func addListCmd(parent *cobra.Command) {
 	listCmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addLogCmd(rootCmd)
-}
-
 func addLogCmd(parent *cobra.Command) {
 	logCmd := &cobra.Command{
 		Use:   "log",

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -15,10 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addOutdatedCmd(rootCmd)
-}
-
 func addOutdatedCmd(parent *cobra.Command) {
 	outdatedCmd := &cobra.Command{
 		Use:   "outdated",

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addReindexCmd(rootCmd)
-}
-
 func addReindexCmd(parent *cobra.Command) {
 	reindexCmd := &cobra.Command{
 		Use:   "reindex",

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addRemoveCmd(rootCmd)
-}
-
 const defaultRemoveTimeout = 5 * time.Minute
 
 func addRemoveCmd(parent *cobra.Command) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,31 +7,25 @@ import (
 var version = "unknown"
 var commit = "unknown"
 var date = "unknown"
+var versionStr = version +
+	"\n          commit " + commit +
+	"\n            date " + date
 
-var rootCmd = &cobra.Command{
-	Use: "git-pkgs",
-	Version: version +
-		"\n          commit " + commit +
-		"\n            date " + date,
-	Short: "Track package dependencies across git history",
-	Long: `git-pkgs indexes package dependencies from manifest files across your git history,
+const shortDesc = "Track package dependencies across git history"
+const longDesc = `git-pkgs indexes package dependencies from manifest files across your git history,
 enabling you to query what packages were used, when they changed, and identify
-potential security vulnerabilities.`,
-	SilenceUsage:     true,
-	PersistentPreRun: preRun,
-}
+potential security vulnerabilities.`
 
 func Execute() error {
-	return rootCmd.Execute()
+	return NewRootCmd().Execute()
 }
 
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "git-pkgs",
-		Short: "Track package dependencies across git history",
-		Long: `git-pkgs indexes package dependencies from manifest files across your git history,
-enabling you to query what packages were used, when they changed, and identify
-potential security vulnerabilities.`,
+		Use:              "git-pkgs",
+		Version:          versionStr,
+		Short:            shortDesc,
+		Long:             longDesc,
 		SilenceUsage:     true,
 		PersistentPreRun: preRun,
 	}
@@ -88,8 +82,4 @@ func addPersistentFlags(cmd *cobra.Command) {
 	flags.BoolP("quiet", "q", false, "Suppress non-essential output")
 	flags.BoolP("pager", "p", false, "Use pager for output")
 	flags.String("color", "auto", "When to colorize output: auto, always, never")
-}
-
-func init() {
-	addPersistentFlags(rootCmd)
 }

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -14,10 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addSBOMCmd(rootCmd)
-}
-
 func addSBOMCmd(parent *cobra.Command) {
 	sbomCmd := &cobra.Command{
 		Use:   "sbom",

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addSchemaCmd(rootCmd)
-}
-
 func addSchemaCmd(parent *cobra.Command) {
 	schemaCmd := &cobra.Command{
 		Use:   "schema",

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addSearchCmd(rootCmd)
-}
-
 func addSearchCmd(parent *cobra.Command) {
 	searchCmd := &cobra.Command{
 		Use:   "search <pattern>",

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addShowCmd(rootCmd)
-}
-
 func addShowCmd(parent *cobra.Command) {
 	showCmd := &cobra.Command{
 		Use:   "show [commit]",

--- a/cmd/stale.go
+++ b/cmd/stale.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addStaleCmd(rootCmd)
-}
-
 func addStaleCmd(parent *cobra.Command) {
 	staleCmd := &cobra.Command{
 		Use:   "stale",

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addStatsCmd(rootCmd)
-}
-
 func addStatsCmd(parent *cobra.Command) {
 	statsCmd := &cobra.Command{
 		Use:   "stats",

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -11,10 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addTreeCmd(rootCmd)
-}
-
 func addTreeCmd(parent *cobra.Command) {
 	treeCmd := &cobra.Command{
 		Use:   "tree",

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addUpdateCmd(rootCmd)
-}
-
 const defaultUpdateTimeout = 10 * time.Minute
 
 func addUpdateCmd(parent *cobra.Command) {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -9,10 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addUpgradeCmd(rootCmd)
-}
-
 func addUpgradeCmd(parent *cobra.Command) {
 	upgradeCmd := &cobra.Command{
 		Use:   "upgrade",

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -15,10 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addVulnsCmd(rootCmd)
-}
-
 func addVulnsCmd(parent *cobra.Command) {
 	vulnsCmd := &cobra.Command{
 		Use:   "vulns",

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -13,10 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addWhereCmd(rootCmd)
-}
-
 func addWhereCmd(parent *cobra.Command) {
 	whereCmd := &cobra.Command{
 		Use:   "where <package>",

--- a/cmd/why.go
+++ b/cmd/why.go
@@ -10,10 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	addWhyCmd(rootCmd)
-}
-
 func addWhyCmd(parent *cobra.Command) {
 	whyCmd := &cobra.Command{
 		Use:   "why <package>",


### PR DESCRIPTION
When I was doing #30, I was initially confused why my new command wasn't being added to the CLI even though I had put it in the `NewRootCmd()`. I don't _think_ there's a reason to have a completely separate command for running and for testing, so this just goes from two sources of truth to one.