### PR TITLE
Upgrade to Go 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-pkgs/git-pkgs
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/ecosyste-ms/ecosystems-go v0.0.0-20260115154313-d5f3879b6ec0


### PR DESCRIPTION
Fixes stdlib vulnerabilities GO-2026-4340 and GO-2026-4341.