### PR TITLE
Respect .gitignore in where command and working dir analysis

### DIFF
--- a/cmd/where.go
+++ b/cmd/where.go
@@ -50,6 +50,12 @@ func runWhere(cmd *cobra.Command, args []string) error {
 
 	workDir := repo.WorkDir()
 
+	ignoreMatcher, err := repo.LoadIgnoreMatcher()
+	if err != nil {
+		// Continue without gitignore support if loading fails
+		ignoreMatcher = nil
+	}
+
 	var matches []WhereMatch
 
 	// Walk the working directory looking for manifest files
@@ -58,19 +64,27 @@ func runWhere(cmd *cobra.Command, args []string) error {
 			return nil // Skip files we can't read
 		}
 
+		// Get relative path for manifest identification
+		relPath, _ := filepath.Rel(workDir, path)
+		// Normalize to forward slashes for cross-platform consistency
+		relPath = filepath.ToSlash(relPath)
+
 		if info.IsDir() {
-			// Skip common non-project directories
-			name := info.Name()
-			if name == ".git" || name == "node_modules" || name == "vendor" {
+			// Always skip .git
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			// Skip directories that match gitignore patterns
+			if ignoreMatcher != nil && ignoreMatcher.IsIgnored(relPath, true) {
 				return filepath.SkipDir
 			}
 			return nil
 		}
 
-		// Get relative path for manifest identification
-		relPath, _ := filepath.Rel(workDir, path)
-		// Normalize to forward slashes for cross-platform consistency
-		relPath = filepath.ToSlash(relPath)
+		// Skip files that match gitignore patterns
+		if ignoreMatcher != nil && ignoreMatcher.IsIgnored(relPath, false) {
+			return nil
+		}
 
 		// Check if this is a manifest file
 		eco, _, ok := manifests.Identify(relPath)

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 
 	"github.com/git-pkgs/manifests"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/utils/merkletrie"
 )
@@ -610,15 +612,18 @@ func (a *Analyzer) parseSupplementsInDir(tree *object.Tree, dir string) map[supp
 func (a *Analyzer) DependenciesInWorkingDir(root string) ([]Change, error) {
 	var deps []Change
 
+	// Load gitignore patterns
+	var matcher gitignore.Matcher
+	if repo, err := git.PlainOpenWithOptions(root, &git.PlainOpenOptions{DetectDotGit: true}); err == nil {
+		if wt, err := repo.Worktree(); err == nil {
+			if patterns, err := gitignore.ReadPatterns(wt.Filesystem, nil); err == nil {
+				matcher = gitignore.NewMatcher(patterns)
+			}
+		}
+	}
+
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil
-		}
-		if info.IsDir() {
-			base := filepath.Base(path)
-			if base == ".git" || base == "node_modules" || base == "vendor" {
-				return filepath.SkipDir
-			}
 			return nil
 		}
 
@@ -628,6 +633,23 @@ func (a *Analyzer) DependenciesInWorkingDir(root string) ([]Change, error) {
 		}
 		// Normalize to forward slashes for cross-platform consistency with git paths
 		relPath = filepath.ToSlash(relPath)
+
+		if info.IsDir() {
+			// Always skip .git
+			if info.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			// Skip directories that match gitignore patterns
+			if matcher != nil && matcher.Match(strings.Split(relPath, "/"), true) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Skip files that match gitignore patterns
+		if matcher != nil && matcher.Match(strings.Split(relPath, "/"), false) {
+			return nil
+		}
 
 		_, _, ok := manifests.Identify(relPath)
 		if !ok {

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -419,6 +419,54 @@ func TestDependenciesInWorkingDirUncommitted(t *testing.T) {
 	}
 }
 
+func TestDependenciesInWorkingDirRespectsGitignore(t *testing.T) {
+	repoDir := createTestRepo(t)
+
+	// Create .gitignore that ignores vendor/ and a specific file
+	addFile(t, repoDir, ".gitignore", "vendor/\nignored-Gemfile\n")
+	addFile(t, repoDir, "README.md", "# Test")
+	commit(t, repoDir, "Initial commit")
+
+	// Add a tracked manifest
+	if err := os.WriteFile(filepath.Join(repoDir, "Gemfile"), []byte(sampleGemfile(map[string]string{
+		"rails": "~> 7.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	// Add an ignored manifest in vendor/
+	if err := os.MkdirAll(filepath.Join(repoDir, "vendor"), 0755); err != nil {
+		t.Fatalf("failed to create vendor dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "vendor", "Gemfile"), []byte(sampleGemfile(map[string]string{
+		"sinatra": "~> 3.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	// Add an ignored manifest by name
+	if err := os.WriteFile(filepath.Join(repoDir, "ignored-Gemfile"), []byte(sampleGemfile(map[string]string{
+		"puma": "~> 6.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	a := analyzer.New()
+	deps, err := a.DependenciesInWorkingDir(repoDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only see rails from the non-ignored Gemfile
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d: %+v", len(deps), deps)
+	}
+
+	if deps[0].Name != "rails" {
+		t.Errorf("expected rails, got %s", deps[0].Name)
+	}
+}
+
 func TestAnalyzeCommitWithGitHubActionsWorkflow(t *testing.T) {
 	repoDir := createTestRepo(t)
 	addFile(t, repoDir, "README.md", "# Test")

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -3,9 +3,11 @@ package git
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
@@ -148,4 +150,32 @@ func (r *Repository) LocalBranches() (map[string][]string, error) {
 	}
 
 	return result, nil
+}
+
+// IgnoreMatcher checks paths against .gitignore patterns.
+type IgnoreMatcher struct {
+	matcher gitignore.Matcher
+}
+
+// LoadIgnoreMatcher loads .gitignore patterns from the repository.
+func (r *Repository) LoadIgnoreMatcher() (*IgnoreMatcher, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("getting worktree: %w", err)
+	}
+
+	patterns, err := gitignore.ReadPatterns(wt.Filesystem, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reading gitignore patterns: %w", err)
+	}
+
+	return &IgnoreMatcher{
+		matcher: gitignore.NewMatcher(patterns),
+	}, nil
+}
+
+// IsIgnored checks if the given path (relative to repo root) is ignored.
+func (m *IgnoreMatcher) IsIgnored(relPath string, isDir bool) bool {
+	parts := strings.Split(filepath.ToSlash(relPath), "/")
+	return m.matcher.Match(parts, isDir)
 }


### PR DESCRIPTION
The `where` command and `DependenciesInWorkingDir` (used by `diff`) now respect `.gitignore` patterns when walking the filesystem.

- Added `IgnoreMatcher` to git package for loading and checking gitignore patterns
- Updated `where` command to skip ignored files and directories
- Updated `DependenciesInWorkingDir` in analyzer to automatically load and respect gitignore
- Added test for gitignore handling