### PR TITLE
Fix reindex integration test running hooks

### DIFF
--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -400,7 +400,7 @@ func TestReindexCommand(t *testing.T) {
 		cleanup := chdir(t, repoDir)
 		defer cleanup()
 
-		_, _, err := runCmd(t, "init")
+		_, _, err := runCmd(t, "init", "--no-hooks")
 		if err != nil {
 			t.Fatalf("init failed: %v", err)
 		}
@@ -423,7 +423,7 @@ func TestReindexCommand(t *testing.T) {
 		cleanup := chdir(t, repoDir)
 		defer cleanup()
 
-		_, _, err := runCmd(t, "init")
+		_, _, err := runCmd(t, "init", "--no-hooks")
 		if err != nil {
 			t.Fatalf("init failed: %v", err)
 		}


### PR DESCRIPTION
The previous implementation passes CI due to not having `git-pkgs` available on the path, so the hook does nothing. Locally, if you have `git-pkgs` installed, this test fails due to the hook updating the database before the test has a chance to.

The point of the test is to see the `git-pkgs reindex` output directly, so the hook should just be disabled.