### PR TITLE
Add dependency counts to info --ecosystems output

### DIFF
--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -242,6 +242,9 @@ func TestInfoCommand(t *testing.T) {
 		if !strings.Contains(stdout, "npm") {
 			t.Errorf("expected 'npm' ecosystem, got: %s", stdout)
 		}
+		if !strings.Contains(stdout, "dependencies") {
+			t.Errorf("expected dependency count in output, got: %s", stdout)
+		}
 	})
 
 	t.Run("outputs json format", func(t *testing.T) {
@@ -271,6 +274,41 @@ func TestInfoCommand(t *testing.T) {
 		}
 		if _, ok := info["row_counts"]; !ok {
 			t.Error("expected 'row_counts' in JSON")
+		}
+	})
+
+	t.Run("ecosystems json includes counts", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "info", "--ecosystems", "-f", "json")
+		if err != nil {
+			t.Fatalf("info --ecosystems json failed: %v", err)
+		}
+
+		var ecosystems []map[string]interface{}
+		if err := json.Unmarshal([]byte(stdout), &ecosystems); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if len(ecosystems) == 0 {
+			t.Fatal("expected at least one ecosystem")
+		}
+
+		eco := ecosystems[0]
+		if _, ok := eco["name"]; !ok {
+			t.Error("expected 'name' field in ecosystem JSON")
+		}
+		if _, ok := eco["count"]; !ok {
+			t.Error("expected 'count' field in ecosystem JSON")
 		}
 	})
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -66,7 +66,7 @@ func runInfo(cmd *cobra.Command, args []string) error {
 			} else {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Tracked ecosystems:")
 				for _, eco := range info.Ecosystems {
-					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", eco)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %d dependencies\n", eco.Name, eco.Count)
 				}
 			}
 		}
@@ -130,7 +130,11 @@ func outputInfoText(cmd *cobra.Command, info *database.DatabaseInfo) error {
 	_, _ = fmt.Fprintln(cmd.OutOrStdout())
 
 	if len(info.Ecosystems) > 0 {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Ecosystems: %s\n", strings.Join(info.Ecosystems, ", "))
+		names := make([]string, len(info.Ecosystems))
+		for i, eco := range info.Ecosystems {
+			names[i] = eco.Name
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Ecosystems: %s\n", strings.Join(names, ", "))
 	}
 
 	return nil

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -151,10 +151,11 @@ func TestAnalyzeCommitWithAddedGemfile(t *testing.T) {
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 
 	if len(result.Changes) != 2 {
-		t.Errorf("expected 2 changes, got %d", len(result.Changes))
+		t.Fatalf("expected 2 changes, got %d", len(result.Changes))
 	}
 
 	var railsChange *analyzer.Change
@@ -167,6 +168,7 @@ func TestAnalyzeCommitWithAddedGemfile(t *testing.T) {
 
 	if railsChange == nil {
 		t.Fatal("expected rails change")
+		return
 	}
 
 	if railsChange.ChangeType != "added" {
@@ -210,10 +212,11 @@ func TestAnalyzeCommitWithModifiedGemfile(t *testing.T) {
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 
 	if len(result.Changes) != 1 {
-		t.Errorf("expected 1 change, got %d", len(result.Changes))
+		t.Fatalf("expected 1 change, got %d", len(result.Changes))
 	}
 
 	ch := result.Changes[0]
@@ -261,10 +264,11 @@ func TestAnalyzeCommitWithRemovedDependency(t *testing.T) {
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 
 	if len(result.Changes) != 1 {
-		t.Errorf("expected 1 change, got %d", len(result.Changes))
+		t.Fatalf("expected 1 change, got %d", len(result.Changes))
 	}
 
 	ch := result.Changes[0]
@@ -300,10 +304,11 @@ func TestAnalyzeCommitWithPackageJSON(t *testing.T) {
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 
 	if len(result.Changes) != 2 {
-		t.Errorf("expected 2 changes, got %d", len(result.Changes))
+		t.Fatalf("expected 2 changes, got %d", len(result.Changes))
 	}
 
 	for _, ch := range result.Changes {

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -562,14 +562,19 @@ type StaleEntry struct {
 	DaysSince    int    `json:"days_since"`
 }
 
+type EcosystemCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
 type DatabaseInfo struct {
-	Path            string         `json:"path"`
-	SizeBytes       int64          `json:"size_bytes"`
-	SchemaVersion   int            `json:"schema_version"`
-	BranchName      string         `json:"branch_name"`
-	LastAnalyzedSHA string         `json:"last_analyzed_sha"`
-	RowCounts       map[string]int `json:"row_counts"`
-	Ecosystems      []string       `json:"ecosystems"`
+	Path            string           `json:"path"`
+	SizeBytes       int64            `json:"size_bytes"`
+	SchemaVersion   int              `json:"schema_version"`
+	BranchName      string           `json:"branch_name"`
+	LastAnalyzedSHA string           `json:"last_analyzed_sha"`
+	RowCounts       map[string]int   `json:"row_counts"`
+	Ecosystems      []EcosystemCount `json:"ecosystems"`
 }
 
 func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
@@ -603,18 +608,20 @@ func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
 		info.RowCounts[table] = count
 	}
 
-	// Ecosystems
+	// Ecosystems with counts from snapshots (current state)
 	rows, err := db.Query(`
-		SELECT DISTINCT ecosystem FROM dependency_changes WHERE ecosystem IS NOT NULL AND ecosystem != ''
-		UNION
-		SELECT DISTINCT ecosystem FROM dependency_snapshots WHERE ecosystem IS NOT NULL AND ecosystem != ''
+		SELECT ecosystem, COUNT(*) FROM dependency_snapshots
+		WHERE ecosystem IS NOT NULL AND ecosystem != ''
+		GROUP BY ecosystem
+		ORDER BY ecosystem
 	`)
 	if err == nil {
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {
 			var eco string
-			if rows.Scan(&eco) == nil && eco != "" {
-				info.Ecosystems = append(info.Ecosystems, eco)
+			var count int
+			if rows.Scan(&eco, &count) == nil && eco != "" {
+				info.Ecosystems = append(info.Ecosystems, EcosystemCount{Name: eco, Count: count})
 			}
 		}
 	}


### PR DESCRIPTION
The `--ecosystems` flag on `info` now shows how many dependencies belong to each ecosystem, both in text and JSON output.

Text output shows `npm: 14 dependencies` instead of just `npm`. JSON output returns objects with `name` and `count` fields instead of plain strings. The default `info` output still lists ecosystem names only.

The query now counts from `dependency_snapshots` (current state) rather than unioning with `dependency_changes` which would double-count.

Closes #19