### PR TITLE
Treat go.sum as a supplement to go.mod, not a standalone lockfile

### DIFF
--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -24,7 +24,6 @@ var lockfilePatterns = []string{
 	"Pipfile.lock",
 	"poetry.lock",
 	"composer.lock",
-	"go.sum",
 	"pubspec.lock",
 	"Podfile.lock",
 	"mix.lock",

--- a/cmd/managers.go
+++ b/cmd/managers.go
@@ -85,9 +85,7 @@ var ecosystemConfigs = []ecosystemConfig{
 		Ecosystem: "go",
 		Manifest:  "go.mod",
 		Default:   "gomod",
-		Lockfiles: []lockfileMapping{
-			{"go.sum", "gomod"},
-		},
+		Lockfiles: []lockfileMapping{},
 	},
 	{
 		Ecosystem: "pypi",

--- a/cmd/managers_test.go
+++ b/cmd/managers_test.go
@@ -65,7 +65,7 @@ func TestDetectManagers(t *testing.T) {
 			expected: []string{"cargo"},
 		},
 		{
-			name: "gomod from go.sum",
+			name: "gomod from go.mod (go.sum is not a lockfile)",
 			files: map[string]string{
 				"go.mod": "module test",
 				"go.sum": "",
@@ -232,10 +232,8 @@ func writeManifestForLockfile(t *testing.T, tmpDir, lockfile string) {
 		if err := os.WriteFile(filepath.Join(tmpDir, "Cargo.toml"), []byte("[package]"), 0644); err != nil {
 			t.Fatalf("failed to write Cargo.toml: %v", err)
 		}
-	case "go.sum":
-		if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module test"), 0644); err != nil {
-			t.Fatalf("failed to write go.mod: %v", err)
-		}
+	case "go.mod":
+		// go.mod is both manifest and detection target; no extra files needed
 	}
 }
 
@@ -284,8 +282,8 @@ func TestInstallDryRun(t *testing.T) {
 		},
 		{
 			name:           "go mod download",
-			lockfile:       "go.sum",
-			lockContent:    "",
+			lockfile:       "go.mod",
+			lockContent:    "module test",
 			flags:          []string{},
 			expectedOutput: "[go mod download]",
 		},
@@ -501,7 +499,7 @@ func TestUpdateDryRun(t *testing.T) {
 		},
 		{
 			name:           "go update all",
-			lockfile:       "go.sum",
+			lockfile:       "go.mod",
 			args:           []string{},
 			expectedOutput: "[go get -u]",
 		},

--- a/cmd/testdata/ades-go.sum
+++ b/cmd/testdata/ades-go.sum
@@ -1,0 +1,14 @@
+github.com/ericcornelissen/go-gha-models v0.8.0 h1:abc123def456=
+github.com/ericcornelissen/go-gha-models v0.8.0/go.mod h1:xyz789=
+github.com/gtramontina/ooze v0.2.0 h1:ooze123hash=
+github.com/gtramontina/ooze v0.2.0/go.mod h1:oozemod=
+github.com/rogpeppe/go-internal v1.14.1 h1:rogpeppe123=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:rogmod=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:jsonschema123=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:jsonmod=
+golang.org/x/mod v0.32.0 h1:xmodhash123=
+golang.org/x/mod v0.32.0/go.mod h1:xmodmodhash=
+4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3 h1:gocheckhash=
+4d63.com/gochecknoinits v0.0.0-20210416043744-25bb07f6e4e3/go.mod h1:gocheckmod=
+mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 h1:unparamhash=
+mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15/go.mod h1:unparammod=

--- a/cmd/tree_test.go
+++ b/cmd/tree_test.go
@@ -61,6 +61,59 @@ func TestTreeMultipleVersionsSamePackage(t *testing.T) {
 	}
 }
 
+func TestTreeGoSumNotSeparateManifest(t *testing.T) {
+	// go.sum should not appear as a separate manifest in tree output.
+	// Instead, its integrity hashes should be merged into go.mod dependencies.
+
+	repoDir := createTestRepo(t)
+
+	goMod, err := os.ReadFile("testdata/ades-go.mod")
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+	goSum, err := os.ReadFile("testdata/ades-go.sum")
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+
+	addFileAndCommit(t, repoDir, "go.mod", string(goMod), "Add go.mod")
+	addFileAndCommit(t, repoDir, "go.sum", string(goSum), "Add go.sum")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"init"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	rootCmd = cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"tree"})
+	rootCmd.SetOut(&stdout)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("tree failed: %v", err)
+	}
+
+	output := stdout.String()
+
+	// go.sum should NOT appear as a separate manifest section
+	if strings.Contains(output, "go.sum") {
+		t.Errorf("go.sum should not appear as a separate manifest in tree output\nOutput:\n%s", output)
+	}
+
+	// go.mod should appear
+	if !strings.Contains(output, "go.mod") {
+		t.Errorf("expected go.mod in tree output\nOutput:\n%s", output)
+	}
+
+	// Dependencies should still be present
+	if !strings.Contains(output, "golang.org/x/mod") {
+		t.Errorf("expected golang.org/x/mod in tree output\nOutput:\n%s", output)
+	}
+}
+
 func TestTreeGoToolDependencies(t *testing.T) {
 	// Regression test for https://github.com/git-pkgs/git-pkgs/issues/38
 	// Go tool dependencies should be classified as "development" not "runtime"

--- a/docs/package-management.md
+++ b/docs/package-management.md
@@ -14,7 +14,7 @@ git-pkgs looks for lockfiles in the current directory and maps them to package m
 | package-lock.json | npm |
 | Gemfile.lock | bundler |
 | Cargo.lock | cargo |
-| go.sum | gomod |
+| go.mod | gomod |
 | uv.lock | uv |
 | poetry.lock | poetry |
 | composer.lock | composer |

--- a/docs/vulns.md
+++ b/docs/vulns.md
@@ -248,7 +248,7 @@ Vulnerability scanning works for ecosystems with lockfiles and OSV coverage:
 | rubygems | Gemfile.lock |
 | pypi | Pipfile.lock, poetry.lock, uv.lock |
 | cargo | Cargo.lock |
-| go | go.sum |
+| go | go.mod |
 | maven | pom.xml (with versions) |
 | nuget | packages.lock.json |
 | packagist | composer.lock |

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/ecosyste-ms/ecosystems-go v0.0.0-20260115154313-d5f3879b6ec0
 	github.com/git-pkgs/managers v0.4.0
-	github.com/git-pkgs/manifests v0.1.6
+	github.com/git-pkgs/manifests v0.2.0
 	github.com/git-pkgs/purl v0.1.2
 	github.com/git-pkgs/registries v0.2.2
 	github.com/git-pkgs/spdx v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/git-pkgs/managers v0.4.0 h1:ydsy8Hq4UpHYrrr33swkfJiR+0HFsFOdlOktsrsaAbY=
 github.com/git-pkgs/managers v0.4.0/go.mod h1:K6B5Z8vd6tfywKzi2JgOB1eDFevmT4F9wxk4Q3VCWXQ=
-github.com/git-pkgs/manifests v0.1.6 h1:rmVblp6U/KR0VX3Gw0byc/EDiGZO0CXSf6lO/8XlSrc=
-github.com/git-pkgs/manifests v0.1.6/go.mod h1:1jeaFvqU/idbu9/QQFFh+s0/lEsMGMRvC6G6pX7S7Dw=
+github.com/git-pkgs/manifests v0.2.0 h1:0YKZJnrihl9+g3YXlmWUePlE4vzzWd1D09BfJOoXrS4=
+github.com/git-pkgs/manifests v0.2.0/go.mod h1:1jeaFvqU/idbu9/QQFFh+s0/lEsMGMRvC6G6pX7S7Dw=
 github.com/git-pkgs/purl v0.1.2 h1:c6u2iN03Jcul4rZD3+IbwAlzIQXXf+i5594lf1xiGa8=
 github.com/git-pkgs/purl v0.1.2/go.mod h1:xTppS50WiiJPGA5DsYwf79CStBhcvznICzdFuRT3sV8=
 github.com/git-pkgs/registries v0.2.2 h1:r6FBAi06w1jg0ub5PQe+dYmb3CGm/0QaK1ut+s5SXIE=

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -12,6 +12,11 @@ import (
 	"github.com/go-git/go-git/v5/utils/merkletrie"
 )
 
+func isSupplementFile(path string) bool {
+	_, kind, ok := manifests.Identify(filepath.Base(path))
+	return ok && kind == manifests.Supplement
+}
+
 type Change struct {
 	ManifestPath        string
 	Ecosystem           string
@@ -226,12 +231,24 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 	}
 
 	for _, path := range added {
+		if isSupplementFile(path) {
+			continue
+		}
 		deps, err := a.parseManifestInTree(tree, path)
 		if err != nil || deps == nil {
 			continue
 		}
 
+		// Merge integrity hashes from supplement files in same directory
+		supHashes := a.parseSupplementsInDir(tree, filepath.Dir(path))
+
 		for _, dep := range deps.Dependencies {
+			integrity := dep.Integrity
+			if integrity == "" {
+				if h, ok := supHashes[supplementKey{dep.Name, dep.Version}]; ok {
+					integrity = h
+				}
+			}
 			change := Change{
 				ManifestPath:   path,
 				Ecosystem:      deps.Ecosystem,
@@ -241,7 +258,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				ChangeType:     "added",
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
-				Integrity:      dep.Integrity,
+				Integrity:      integrity,
 			}
 			result.Changes = append(result.Changes, change)
 
@@ -252,12 +269,15 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				PURL:           dep.PURL,
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
-				Integrity:      dep.Integrity,
+				Integrity:      integrity,
 			}
 		}
 	}
 
 	for _, path := range modified {
+		if isSupplementFile(path) {
+			continue
+		}
 		var beforeDeps *manifests.ParseResult
 		if parentTree != nil {
 			beforeDeps, _ = a.parseManifestInTree(parentTree, path)
@@ -266,6 +286,9 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 		if err != nil || afterDeps == nil {
 			continue
 		}
+
+		// Merge integrity hashes from supplement files in same directory
+		supHashes := a.parseSupplementsInDir(tree, filepath.Dir(path))
 
 		// Build maps by name for change detection (modified = version changed)
 		// But also track all name+version pairs for snapshot storage
@@ -294,6 +317,13 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 			}
 			seen[nameVersion] = true
 
+			integrity := dep.Integrity
+			if integrity == "" {
+				if h, ok := supHashes[supplementKey{dep.Name, dep.Version}]; ok {
+					integrity = h
+				}
+			}
+
 			key := SnapshotKey{ManifestPath: path, Name: dep.Name, Requirement: dep.Version}
 
 			// Check if this exact name+version existed before
@@ -310,7 +340,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 						Requirement:         dep.Version,
 						PreviousRequirement: before.Version,
 						DependencyType:      string(dep.Scope),
-						Integrity:           dep.Integrity,
+						Integrity:           integrity,
 					})
 				}
 			} else if before, exists := beforeByName[dep.Name]; exists {
@@ -325,7 +355,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 					Requirement:         dep.Version,
 					PreviousRequirement: before.Version,
 					DependencyType:      string(dep.Scope),
-					Integrity:           dep.Integrity,
+					Integrity:           integrity,
 				})
 			} else {
 				// Completely new package
@@ -338,7 +368,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 					ChangeType:     "added",
 					Requirement:    dep.Version,
 					DependencyType: string(dep.Scope),
-					Integrity:      dep.Integrity,
+					Integrity:      integrity,
 				})
 			}
 
@@ -348,7 +378,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				PURL:           dep.PURL,
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
-				Integrity:      dep.Integrity,
+				Integrity:      integrity,
 			}
 		}
 
@@ -386,6 +416,9 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 	}
 
 	for _, path := range deleted {
+		if isSupplementFile(path) {
+			continue
+		}
 		var deps *manifests.ParseResult
 		if parentTree != nil {
 			deps, _ = a.parseManifestInTree(parentTree, path)
@@ -454,13 +487,24 @@ func (a *Analyzer) DependenciesAtCommit(commit *object.Commit) ([]Change, error)
 		if !ok {
 			return nil
 		}
+		if isSupplementFile(f.Name) {
+			return nil
+		}
 
 		result, err := a.parseManifestInTree(tree, f.Name)
 		if err != nil || result == nil {
 			return nil
 		}
 
+		supHashes := a.parseSupplementsInDir(tree, filepath.Dir(f.Name))
+
 		for _, dep := range result.Dependencies {
+			integrity := dep.Integrity
+			if integrity == "" {
+				if h, ok := supHashes[supplementKey{dep.Name, dep.Version}]; ok {
+					integrity = h
+				}
+			}
 			deps = append(deps, Change{
 				ManifestPath:   f.Name,
 				Ecosystem:      result.Ecosystem,
@@ -469,7 +513,7 @@ func (a *Analyzer) DependenciesAtCommit(commit *object.Commit) ([]Change, error)
 				PURL:           dep.PURL,
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
-				Integrity:      dep.Integrity,
+				Integrity:      integrity,
 			})
 		}
 
@@ -477,6 +521,52 @@ func (a *Analyzer) DependenciesAtCommit(commit *object.Commit) ([]Change, error)
 	})
 
 	return deps, err
+}
+
+// supplementKey identifies a dependency for supplement hash matching.
+type supplementKey struct {
+	name    string
+	version string
+}
+
+// parseSupplementsInDir reads all supplement files in the same directory as the given path
+// from the tree, and returns a map of name+version to integrity hash.
+func (a *Analyzer) parseSupplementsInDir(tree *object.Tree, dir string) map[supplementKey]string {
+	if tree == nil {
+		return nil
+	}
+
+	hashes := make(map[supplementKey]string)
+
+	_ = tree.Files().ForEach(func(f *object.File) error {
+		fileDir := filepath.Dir(f.Name)
+		if fileDir == "." {
+			fileDir = ""
+		}
+		if dir == "." {
+			dir = ""
+		}
+		if fileDir != dir {
+			return nil
+		}
+		if !isSupplementFile(f.Name) {
+			return nil
+		}
+
+		result, err := a.parseManifestInTree(tree, f.Name)
+		if err != nil || result == nil {
+			return nil
+		}
+
+		for _, dep := range result.Dependencies {
+			if dep.Integrity != "" {
+				hashes[supplementKey{dep.Name, dep.Version}] = dep.Integrity
+			}
+		}
+		return nil
+	})
+
+	return hashes
 }
 
 func copySnapshot(s Snapshot) Snapshot {


### PR DESCRIPTION
go.sum was parsed as a separate lockfile, producing its own dependency tree with everything marked "runtime". It should only provide integrity hashes for go.mod dependencies.

- Upgrade manifests to v0.2.0 which reclassifies go.sum as a supplement
- Analyzer skips supplement files when building changes/snapshots
- Analyzer merges integrity hashes from supplement files into co-located manifest dependencies by matching on name+version
- Remove go.sum from lockfile detection in manager config and diff driver patterns
- Update docs to reflect go.mod as the Go ecosystem entry point

Fixes #38