### PR TITLE
Close pipe file descriptors in pager setup

### DIFF
--- a/cmd/output.go
+++ b/cmd/output.go
@@ -200,8 +200,13 @@ func SetupPager(cmd *cobra.Command) func() {
 
 	if err := pager.Start(); err != nil {
 		os.Stdout = oldStdout
+		_ = r.Close()
+		_ = w.Close()
 		return func() {}
 	}
+
+	// Parent doesn't need read end; child has its own copy
+	_ = r.Close()
 
 	return func() {
 		_ = w.Close()


### PR DESCRIPTION
The read end of the pipe was never closed after starting the pager process. The parent doesn't need it since the child has its own copy. Also close both ends if pager.Start fails.