### PR TITLE
diff-file: Treat empty files as having no dependencies

### DIFF
--- a/cmd/diff_file.go
+++ b/cmd/diff_file.go
@@ -51,6 +51,9 @@ func parseFile(filename, defaultFilename string) ([]database.Dependency, error) 
 	if err != nil {
 		return nil, err
 	}
+	if len(data) == 0 {
+		return []database.Dependency{}, nil
+	}
 
 	name := filepath.Base(cmp.Or(defaultFilename, filename))
 	result, err := manifests.Parse(name, data)


### PR DESCRIPTION
I'm currently using `git-pkgs` as a tool for diffing files across
commits in Jujutsu. git-pkgs is invoked using `git-pkgs $left $right`,
where `$left` and `$right` will be replaced by the paths to the files in the
diff pre-image and diff post-image respectively. However,
addition/removal of files across commits leads to `git-pkgs` being
invoked with the path to a materialized empty file. Whilst empty files
are valid for certain manifest/lockfiles formats (e.g. `go.mod`, TOML
files), they cannot be correctly parsed for other file formats (e.g.
JSON files). Treating an empty path as having no dependencies seems
logical to me, so that the diff of a newly added/removed
manifest/lockfile can be computed safely for all formats.

(Git has a similar utility called `git difftool`, which passes
`/dev/null` instead of materializing an empty file to represent an empty
diff pre/post-image.)