### PR TITLE
Fix vulns sync skipping all packages

### DIFF
--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -147,12 +147,10 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 	var queries []osv.QueryRequest
 	var queryKeys []pkgKey
 	for key := range uniquePkgs {
-		// Check if we need to sync (unless force)
+		// Check if recently synced (unless force)
 		if !force {
-			count, _ := db.GetStoredVulnCount(key.ecosystem, key.name)
-			if count >= 0 {
-				// Already synced, skip unless force
-				// Note: count=0 means synced with no vulns, which is valid
+			syncedAt, _ := db.GetVulnsSyncedAt(key.ecosystem, key.name)
+			if !syncedAt.IsZero() && time.Since(syncedAt) < 24*time.Hour {
 				continue
 			}
 		}
@@ -257,6 +255,11 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 			}
 
 			totalVulns++
+		}
+
+		// Mark as synced so we don't re-query within 24 hours
+		if err := db.SetVulnsSyncedAt(key.ecosystem, key.name); err != nil {
+			return fmt.Errorf("recording sync time for %s/%s: %w", key.ecosystem, key.name, err)
 		}
 	}
 

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1553,6 +1553,40 @@ func (db *DB) GetStoredVulnCount(ecosystem, packageName string) (int, error) {
 	return count, err
 }
 
+// GetVulnsSyncedAt returns when vulnerabilities were last synced for a package.
+// Returns the zero time if never synced.
+func (db *DB) GetVulnsSyncedAt(ecosystem, name string) (time.Time, error) {
+	var syncedAt sql.NullString
+	err := db.QueryRow(`
+		SELECT vulns_synced_at FROM packages
+		WHERE ecosystem = ? AND name = ?
+		LIMIT 1
+	`, ecosystem, name).Scan(&syncedAt)
+	if err == sql.ErrNoRows || !syncedAt.Valid {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, _ := time.Parse(time.RFC3339, syncedAt.String)
+	return t, nil
+}
+
+// SetVulnsSyncedAt records that vulnerabilities were synced for a package.
+// Creates a basic package record if one doesn't exist.
+func (db *DB) SetVulnsSyncedAt(ecosystem, name string) error {
+	now := time.Now().Format(time.RFC3339)
+	purl := "pkg:" + strings.ToLower(ecosystem) + "/" + name
+	_, err := db.Exec(`
+		INSERT INTO packages (purl, ecosystem, name, vulns_synced_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(purl) DO UPDATE SET
+			vulns_synced_at = excluded.vulns_synced_at,
+			updated_at = excluded.updated_at
+	`, purl, ecosystem, name, now, now, now)
+	return err
+}
+
 // InsertVulnerability inserts or updates a vulnerability record.
 func (db *DB) InsertVulnerability(v Vulnerability) error {
 	aliases := joinCommaList(v.Aliases)


### PR DESCRIPTION
`GetStoredVulnCount` returned `COUNT(*)` which is always >= 0, so `vulns sync` skipped every package. Replaced with a 24-hour TTL check using the existing `vulns_synced_at` column on the `packages` table. Packages with zero vulns now get marked as synced and won't be re-queried on subsequent runs. Use `--force` to bypass the TTL.