### PR TITLE
Fix empty name/ecosystem for docker packages in licenses command

### DIFF
--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -182,9 +182,17 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	for purl, data := range packageData {
 		dep := purlToDep[purl]
 
+		// Use API data when dep lookup failed (PURL mismatch)
+		name := dep.Name
+		ecosystem := dep.Ecosystem
+		if name == "" && data.Name != "" {
+			name = data.Name
+			ecosystem = data.Ecosystem
+		}
+
 		info := LicenseInfo{
-			Name:         dep.Name,
-			Ecosystem:    dep.Ecosystem,
+			Name:         name,
+			Ecosystem:    ecosystem,
 			Version:      dep.Requirement,
 			ManifestPath: dep.ManifestPath,
 			PURL:         purl,
@@ -286,7 +294,9 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 }
 
 type licenseData struct {
-	License string
+	License   string
+	Name      string
+	Ecosystem string
 }
 
 func getLicenseData(db *database.DB, purls []string, purlToDep map[string]database.Dependency) (map[string]*licenseData, error) {
@@ -300,7 +310,11 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 			return nil, err
 		}
 		for purl, cp := range cached {
-			result[purl] = &licenseData{License: cp.License}
+			result[purl] = &licenseData{
+				License:   cp.License,
+				Name:      cp.Name,
+				Ecosystem: cp.Ecosystem,
+			}
 		}
 		// Find uncached PURLs
 		for _, purl := range purls {
@@ -330,6 +344,8 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 		for purl, pkg := range packages {
 			data := &licenseData{}
 			if pkg != nil {
+				data.Name = pkg.Name
+				data.Ecosystem = pkg.Ecosystem
 				// Normalize license to SPDX identifier
 				if pkg.License != "" {
 					if normalized, err := spdx.Normalize(pkg.License); err == nil {
@@ -343,8 +359,8 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 
 			// Save to cache if DB available
 			if db != nil && pkg != nil {
-				dep := purlToDep[purl]
-				_ = db.SavePackageEnrichment(purl, dep.Ecosystem, dep.Name, pkg.LatestVersion, pkg.License, pkg.RegistryURL, pkg.Source)
+				// Use API data for ecosystem/name (in case PURL was canonicalized)
+				_ = db.SavePackageEnrichment(purl, pkg.Ecosystem, pkg.Name, pkg.LatestVersion, pkg.License, pkg.RegistryURL, pkg.Source)
 			}
 		}
 	}

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -294,6 +294,64 @@ func TestSpdxNormalization(t *testing.T) {
 	}
 }
 
+// TestLicensesDockerPURLCanonicalization tests that docker images show proper
+// names even when the API returns a canonicalized PURL different from the input.
+// For example, pkg:docker/postgres becomes pkg:docker/library%2Fpostgres in the response.
+func TestLicensesDockerPURLCanonicalization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Docker compose file with official images (no library/ prefix)
+	const dockerCompose = `version: '3'
+services:
+  db:
+    image: postgres:16-alpine
+  cache:
+    image: redis:7-alpine
+`
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "docker-compose.yml", dockerCompose, "Add docker-compose")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"init"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rootCmd = cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"licenses", "--format", "json"})
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	_ = rootCmd.Execute()
+
+	output := stdout.String()
+	if output == "" {
+		t.Fatal("expected JSON output, got empty string")
+	}
+
+	var results []cmd.LicenseInfo
+	if err := json.Unmarshal([]byte(output), &results); err != nil {
+		t.Fatalf("failed to parse JSON: %v\nOutput: %s", err, output)
+	}
+
+	// Find docker packages and verify they have names
+	for _, r := range results {
+		if strings.Contains(r.PURL, "docker") {
+			if r.Name == "" {
+				t.Errorf("docker package %s has empty name", r.PURL)
+			}
+			if r.Ecosystem == "" {
+				t.Errorf("docker package %s has empty ecosystem", r.PURL)
+			}
+		}
+	}
+}
+
 func TestSpdxDenyListMatching(t *testing.T) {
 	// Simulate the deny list logic from licenses.go
 	denyList := []string{"GPL v3", "LGPL"}


### PR DESCRIPTION
When the ecosyste.ms API returns a canonicalized PURL (e.g., `pkg:docker/library%2Fpostgres` instead of `pkg:docker/postgres`), the lookup in `purlToDep` failed, resulting in empty name and ecosystem fields in the output.

Before:
```
 (): Apache-2.0
 (): Apache-2.0
 (): Apache-2.0
```

After:
```
library/postgres (docker): Apache-2.0
library/redis (docker): Apache-2.0
library/ruby (docker): Apache-2.0
```

Changes:
- Store name/ecosystem from API response in licenseData struct
- Use API data when the dependency lookup returns empty values
- Save correct name/ecosystem to cache from API response
- Populate name/ecosystem from cache when loading cached data
- Add test for docker PURL canonicalization behavior