### PR TITLE
Fix stale command reporting 0 days for all dependencies

### DIFF
--- a/cmd/analysis_test.go
+++ b/cmd/analysis_test.go
@@ -3,6 +3,9 @@ package cmd_test
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -861,6 +864,68 @@ func TestStaleCommand(t *testing.T) {
 		first := result[0]
 		if _, ok := first["name"]; !ok {
 			t.Error("expected 'name' field in stale JSON")
+		}
+	})
+
+	t.Run("computes days since correctly for old commits", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+
+		// Create lockfile with a backdated commit (90 days ago)
+		fullPath := filepath.Join(repoDir, "package-lock.json")
+		if err := os.WriteFile(fullPath, []byte(packageLockJSON), 0644); err != nil {
+			t.Fatal(err)
+		}
+		gitCmd := exec.Command("git", "add", "package-lock.json")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		gitCmd = exec.Command("git", "commit", "-m", "Add lockfile")
+		gitCmd.Dir = repoDir
+		gitCmd.Env = append(os.Environ(),
+			"GIT_COMMITTER_DATE=2020-01-01T00:00:00Z",
+			"GIT_AUTHOR_DATE=2020-01-01T00:00:00Z",
+		)
+		if err := gitCmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		var stdout bytes.Buffer
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"stale", "--days", "0", "--format", "json"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("stale failed: %v", err)
+		}
+
+		var result []map[string]interface{}
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if len(result) == 0 {
+			t.Fatal("expected stale packages")
+		}
+
+		// The commit is from 2020, so days_since should be well over 1000
+		for _, entry := range result {
+			days, ok := entry["days_since"].(float64)
+			if !ok {
+				t.Fatalf("days_since not a number: %v", entry["days_since"])
+			}
+			if days < 1000 {
+				t.Errorf("expected days_since > 1000 for a 2020 commit, got %v for %v", days, entry["name"])
+			}
 		}
 	})
 }

--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -228,7 +228,7 @@ func (w *BatchWriter) insertCommits(tx *sql.Tx, now time.Time) error {
 			if pc.hasChanges {
 				hasChanges = 1
 			}
-			args = append(args, pc.info.SHA, pc.info.Message, pc.info.AuthorName, pc.info.AuthorEmail, pc.info.CommittedAt, hasChanges, now, now)
+			args = append(args, pc.info.SHA, pc.info.Message, pc.info.AuthorName, pc.info.AuthorEmail, pc.info.CommittedAt.UTC().Format("2006-01-02 15:04:05"), hasChanges, now, now)
 		}
 
 		if _, err := tx.Exec(sb.String(), args...); err != nil {

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -696,7 +696,7 @@ func (db *DB) GetStaleDependencies(branchID int64, ecosystem string, days int) (
 		)
 		SELECT cd.name, cd.ecosystem, cd.requirement, cd.path,
 		       COALESCE(lc.last_changed, '') as last_changed,
-		       CAST(julianday('now') - julianday(COALESCE(lc.last_changed, '2000-01-01')) AS INTEGER) as days_since
+		       CAST(julianday('now') - julianday(substr(COALESCE(lc.last_changed, '2000-01-01'), 1, 19)) AS INTEGER) as days_since
 		FROM current_deps cd
 		LEFT JOIN last_changed lc ON lc.name = cd.name AND lc.path = cd.path
 	`
@@ -713,7 +713,7 @@ func (db *DB) GetStaleDependencies(branchID int64, ecosystem string, days int) (
 		} else {
 			query += " WHERE"
 		}
-		query += " CAST(julianday('now') - julianday(COALESCE(lc.last_changed, '2000-01-01')) AS INTEGER) >= ?"
+		query += " CAST(julianday('now') - julianday(substr(COALESCE(lc.last_changed, '2000-01-01'), 1, 19)) AS INTEGER) >= ?"
 		args = append(args, days)
 	}
 

--- a/internal/database/writer.go
+++ b/internal/database/writer.go
@@ -196,7 +196,7 @@ func (w *Writer) InsertCommit(info CommitInfo, hasChanges bool) (int64, bool, er
 		info.Message,
 		info.AuthorName,
 		info.AuthorEmail,
-		info.CommittedAt,
+		info.CommittedAt.UTC().Format("2006-01-02 15:04:05"),
 		hasChangesInt,
 		now,
 		now,


### PR DESCRIPTION
Go's time.Time.String() produces timestamps like `2026-02-05 14:16:48 +0000 +0000` which SQLite's julianday() can't parse, returning NULL. The CAST to INTEGER then produces 0 for every entry.

Two changes: format committed_at as UTC when storing (`2006-01-02 15:04:05`), and wrap the julianday() calls in substr(..., 1, 19) so existing databases with the old format still work.

Reproduced and verified on pypi/warehouse at the commit from the issue report.

Fixes #83