### PR TITLE
Fix stats showing zero current dependencies

### DIFF
--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -767,11 +767,23 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 		return nil, err
 	}
 
-	// Current deps count and by ecosystem - use pre-computed latest commit_id
+	// Current deps count and by ecosystem - find the latest snapshot commit
+	// (which may differ from the latest commit if recent commits had no dep changes)
+	var snapshotCommitID sql.NullInt64
 	if latestCommitID.Valid {
+		_ = db.QueryRow(`
+			SELECT ds.commit_id
+			FROM dependency_snapshots ds
+			JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+			WHERE bc.branch_id = ?
+			ORDER BY bc.position DESC
+			LIMIT 1
+		`, opts.BranchID).Scan(&snapshotCommitID)
+	}
+	if snapshotCommitID.Valid {
 		err = db.QueryRow(`
 			SELECT COUNT(*) FROM dependency_snapshots WHERE commit_id = ?
-		`, latestCommitID.Int64).Scan(&stats.CurrentDeps)
+		`, snapshotCommitID.Int64).Scan(&stats.CurrentDeps)
 		if err != nil {
 			return nil, err
 		}
@@ -782,7 +794,7 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 			FROM dependency_snapshots
 			WHERE commit_id = ?
 			GROUP BY ecosystem
-		`, latestCommitID.Int64)
+		`, snapshotCommitID.Int64)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -589,6 +589,48 @@ func TestNpmMultipleVersionsSurviveModifiedLockfile(t *testing.T) {
 	}
 }
 
+func TestStatsCurrentDepsNonZeroWhenLastCommitHasNoChanges(t *testing.T) {
+	repoDir := createTestRepo(t)
+
+	// Commit 1: add Gemfile (has dependency changes)
+	addFileAndCommit(t, repoDir, "Gemfile", "source \"https://rubygems.org\"\ngem \"rails\", \"~> 7.0\"\ngem \"puma\"\n", "Add Gemfile")
+
+	// Commit 2: non-manifest change (no dependency changes)
+	addFileAndCommit(t, repoDir, "README.md", "# Hello", "Add readme")
+
+	repo, err := gitpkg.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("failed to open repo: %v", err)
+	}
+
+	dbPath := filepath.Join(repoDir, ".git", "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := indexer.New(repo, db, indexer.Options{Quiet: true})
+	_, err = idx.Run()
+	if err != nil {
+		t.Fatalf("indexer failed: %v", err)
+	}
+
+	branch, err := db.GetDefaultBranch()
+	if err != nil {
+		t.Fatalf("failed to get branch: %v", err)
+	}
+
+	stats, err := db.GetStats(database.StatsOptions{BranchID: branch.ID})
+	if err != nil {
+		t.Fatalf("GetStats failed: %v", err)
+	}
+
+	if stats.CurrentDeps != 2 {
+		t.Errorf("expected 2 current deps, got %d", stats.CurrentDeps)
+	}
+}
+
 func TestIndexerStoresSnapshots(t *testing.T) {
 	repoDir := createTestRepo(t)
 


### PR DESCRIPTION
`GetStats` queried `dependency_snapshots` using the latest commit on the branch, but snapshots are only stored at commits with dependency changes. When the last commits on a branch don't touch dependencies, the query found no snapshot and reported zero current deps.

Now looks up the latest snapshot commit instead, matching how `GetLatestDependencies` already works.

Fixes #54