### PR TITLE
Ignore git submodules when scanning for manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,13 @@ git-pkgs respects [standard git configuration](https://git-scm.com/docs/git-conf
 
 **Pager** follows git's precedence: `GIT_PAGER` env, `core.pager` config, `PAGER` env, then `less -FRSX`. Use `--no-pager` flag or `git config core.pager cat` to disable.
 
+**Submodules** are ignored by default when scanning the working directory to prevent reporting their dependencies as part of the main repository. Use `--include-submodules` to scan submodules:
+
+```bash
+git pkgs diff --include-submodules       # include submodule dependencies
+git pkgs where lodash --include-submodules
+```
+
 **Ecosystem filtering** lets you limit which package ecosystems are tracked:
 
 ```bash

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -49,6 +49,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	toRef, _ := cmd.Flags().GetString("to")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	format, _ := cmd.Flags().GetString("format")
+	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
 
 	// Parse range syntax if provided
 	if len(args) > 0 {
@@ -77,7 +78,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	// When comparing to working tree, use direct parsing since there's
 	// no database state for uncommitted changes
 	if toRef == "" {
-		result, err = diffWithWorkingTree(repo, fromRef)
+		result, err = diffWithWorkingTree(repo, fromRef, includeSubmodules)
 	} else {
 		result, err = diffBetweenCommits(repo, fromRef, toRef)
 	}
@@ -120,7 +121,7 @@ func diffBetweenCommits(repo *git.Repository, fromRef, toRef string) (*DiffResul
 }
 
 // diffWithWorkingTree compares dependencies between a commit and the working tree.
-func diffWithWorkingTree(repo *git.Repository, fromRef string) (*DiffResult, error) {
+func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules bool) (*DiffResult, error) {
 	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
@@ -128,7 +129,7 @@ func diffWithWorkingTree(repo *git.Repository, fromRef string) (*DiffResult, err
 
 	// Parse working tree directly
 	a := analyzer.New()
-	toChanges, err := a.DependenciesInWorkingDir(repo.WorkDir())
+	toChanges, err := a.DependenciesInWorkingDir(repo.WorkDir(), includeSubmodules)
 	if err != nil {
 		return nil, fmt.Errorf("reading working tree: %w", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,4 +111,5 @@ func addPersistentFlags(cmd *cobra.Command) {
 	flags.BoolP("quiet", "q", false, "Suppress non-essential output")
 	flags.BoolP("pager", "p", false, "Use pager for output")
 	flags.String("color", "auto", "When to colorize output: auto, always, never")
+	flags.Bool("include-submodules", false, "Include git submodules when scanning for manifests")
 }

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -42,6 +42,7 @@ func runWhere(cmd *cobra.Command, args []string) error {
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	context, _ := cmd.Flags().GetInt("context")
 	format, _ := cmd.Flags().GetString("format")
+	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {
@@ -54,6 +55,20 @@ func runWhere(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		// Continue without gitignore support if loading fails
 		ignoreMatcher = nil
+	}
+
+	// Load submodule paths only if we need to skip them
+	var submoduleMap map[string]bool
+	if !includeSubmodules {
+		submodulePaths, err := repo.GetSubmodulePaths()
+		if err != nil {
+			// Continue without submodule filtering if loading fails
+			submodulePaths = nil
+		}
+		submoduleMap = make(map[string]bool, len(submodulePaths))
+		for _, p := range submodulePaths {
+			submoduleMap[p] = true
+		}
 	}
 
 	var matches []WhereMatch
@@ -76,6 +91,10 @@ func runWhere(cmd *cobra.Command, args []string) error {
 			}
 			// Skip directories that match gitignore patterns
 			if ignoreMatcher != nil && ignoreMatcher.IsIgnored(relPath, true) {
+				return filepath.SkipDir
+			}
+			// Skip git submodule directories
+			if submoduleMap[relPath] {
 				return filepath.SkipDir
 			}
 			return nil

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -19,7 +19,7 @@ internal/
 
 ## Entry Point
 
-The CLI uses [cobra](https://github.com/spf13/cobra). Each command is registered in `cmd/` via `init()` functions. The root command handles global flags (`--quiet`, `--color=auto`, `--no-pager`) and dispatches to subcommands.
+The CLI uses [cobra](https://github.com/spf13/cobra). Each command is registered in `cmd/` via `init()` functions. The root command handles global flags (`--quiet`, `--color=auto`, `--no-pager`, `--include-submodules`) and dispatches to subcommands.
 
 ## Database
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -609,15 +609,28 @@ func (a *Analyzer) parseSupplementsInDir(tree *object.Tree, dir string) map[supp
 	return hashes
 }
 
-func (a *Analyzer) DependenciesInWorkingDir(root string) ([]Change, error) {
+func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool) ([]Change, error) {
 	var deps []Change
 
-	// Load gitignore patterns
+	// Load gitignore patterns and submodule paths
 	var matcher gitignore.Matcher
+	var submodulePaths map[string]bool
 	if repo, err := git.PlainOpenWithOptions(root, &git.PlainOpenOptions{DetectDotGit: true}); err == nil {
 		if wt, err := repo.Worktree(); err == nil {
 			if patterns, err := gitignore.ReadPatterns(wt.Filesystem, nil); err == nil {
 				matcher = gitignore.NewMatcher(patterns)
+			}
+
+			// Load submodule paths only if we need to skip them
+			if !includeSubmodules {
+				if submodules, err := wt.Submodules(); err == nil {
+					submodulePaths = make(map[string]bool, len(submodules))
+					for _, submodule := range submodules {
+						config := submodule.Config()
+						path := filepath.ToSlash(config.Path)
+						submodulePaths[path] = true
+					}
+				}
 			}
 		}
 	}
@@ -641,6 +654,10 @@ func (a *Analyzer) DependenciesInWorkingDir(root string) ([]Change, error) {
 			}
 			// Skip directories that match gitignore patterns
 			if matcher != nil && matcher.Match(strings.Split(relPath, "/"), true) {
+				return filepath.SkipDir
+			}
+			// Skip git submodule directories
+			if submodulePaths != nil && submodulePaths[relPath] {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -369,7 +369,7 @@ func TestDependenciesInWorkingDir(t *testing.T) {
 	commit(t, repoDir, "Add manifests")
 
 	a := analyzer.New()
-	deps, err := a.DependenciesInWorkingDir(repoDir)
+	deps, err := a.DependenciesInWorkingDir(repoDir, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestDependenciesInWorkingDirUncommitted(t *testing.T) {
 	}
 
 	a := analyzer.New()
-	deps, err := a.DependenciesInWorkingDir(repoDir)
+	deps, err := a.DependenciesInWorkingDir(repoDir, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestDependenciesInWorkingDirRespectsGitignore(t *testing.T) {
 	}
 
 	a := analyzer.New()
-	deps, err := a.DependenciesInWorkingDir(repoDir)
+	deps, err := a.DependenciesInWorkingDir(repoDir, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -464,6 +464,135 @@ func TestDependenciesInWorkingDirRespectsGitignore(t *testing.T) {
 
 	if deps[0].Name != "rails" {
 		t.Errorf("expected rails, got %s", deps[0].Name)
+	}
+}
+
+func TestDependenciesInWorkingDirIgnoresSubmodules(t *testing.T) {
+	repoDir := createTestRepo(t)
+
+	// Create .gitmodules with submodules
+	gitmodulesContent := `[submodule "vendor/lib"]
+	path = vendor/lib
+	url = https://github.com/example/lib.git
+[submodule "external/tool"]
+	path = external/tool
+	url = https://github.com/example/tool.git
+`
+	addFile(t, repoDir, ".gitmodules", gitmodulesContent)
+	addFile(t, repoDir, "README.md", "# Test")
+	commit(t, repoDir, "Initial commit")
+
+	// Add a tracked manifest at root
+	if err := os.WriteFile(filepath.Join(repoDir, "Gemfile"), []byte(sampleGemfile(map[string]string{
+		"rails": "~> 7.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	// Add manifests in submodule directories (should be ignored)
+	if err := os.MkdirAll(filepath.Join(repoDir, "vendor", "lib"), 0755); err != nil {
+		t.Fatalf("failed to create vendor/lib dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "vendor", "lib", "Gemfile"), []byte(sampleGemfile(map[string]string{
+		"sinatra": "~> 3.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(repoDir, "external", "tool"), 0755); err != nil {
+		t.Fatalf("failed to create external/tool dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "external", "tool", "package.json"), []byte(`{
+		"name": "test",
+		"dependencies": {
+			"lodash": "^4.17.21"
+		}
+	}`), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	a := analyzer.New()
+	deps, err := a.DependenciesInWorkingDir(repoDir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should only see rails from the root Gemfile, not dependencies from submodules
+	if len(deps) != 1 {
+		t.Fatalf("expected 1 dependency, got %d: %+v", len(deps), deps)
+	}
+
+	if deps[0].Name != "rails" {
+		t.Errorf("expected rails, got %s", deps[0].Name)
+	}
+}
+
+func TestDependenciesInWorkingDirIncludesSubmodules(t *testing.T) {
+	repoDir := createTestRepo(t)
+
+	// Create .gitmodules with submodules
+	gitmodulesContent := `[submodule "vendor/lib"]
+	path = vendor/lib
+	url = https://github.com/example/lib.git
+[submodule "external/tool"]
+	path = external/tool
+	url = https://github.com/example/tool.git
+`
+	addFile(t, repoDir, ".gitmodules", gitmodulesContent)
+	addFile(t, repoDir, "README.md", "# Test")
+	commit(t, repoDir, "Initial commit")
+
+	// Add a tracked manifest at root
+	if err := os.WriteFile(filepath.Join(repoDir, "Gemfile"), []byte(sampleGemfile(map[string]string{
+		"rails": "~> 7.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	// Add manifests in submodule directories (should be included when flag is true)
+	if err := os.MkdirAll(filepath.Join(repoDir, "vendor", "lib"), 0755); err != nil {
+		t.Fatalf("failed to create vendor/lib dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "vendor", "lib", "Gemfile"), []byte(sampleGemfile(map[string]string{
+		"sinatra": "~> 3.0",
+	})), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(repoDir, "external", "tool"), 0755); err != nil {
+		t.Fatalf("failed to create external/tool dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "external", "tool", "package.json"), []byte(`{
+		"name": "test",
+		"dependencies": {
+			"lodash": "^4.17.21"
+		}
+	}`), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	a := analyzer.New()
+	deps, err := a.DependenciesInWorkingDir(repoDir, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should see all dependencies including those from submodules
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 dependencies, got %d: %+v", len(deps), deps)
+	}
+
+	// Verify we have deps from all three manifests
+	names := make(map[string]bool)
+	for _, dep := range deps {
+		names[dep.Name] = true
+	}
+
+	expected := []string{"rails", "sinatra", "lodash"}
+	for _, name := range expected {
+		if !names[name] {
+			t.Errorf("expected to find %s in dependencies", name)
+		}
 	}
 }
 

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -179,3 +179,26 @@ func (m *IgnoreMatcher) IsIgnored(relPath string, isDir bool) bool {
 	parts := strings.Split(filepath.ToSlash(relPath), "/")
 	return m.matcher.Match(parts, isDir)
 }
+
+// GetSubmodulePaths returns a list of submodule paths using go-git's submodule support.
+func (r *Repository) GetSubmodulePaths() ([]string, error) {
+	wt, err := r.repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("getting worktree: %w", err)
+	}
+
+	submodules, err := wt.Submodules()
+	if err != nil {
+		return nil, nil // No submodules or can't read them, return empty list
+	}
+
+	paths := make([]string, 0, len(submodules))
+	for _, submodule := range submodules {
+		config := submodule.Config()
+		// Normalize to forward slashes for cross-platform consistency
+		path := filepath.ToSlash(config.Path)
+		paths = append(paths, path)
+	}
+
+	return paths, nil
+}

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -369,3 +369,69 @@ func TestLocalBranches(t *testing.T) {
 		t.Errorf("expected feature in branches at featureSHA, got %v", branches[featureSHA])
 	}
 }
+
+func TestGetSubmodulePaths(t *testing.T) {
+	t.Run("returns empty list when no submodules", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFile(t, repoDir, "README.md", "# Test")
+		commit(t, repoDir, "Initial commit")
+
+		repo, err := git.OpenRepository(repoDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		paths, err := repo.GetSubmodulePaths()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(paths) != 0 {
+			t.Errorf("expected empty list, got %d submodules: %v", len(paths), paths)
+		}
+	})
+
+	t.Run("returns submodule paths when present", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFile(t, repoDir, "README.md", "# Test")
+		commit(t, repoDir, "Initial commit")
+
+		// Manually create .gitmodules file
+		gitmodulesContent := `[submodule "vendor/lib"]
+	path = vendor/lib
+	url = https://github.com/example/lib.git
+[submodule "external/tool"]
+	path = external/tool
+	url = https://github.com/example/tool.git
+`
+		addFile(t, repoDir, ".gitmodules", gitmodulesContent)
+		commit(t, repoDir, "Add submodules config")
+
+		repo, err := git.OpenRepository(repoDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		paths, err := repo.GetSubmodulePaths()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(paths) != 2 {
+			t.Fatalf("expected 2 submodules, got %d: %v", len(paths), paths)
+		}
+
+		// Check that both paths are present
+		pathMap := make(map[string]bool)
+		for _, p := range paths {
+			pathMap[p] = true
+		}
+
+		if !pathMap["vendor/lib"] {
+			t.Errorf("expected submodule path 'vendor/lib', got %v", paths)
+		}
+		if !pathMap["external/tool"] {
+			t.Errorf("expected submodule path 'external/tool', got %v", paths)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #72

Manifests and lockfiles found in git submodule directories are now properly ignored when scanning the working directory. This prevents dependencies from submodules being incorrectly reported as part of the main repository.

The implementation uses go-git's native `Worktree.Submodules()` API to detect submodule paths, which are then filtered out during filesystem walks in both the analyzer and where command.

Changes:
- Added `GetSubmodulePaths()` method to `Repository` using go-git's submodule support
- Updated `DependenciesInWorkingDir()` to skip submodule directories
- Updated `where` command to skip submodule directories
- Added comprehensive tests for submodule filtering