### PR TITLE
Fix diff showing stale entries for renamed manifests

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -121,7 +121,7 @@ func diffBetweenCommits(repo *git.Repository, fromRef, toRef string) (*DiffResul
 
 // diffWithWorkingTree compares dependencies between a commit and the working tree.
 func diffWithWorkingTree(repo *git.Repository, fromRef string) (*DiffResult, error) {
-	fromDeps, err := repo.GetDependencies( fromRef, "")
+	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
 	}

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -155,6 +155,92 @@ func TestDiff_ManifestDeletedBetweenCommits(t *testing.T) {
 	}
 }
 
+func TestDiff_ManifestRenamed(t *testing.T) {
+	// Create a temp repo
+	dir := t.TempDir()
+
+	// Initialize git
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("init")
+	run("config", "user.email", "test@test.com")
+	run("config", "user.name", "Test")
+
+	// Create initial workflow file
+	workflow := `name: Test
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+`
+	if err := os.MkdirAll(filepath.Join(dir, ".github/workflows"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".github/workflows/test.yml"), []byte(workflow), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "Add workflow")
+
+	// Rename the workflow file
+	run("mv", ".github/workflows/test.yml", ".github/workflows/ci.yml")
+	run("commit", "-am", "Rename workflow")
+
+	// Add more commits so there's history
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+	run("commit", "-m", "Add readme")
+
+	// Change to repo dir
+	oldDir, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(oldDir) }()
+
+	// Initialize database (this exercises the PrefetchDiffs rename handling)
+	rootCmd := NewRootCmd()
+	rootCmd.SetArgs([]string{"init"})
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Run diff - should show no changes since HEAD and working tree are identical
+	rootCmd = NewRootCmd()
+	rootCmd.SetArgs([]string{"diff"})
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&bytes.Buffer{})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("diff command failed: %v", err)
+	}
+	out := buf.String()
+
+	// Should NOT show old test.yml as removed (the bug we fixed)
+	if containsString(out, "test.yml") {
+		t.Errorf("expected test.yml to NOT appear (it was renamed, not deleted), got:\n%s", out)
+	}
+
+	// Should show no dependency changes
+	if !containsString(out, "No dependency changes") {
+		t.Errorf("expected 'No dependency changes', got:\n%s", out)
+	}
+}
+
 func containsString(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -128,16 +128,21 @@ func (a *Analyzer) PrefetchDiffs(commits []*object.Commit, numWorkers int) {
 			continue
 		}
 
-		// Name-status line (starts with A, M, D followed by tab)
-		if currentDiff != nil && len(line) >= 2 && (line[0] == 'A' || line[0] == 'M' || line[0] == 'D') && line[1] == '\t' {
-			status := line[0]
-			path := line[2:] // Skip status and tab
+		// Name-status line: A/M/D followed by tab, or R/C followed by digits and tab
+		if currentDiff == nil || len(line) < 2 {
+			continue
+		}
 
-			_, _, ok := manifests.Identify(path)
-			if !ok {
+		status := line[0]
+		switch status {
+		case 'A', 'M', 'D':
+			if line[1] != '\t' {
 				continue
 			}
-
+			path := line[2:]
+			if _, _, ok := manifests.Identify(path); !ok {
+				continue
+			}
 			switch status {
 			case 'A':
 				currentDiff.added = append(currentDiff.added, path)
@@ -145,6 +150,29 @@ func (a *Analyzer) PrefetchDiffs(commits []*object.Commit, numWorkers int) {
 				currentDiff.modified = append(currentDiff.modified, path)
 			case 'D':
 				currentDiff.deleted = append(currentDiff.deleted, path)
+			}
+
+		case 'R', 'C':
+			// Rename/Copy: R063\told_path\tnew_path or C063\told_path\tnew_path
+			// Find the first tab to skip the status+percentage
+			firstTab := strings.Index(line, "\t")
+			if firstTab == -1 {
+				continue
+			}
+			rest := line[firstTab+1:]
+			secondTab := strings.Index(rest, "\t")
+			if secondTab == -1 {
+				continue
+			}
+			oldPath := rest[:secondTab]
+			newPath := rest[secondTab+1:]
+
+			// Treat rename as delete old + add new
+			if _, _, ok := manifests.Identify(oldPath); ok {
+				currentDiff.deleted = append(currentDiff.deleted, oldPath)
+			}
+			if _, _, ok := manifests.Identify(newPath); ok {
+				currentDiff.added = append(currentDiff.added, newPath)
 			}
 		}
 	}


### PR DESCRIPTION
PrefetchDiffs only handled A/M/D status codes from git log --name-status. When manifests were renamed (status R), the old path was never removed from the rolling snapshot, causing stale dependencies to appear in diff output.

Added handling for R (rename) and C (copy) status codes. A rename is treated as delete old + add new.

Fixes #53