### PR TITLE
Add praise as alias for blame command

### DIFF
--- a/cmd/blame.go
+++ b/cmd/blame.go
@@ -11,10 +11,11 @@ import (
 
 func addBlameCmd(parent *cobra.Command) {
 	blameCmd := &cobra.Command{
-		Use:   "blame",
-		Short: "Show who added each dependency",
-		Long:  `Show the commit and author that first added each current dependency.`,
-		RunE:  runBlame,
+		Use:     "blame",
+		Aliases: []string{"praise"},
+		Short:   "Show who added each dependency",
+		Long:    `Show the commit and author that first added each current dependency.`,
+		RunE:    runBlame,
 	}
 
 	blameCmd.Flags().StringP("branch", "b", "", "Branch to query (default: first tracked branch)")


### PR DESCRIPTION
Adds `praise` as an alias for the `blame` command, matching the pattern used in `vulns praise`.