### PR TITLE
Fix --pager for all commands

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -29,9 +29,6 @@ Changes are shown in chronological order.`,
 }
 
 func runHistory(cmd *cobra.Command, args []string) error {
-	cleanup := SetupPager(cmd)
-	defer cleanup()
-
 	packageName := ""
 	if len(args) > 0 {
 		packageName = args[0]

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,9 +31,6 @@ Defaults to HEAD if no commit is specified.`,
 }
 
 func runList(cmd *cobra.Command, args []string) error {
-	cleanup := SetupPager(cmd)
-	defer cleanup()
-
 	commitRef, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -28,9 +28,6 @@ func addLogCmd(parent *cobra.Command) {
 }
 
 func runLog(cmd *cobra.Command, args []string) error {
-	cleanup := SetupPager(cmd)
-	defer cleanup()
-
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	author, _ := cmd.Flags().GetString("author")
 	since, _ := cmd.Flags().GetString("since")

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -20,6 +20,8 @@ var (
 	Color ColorOutput
 	// UsePager enables pager for long output
 	UsePager bool
+	// pagerCleanup holds the cleanup function for the active pager
+	pagerCleanup func()
 )
 
 // Color codes for terminal output
@@ -123,6 +125,23 @@ func Bold(text string) string {
 // Dim returns text in dim/faded style
 func Dim(text string) string {
 	return Colorize(text, colorDim)
+}
+
+// SetupOutput configures colour and pager for a command
+func SetupOutput(cmd *cobra.Command) {
+	c, _ := cmd.Flags().GetString("color")
+	Color = parseColor(c)
+	UsePager, _ = cmd.Flags().GetBool("pager")
+	cleanup := SetupPager(cmd)
+	pagerCleanup = cleanup
+}
+
+// CleanupOutput tears down the pager if one is active
+func CleanupOutput() {
+	if pagerCleanup != nil {
+		pagerCleanup()
+		pagerCleanup = nil
+	}
 }
 
 // GetPager returns the pager command to use

--- a/cmd/pager_test.go
+++ b/cmd/pager_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestPagerFlagAccepted(t *testing.T) {
+	commands := []string{
+		"blame",
+		"show",
+		"tree",
+		"search",
+		"diff",
+		"where",
+		"why",
+		"stats",
+		"stale",
+		"log",
+		"list",
+		"history",
+	}
+
+	for _, name := range commands {
+		t.Run(name, func(t *testing.T) {
+			root := NewRootCmd()
+			root.SetArgs([]string{name, "--pager", "--help"})
+			err := root.Execute()
+			if err != nil {
+				t.Fatalf("%s --pager --help failed: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestUsePagerSetByFlag(t *testing.T) {
+	// Reset global state
+	UsePager = false
+
+	root := NewRootCmd()
+	// list without a repo will fail in RunE, but PersistentPreRun still runs
+	root.SetArgs([]string{"--pager", "list"})
+	_ = root.Execute()
+
+	if !UsePager {
+		t.Error("expected UsePager to be true after --pager flag")
+	}
+
+	// Clean up
+	UsePager = false
+}
+
+func TestCleanupOutputSafe(t *testing.T) {
+	// CleanupOutput should be safe to call when no pager is active
+	pagerCleanup = nil
+	CleanupOutput()
+
+	// And when a cleanup function is set, it should be called and nilled
+	called := false
+	pagerCleanup = func() { called = true }
+	CleanupOutput()
+
+	if !called {
+		t.Error("expected pagerCleanup to be called")
+	}
+	if pagerCleanup != nil {
+		t.Error("expected pagerCleanup to be nil after CleanupOutput")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,8 +26,9 @@ func NewRootCmd() *cobra.Command {
 		Version:          versionStr,
 		Short:            shortDesc,
 		Long:             longDesc,
-		SilenceUsage:     true,
-		PersistentPreRun: preRun,
+		SilenceUsage:      true,
+		PersistentPreRun:  preRun,
+		PersistentPostRun: postRun,
 	}
 	addPersistentFlags(cmd)
 
@@ -72,9 +73,11 @@ func NewRootCmd() *cobra.Command {
 }
 
 func preRun(cmd *cobra.Command, args []string) {
-	c, _ := cmd.Flags().GetString("color")
-	Color = parseColor(c)
-	UsePager, _ = cmd.Flags().GetBool("pager")
+	SetupOutput(cmd)
+}
+
+func postRun(cmd *cobra.Command, args []string) {
+	CleanupOutput()
 }
 
 func addPersistentFlags(cmd *cobra.Command) {


### PR DESCRIPTION
Move pager setup from per-command RunE functions into PersistentPreRun/PersistentPostRun on the root command so every subcommand gets pager support automatically. Previously only log, list, and history called SetupPager; commands like blame, show, tree, etc. silently ignored the flag.

Fixes #45