### PR TITLE
Add .tool-versions (asdf) ecosystem support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.6
 require (
 	github.com/ecosyste-ms/ecosystems-go v0.1.0
 	github.com/git-pkgs/managers v0.4.0
-	github.com/git-pkgs/manifests v0.3.2
+	github.com/git-pkgs/manifests v0.3.3
 	github.com/git-pkgs/purl v0.1.4
 	github.com/git-pkgs/registries v0.2.3
 	github.com/git-pkgs/spdx v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/git-pkgs/managers v0.4.0 h1:ydsy8Hq4UpHYrrr33swkfJiR+0HFsFOdlOktsrsaAbY=
 github.com/git-pkgs/managers v0.4.0/go.mod h1:K6B5Z8vd6tfywKzi2JgOB1eDFevmT4F9wxk4Q3VCWXQ=
-github.com/git-pkgs/manifests v0.3.2 h1:3dt3Raac5ZpgLj/BL/pSpTH3Qf0cwxYV6Ii5biH9f3k=
-github.com/git-pkgs/manifests v0.3.2/go.mod h1:Fp08VXq28FfRVlnHhKTmLjTA1dLCmexfS1asNLgECRY=
+github.com/git-pkgs/manifests v0.3.3 h1:EUNqI0q1TH/Xr7HJxzlEwtEb7yZyQTZnpfhZ0Qlep3o=
+github.com/git-pkgs/manifests v0.3.3/go.mod h1:Fp08VXq28FfRVlnHhKTmLjTA1dLCmexfS1asNLgECRY=
 github.com/git-pkgs/purl v0.1.4 h1:FtyjLvADc23JizKHD43OtWsihU1GU5qVnMaT1aBnOqg=
 github.com/git-pkgs/purl v0.1.4/go.mod h1:2lthcr/s+JtSz1KV/M2gp3L98aGx0OqwQ7+23JNokIk=
 github.com/git-pkgs/registries v0.2.3 h1:KE9QQr+aqO06Jqb2lEfwFJ0Alimfdqmgs/QfgxIh0YU=


### PR DESCRIPTION
Bumps manifests to v0.3.3 which adds parsing for `.tool-versions` files used by asdf, mise, and rtx version managers.

Closes #86