### PR TITLE
Add notes subcommand for attaching metadata to packages

### DIFF
--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -1,0 +1,275 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/spf13/cobra"
+)
+
+func addNotesCmd(parent *cobra.Command) {
+	notesCmd := &cobra.Command{
+		Use:   "notes",
+		Short: "Manage notes on packages",
+		Long: `Attach arbitrary metadata and messages to packages identified by PURL.
+
+Notes are keyed on (purl, namespace) pairs. A namespace lets you categorize
+notes (e.g. "security", "audit", "review"). The default namespace is empty.`,
+	}
+
+	addCmd := &cobra.Command{
+		Use:   "add <purl>",
+		Short: "Add a note to a package",
+		Long:  `Create a new note for a package. Errors if a note already exists for the purl+namespace unless --force is used.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runNotesAdd,
+	}
+	addCmd.Flags().StringP("message", "m", "", "Note message")
+	addCmd.Flags().String("namespace", "", "Note namespace for categorization")
+	addCmd.Flags().StringArray("set", nil, "Set metadata key=value pair")
+	addCmd.Flags().Bool("force", false, "Overwrite existing note")
+
+	appendCmd := &cobra.Command{
+		Use:   "append <purl>",
+		Short: "Append to an existing note",
+		Long:  `Append message text and merge metadata into an existing note. Creates a new note if none exists.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runNotesAppend,
+	}
+	appendCmd.Flags().StringP("message", "m", "", "Message to append")
+	appendCmd.Flags().String("namespace", "", "Note namespace for categorization")
+	appendCmd.Flags().StringArray("set", nil, "Set metadata key=value pair")
+
+	showCmd := &cobra.Command{
+		Use:   "show <purl>",
+		Short: "Show a note for a package",
+		Long:  `Display the note attached to a package.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runNotesShow,
+	}
+	showCmd.Flags().String("namespace", "", "Note namespace to show")
+	showCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+
+	listCmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all notes",
+		Long:  `List all notes, optionally filtered by namespace or purl substring.`,
+		RunE:  runNotesList,
+	}
+	listCmd.Flags().String("namespace", "", "Filter by namespace")
+	listCmd.Flags().String("purl-filter", "", "Filter by purl substring")
+	listCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+
+	removeCmd := &cobra.Command{
+		Use:   "remove <purl>",
+		Short: "Remove a note",
+		Long:  `Delete the note for a package.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runNotesRemove,
+	}
+	removeCmd.Flags().String("namespace", "", "Note namespace to remove")
+
+	notesCmd.AddCommand(addCmd, appendCmd, showCmd, listCmd, removeCmd)
+	parent.AddCommand(notesCmd)
+}
+
+func runNotesAdd(cmd *cobra.Command, args []string) error {
+	purl := args[0]
+	message, _ := cmd.Flags().GetString("message")
+	namespace, _ := cmd.Flags().GetString("namespace")
+	setPairs, _ := cmd.Flags().GetStringArray("set")
+	force, _ := cmd.Flags().GetBool("force")
+
+	metadata, err := parseMetadata(setPairs)
+	if err != nil {
+		return err
+	}
+
+	_, db, err := openDatabase()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	existing, err := db.GetNote(purl, namespace)
+	if err != nil {
+		return fmt.Errorf("checking existing note: %w", err)
+	}
+
+	if existing != nil && !force {
+		return fmt.Errorf("note already exists for %s (namespace %q). Use --force to overwrite", purl, namespace)
+	}
+
+	if existing != nil && force {
+		err = db.UpdateNote(database.Note{
+			PURL:      purl,
+			Namespace: namespace,
+			Message:   message,
+			Metadata:  metadata,
+		})
+	} else {
+		err = db.InsertNote(database.Note{
+			PURL:      purl,
+			Namespace: namespace,
+			Message:   message,
+			Metadata:  metadata,
+		})
+	}
+	if err != nil {
+		return fmt.Errorf("saving note: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added note for %s\n", purl)
+	return nil
+}
+
+func runNotesAppend(cmd *cobra.Command, args []string) error {
+	purl := args[0]
+	message, _ := cmd.Flags().GetString("message")
+	namespace, _ := cmd.Flags().GetString("namespace")
+	setPairs, _ := cmd.Flags().GetStringArray("set")
+
+	metadata, err := parseMetadata(setPairs)
+	if err != nil {
+		return err
+	}
+
+	_, db, err := openDatabase()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.AppendNote(purl, namespace, message, metadata); err != nil {
+		return fmt.Errorf("appending note: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Appended to note for %s\n", purl)
+	return nil
+}
+
+func runNotesShow(cmd *cobra.Command, args []string) error {
+	purl := args[0]
+	namespace, _ := cmd.Flags().GetString("namespace")
+	format, _ := cmd.Flags().GetString("format")
+
+	_, db, err := openDatabase()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	note, err := db.GetNote(purl, namespace)
+	if err != nil {
+		return fmt.Errorf("getting note: %w", err)
+	}
+	if note == nil {
+		return fmt.Errorf("no note found for %s (namespace %q)", purl, namespace)
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(note)
+	default:
+		return outputNoteText(cmd, note)
+	}
+}
+
+func runNotesList(cmd *cobra.Command, args []string) error {
+	namespace, _ := cmd.Flags().GetString("namespace")
+	purlFilter, _ := cmd.Flags().GetString("purl-filter")
+	format, _ := cmd.Flags().GetString("format")
+
+	_, db, err := openDatabase()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	notes, err := db.ListNotes(namespace, purlFilter)
+	if err != nil {
+		return fmt.Errorf("listing notes: %w", err)
+	}
+
+	if len(notes) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No notes found.")
+		return nil
+	}
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(notes)
+	default:
+		for _, n := range notes {
+			line := n.PURL
+			if n.Namespace != "" {
+				line += " [" + n.Namespace + "]"
+			}
+			if n.Message != "" {
+				first := strings.SplitN(n.Message, "\n", 2)[0]
+				if len(first) > 60 {
+					first = first[:57] + "..."
+				}
+				line += " - " + first
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), line)
+		}
+		return nil
+	}
+}
+
+func runNotesRemove(cmd *cobra.Command, args []string) error {
+	purl := args[0]
+	namespace, _ := cmd.Flags().GetString("namespace")
+
+	_, db, err := openDatabase()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if err := db.DeleteNote(purl, namespace); err != nil {
+		return err
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Removed note for %s\n", purl)
+	return nil
+}
+
+func outputNoteText(cmd *cobra.Command, n *database.Note) error {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "PURL: %s\n", n.PURL)
+	if n.Namespace != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Namespace: %s\n", n.Namespace)
+	}
+	if n.Message != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", n.Message)
+	}
+	if len(n.Metadata) > 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nMetadata:")
+		for k, v := range n.Metadata {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", k, v)
+		}
+	}
+	return nil
+}
+
+func parseMetadata(pairs []string) (map[string]string, error) {
+	if len(pairs) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]string, len(pairs))
+	for _, pair := range pairs {
+		idx := strings.IndexByte(pair, '=')
+		if idx < 1 {
+			return nil, fmt.Errorf("invalid metadata format %q, expected key=value", pair)
+		}
+		m[pair[:idx]] = pair[idx+1:]
+	}
+	return m, nil
+}

--- a/cmd/notes_test.go
+++ b/cmd/notes_test.go
@@ -1,0 +1,462 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestNotesAdd(t *testing.T) {
+	t.Run("adds a note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "add", "pkg:npm/lodash@4.17.21", "-m", "approved for use", "--set", "status=approved")
+		if err != nil {
+			t.Fatalf("notes add failed: %v", err)
+		}
+		if !strings.Contains(stdout, "Added note") {
+			t.Errorf("expected 'Added note' message, got: %s", stdout)
+		}
+	})
+
+	t.Run("errors on duplicate without force", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "first")
+		if err != nil {
+			t.Fatalf("first add failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "second")
+		if err == nil {
+			t.Error("expected error for duplicate note")
+		}
+		if err != nil && !strings.Contains(err.Error(), "already exists") {
+			t.Errorf("expected 'already exists' error, got: %v", err)
+		}
+	})
+
+	t.Run("force overwrites existing note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "first")
+		if err != nil {
+			t.Fatalf("first add failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "replaced", "--force")
+		if err != nil {
+			t.Fatalf("force add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+		if !strings.Contains(stdout, "replaced") {
+			t.Errorf("expected 'replaced' message, got: %s", stdout)
+		}
+		if strings.Contains(stdout, "first") {
+			t.Errorf("old message should not be present, got: %s", stdout)
+		}
+	})
+}
+
+func TestNotesShow(t *testing.T) {
+	t.Run("shows a note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "good package", "--set", "status=approved")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+		if !strings.Contains(stdout, "pkg:npm/lodash") {
+			t.Errorf("expected purl in output, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "good package") {
+			t.Errorf("expected message in output, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "status") {
+			t.Errorf("expected metadata in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("errors for non-existent note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "show", "pkg:npm/nonexistent")
+		if err == nil {
+			t.Error("expected error for non-existent note")
+		}
+	})
+
+	t.Run("outputs json format", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "test note", "--set", "reviewer=alice")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "-f", "json")
+		if err != nil {
+			t.Fatalf("show json failed: %v", err)
+		}
+
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if note.PURL != "pkg:npm/lodash" {
+			t.Errorf("expected purl 'pkg:npm/lodash', got: %s", note.PURL)
+		}
+		if note.Message != "test note" {
+			t.Errorf("expected message 'test note', got: %s", note.Message)
+		}
+		if note.Metadata["reviewer"] != "alice" {
+			t.Errorf("expected metadata reviewer=alice, got: %v", note.Metadata)
+		}
+	})
+}
+
+func TestNotesList(t *testing.T) {
+	t.Run("lists notes", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "note one")
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/express", "-m", "note two")
+
+		stdout, _, err := runCmd(t, "notes", "list")
+		if err != nil {
+			t.Fatalf("list failed: %v", err)
+		}
+		if !strings.Contains(stdout, "pkg:npm/lodash") {
+			t.Errorf("expected lodash in list, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "pkg:npm/express") {
+			t.Errorf("expected express in list, got: %s", stdout)
+		}
+	})
+
+	t.Run("filters by namespace", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "security review", "--namespace", "security")
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/express", "-m", "audit note", "--namespace", "audit")
+
+		stdout, _, err := runCmd(t, "notes", "list", "--namespace", "security")
+		if err != nil {
+			t.Fatalf("list failed: %v", err)
+		}
+		if !strings.Contains(stdout, "pkg:npm/lodash") {
+			t.Errorf("expected lodash in filtered list, got: %s", stdout)
+		}
+		if strings.Contains(stdout, "pkg:npm/express") {
+			t.Errorf("express should not be in security namespace list, got: %s", stdout)
+		}
+	})
+
+	t.Run("filters by purl substring", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "note one")
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/express", "-m", "note two")
+
+		stdout, _, err := runCmd(t, "notes", "list", "--purl-filter", "lodash")
+		if err != nil {
+			t.Fatalf("list failed: %v", err)
+		}
+		if !strings.Contains(stdout, "pkg:npm/lodash") {
+			t.Errorf("expected lodash in filtered list, got: %s", stdout)
+		}
+		if strings.Contains(stdout, "pkg:npm/express") {
+			t.Errorf("express should not be in filtered list, got: %s", stdout)
+		}
+	})
+
+	t.Run("outputs json format", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "note one")
+
+		stdout, _, err := runCmd(t, "notes", "list", "-f", "json")
+		if err != nil {
+			t.Fatalf("list json failed: %v", err)
+		}
+
+		var notes []database.Note
+		if err := json.Unmarshal([]byte(stdout), &notes); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if len(notes) != 1 {
+			t.Fatalf("expected 1 note, got %d", len(notes))
+		}
+		if notes[0].PURL != "pkg:npm/lodash" {
+			t.Errorf("expected purl 'pkg:npm/lodash', got: %s", notes[0].PURL)
+		}
+	})
+
+	t.Run("shows no notes message", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "list")
+		if err != nil {
+			t.Fatalf("list failed: %v", err)
+		}
+		if !strings.Contains(stdout, "No notes found") {
+			t.Errorf("expected 'No notes found' message, got: %s", stdout)
+		}
+	})
+}
+
+func TestNotesRemove(t *testing.T) {
+	t.Run("removes a note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, _ = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "to delete")
+
+		stdout, _, err := runCmd(t, "notes", "remove", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("remove failed: %v", err)
+		}
+		if !strings.Contains(stdout, "Removed") {
+			t.Errorf("expected 'Removed' message, got: %s", stdout)
+		}
+
+		_, _, err = runCmd(t, "notes", "show", "pkg:npm/lodash")
+		if err == nil {
+			t.Error("expected error showing removed note")
+		}
+	})
+
+	t.Run("errors removing non-existent note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "remove", "pkg:npm/nonexistent")
+		if err == nil {
+			t.Error("expected error removing non-existent note")
+		}
+	})
+}
+
+func TestNotesAppend(t *testing.T) {
+	t.Run("appends to existing note", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "first line", "--set", "status=pending")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "append", "pkg:npm/lodash", "-m", "second line", "--set", "reviewer=alice")
+		if err != nil {
+			t.Fatalf("append failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "-f", "json")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if !strings.Contains(note.Message, "first line") {
+			t.Errorf("expected 'first line' in message, got: %s", note.Message)
+		}
+		if !strings.Contains(note.Message, "second line") {
+			t.Errorf("expected 'second line' in message, got: %s", note.Message)
+		}
+		if note.Metadata["status"] != "pending" {
+			t.Errorf("expected status=pending, got: %v", note.Metadata)
+		}
+		if note.Metadata["reviewer"] != "alice" {
+			t.Errorf("expected reviewer=alice, got: %v", note.Metadata)
+		}
+	})
+
+	t.Run("creates note when none exists", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "append", "pkg:npm/lodash", "-m", "new note via append")
+		if err != nil {
+			t.Fatalf("append failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+		if !strings.Contains(stdout, "new note via append") {
+			t.Errorf("expected message in output, got: %s", stdout)
+		}
+	})
+}
+
+func TestNotesNamespace(t *testing.T) {
+	t.Run("same purl different namespaces", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "security note", "--namespace", "security")
+		if err != nil {
+			t.Fatalf("add security failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "audit note", "--namespace", "audit")
+		if err != nil {
+			t.Fatalf("add audit failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "--namespace", "security")
+		if err != nil {
+			t.Fatalf("show security failed: %v", err)
+		}
+		if !strings.Contains(stdout, "security note") {
+			t.Errorf("expected 'security note', got: %s", stdout)
+		}
+
+		stdout, _, err = runCmd(t, "notes", "show", "pkg:npm/lodash", "--namespace", "audit")
+		if err != nil {
+			t.Fatalf("show audit failed: %v", err)
+		}
+		if !strings.Contains(stdout, "audit note") {
+			t.Errorf("expected 'audit note', got: %s", stdout)
+		}
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,6 +87,7 @@ func NewRootCmd() *cobra.Command {
 	addDiffFileCmd(cmd)
 	addBisectCmd(cmd)
 	addEcosystemsCmd(cmd)
+	addNotesCmd(cmd)
 
 	// Package manager commands
 	addInstallCmd(cmd)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Technical documentation for git-pkgs maintainers and contributors.
 - [schema.md](schema.md) - Database tables and relationships
 - [vulns.md](vulns.md) - Vulnerability scanning via OSV
 - [ci-cd.md](ci-cd.md) - CI/CD integration examples
+- [notes.md](notes.md) - Attaching metadata to packages
 - [package-management.md](package-management.md) - Package manager commands
 
 For user-facing documentation, see the main [README](../README.md).

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -1,0 +1,182 @@
+# Notes
+
+`git pkgs notes` attaches arbitrary metadata to packages identified by PURL. It works like `git notes` but keyed on package URLs instead of commits.
+
+Notes live in the local git-pkgs database. Each note is identified by a (purl, namespace) pair, so you can have separate notes for different concerns on the same package.
+
+## Basic usage
+
+Add a note:
+
+```
+$ git pkgs notes add pkg:npm/lodash@4.17.21 -m "approved for use" --set status=approved
+```
+
+View it:
+
+```
+$ git pkgs notes show pkg:npm/lodash@4.17.21
+PURL: pkg:npm/lodash@4.17.21
+
+approved for use
+
+Metadata:
+  status: approved
+```
+
+Append more information later:
+
+```
+$ git pkgs notes append pkg:npm/lodash@4.17.21 -m "re-reviewed Q1 2026" --set reviewer=alice
+```
+
+List all notes:
+
+```
+$ git pkgs notes list
+pkg:npm/lodash@4.17.21 - approved for use
+pkg:npm/express@4.18.2 - needs security review
+```
+
+Remove a note:
+
+```
+$ git pkgs notes remove pkg:npm/lodash@4.17.21
+```
+
+## Namespaces
+
+Namespaces let you keep different kinds of notes separate. A package can have one note per namespace.
+
+```
+$ git pkgs notes add pkg:npm/lodash -m "no known issues" --namespace security
+$ git pkgs notes add pkg:npm/lodash -m "approved Q4 2025" --namespace audit
+$ git pkgs notes list --namespace security
+pkg:npm/lodash [security] - no known issues
+```
+
+## Metadata
+
+The `--set key=value` flag stores structured key-value pairs as JSON. Append merges new keys into existing metadata without removing old ones.
+
+```
+$ git pkgs notes add pkg:npm/lodash --set status=approved --set reviewer=alice
+$ git pkgs notes show pkg:npm/lodash -f json
+{
+  "purl": "pkg:npm/lodash",
+  "namespace": "",
+  "message": "",
+  "metadata": {
+    "reviewer": "alice",
+    "status": "approved"
+  },
+  ...
+}
+```
+
+## Options
+
+All subcommands that take a purl accept both versioned (`pkg:npm/lodash@4.17.21`) and unversioned (`pkg:npm/lodash`) PURLs. These are distinct keys, so a note on `pkg:npm/lodash` is separate from one on `pkg:npm/lodash@4.17.21`.
+
+```
+add <purl>     Create a note (--force to overwrite)
+append <purl>  Append message text and merge metadata (creates if missing)
+show <purl>    Display a note
+list           List all notes
+remove <purl>  Delete a note
+```
+
+Common flags:
+
+```
+--namespace=NAME   Categorize notes (default: empty)
+-m, --message=TEXT Freeform text content
+--set key=value    Structured metadata (repeatable)
+-f, --format=FMT   Output format: text, json
+--force            Overwrite existing note (add only)
+--purl-filter=STR  Filter by purl substring (list only)
+```
+
+## Ideas for tooling integration
+
+Notes are a general-purpose annotation layer. Here are some ways tools could use them.
+
+### Capability analysis with capslock
+
+[capslock](https://github.com/google/capslock) detects what system capabilities Go packages use (network, filesystem, exec, etc). A CI step could record capability snapshots as notes:
+
+```bash
+for pkg in $(git pkgs list -f json | jq -r '.[].purl'); do
+  caps=$(capslock -packages "$pkg" 2>/dev/null | tr '\n' ',')
+  if [ -n "$caps" ]; then
+    git pkgs notes add "$pkg" --namespace capabilities --set "caps=$caps" --force
+  fi
+done
+```
+
+Later you can query which packages have network access:
+
+```bash
+git pkgs notes list --namespace capabilities -f json | jq '.[] | select(.metadata.caps | contains("NETWORK"))'
+```
+
+### Tracking sponsorship
+
+Record which packages your org sponsors:
+
+```bash
+git pkgs notes add pkg:npm/express --namespace sponsorship \
+  -m "Sponsored via GitHub Sponsors" \
+  --set platform=github --set amount=100 --set currency=USD --set since=2025-01
+```
+
+List all sponsored packages:
+
+```bash
+git pkgs notes list --namespace sponsorship
+```
+
+Cross-reference with current dependencies to find unsponsored packages you depend on, or sponsorships for packages you no longer use.
+
+### License review decisions
+
+Store the outcome of manual license reviews:
+
+```bash
+git pkgs notes add pkg:npm/some-lib --namespace license-review \
+  -m "Dual licensed MIT/GPL. We use under MIT terms per author confirmation in issue #42." \
+  --set decision=approved --set reviewed-by=legal-team --set date=2026-01-15
+```
+
+### Internal package policy
+
+Mark packages as approved, deprecated, or banned for your org:
+
+```bash
+git pkgs notes add pkg:npm/moment --namespace policy \
+  -m "Use dayjs instead" --set status=deprecated --set alternative=dayjs
+git pkgs notes add pkg:npm/event-stream --namespace policy \
+  -m "Compromised in 2018" --set status=banned
+```
+
+A CI check could compare current dependencies against policy notes and fail if any banned package is present.
+
+### Security review tracking
+
+Record when packages were last reviewed and by whom:
+
+```bash
+git pkgs notes add pkg:npm/lodash@4.17.21 --namespace security \
+  -m "Reviewed source, no concerns" \
+  --set reviewed-at=2026-01-20 --set reviewer=alice --set result=pass
+```
+
+### Build provenance
+
+Store build-related metadata like whether a package has reproducible builds or where its source is hosted:
+
+```bash
+git pkgs notes add pkg:npm/lodash --namespace provenance \
+  --set reproducible=yes --set source=https://github.com/lodash/lodash \
+  --set sigstore=true
+```

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 7
+const SchemaVersion = 8
 
 type DB struct {
 	*sql.DB

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -1998,6 +1999,171 @@ func (db *DB) SaveVersions(versions []CachedVersion) error {
 	}
 
 	return tx.Commit()
+}
+
+// Note represents a user-attached note on a PURL.
+type Note struct {
+	ID        int64             `json:"id"`
+	PURL      string            `json:"purl"`
+	Namespace string            `json:"namespace"`
+	Message   string            `json:"message,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	CreatedAt string            `json:"created_at"`
+	UpdatedAt string            `json:"updated_at"`
+}
+
+func (db *DB) InsertNote(note Note) error {
+	now := time.Now().Format(time.RFC3339)
+	metadataJSON := encodeMetadata(note.Metadata)
+	_, err := db.Exec(`
+		INSERT INTO notes (purl, namespace, message, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, note.PURL, note.Namespace, note.Message, metadataJSON, now, now)
+	return err
+}
+
+func (db *DB) UpdateNote(note Note) error {
+	now := time.Now().Format(time.RFC3339)
+	metadataJSON := encodeMetadata(note.Metadata)
+	_, err := db.Exec(`
+		UPDATE notes SET message = ?, metadata = ?, updated_at = ?
+		WHERE purl = ? AND namespace = ?
+	`, note.Message, metadataJSON, now, note.PURL, note.Namespace)
+	return err
+}
+
+func (db *DB) GetNote(purl, namespace string) (*Note, error) {
+	var n Note
+	var message, metadata sql.NullString
+	err := db.QueryRow(`
+		SELECT id, purl, namespace, message, metadata, created_at, updated_at
+		FROM notes WHERE purl = ? AND namespace = ?
+	`, purl, namespace).Scan(&n.ID, &n.PURL, &n.Namespace, &message, &metadata, &n.CreatedAt, &n.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if message.Valid {
+		n.Message = message.String
+	}
+	if metadata.Valid {
+		n.Metadata = decodeMetadata(metadata.String)
+	}
+	return &n, nil
+}
+
+func (db *DB) ListNotes(namespace, purlFilter string) ([]Note, error) {
+	query := "SELECT id, purl, namespace, message, metadata, created_at, updated_at FROM notes WHERE 1=1"
+	var args []any
+
+	if namespace != "" {
+		query += " AND namespace = ?"
+		args = append(args, namespace)
+	}
+	if purlFilter != "" {
+		query += " AND purl LIKE ?"
+		args = append(args, "%"+purlFilter+"%")
+	}
+
+	query += " ORDER BY purl, namespace"
+
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var notes []Note
+	for rows.Next() {
+		var n Note
+		var message, metadata sql.NullString
+		if err := rows.Scan(&n.ID, &n.PURL, &n.Namespace, &message, &metadata, &n.CreatedAt, &n.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if message.Valid {
+			n.Message = message.String
+		}
+		if metadata.Valid {
+			n.Metadata = decodeMetadata(metadata.String)
+		}
+		notes = append(notes, n)
+	}
+	return notes, rows.Err()
+}
+
+func (db *DB) DeleteNote(purl, namespace string) error {
+	result, err := db.Exec("DELETE FROM notes WHERE purl = ? AND namespace = ?", purl, namespace)
+	if err != nil {
+		return err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return fmt.Errorf("no note found for %s (namespace %q)", purl, namespace)
+	}
+	return nil
+}
+
+func (db *DB) AppendNote(purl, namespace, message string, metadata map[string]string) error {
+	existing, err := db.GetNote(purl, namespace)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return db.InsertNote(Note{
+			PURL:      purl,
+			Namespace: namespace,
+			Message:   message,
+			Metadata:  metadata,
+		})
+	}
+
+	newMessage := existing.Message
+	if message != "" {
+		if newMessage != "" {
+			newMessage += "\n" + message
+		} else {
+			newMessage = message
+		}
+	}
+
+	merged := existing.Metadata
+	if merged == nil {
+		merged = make(map[string]string)
+	}
+	for k, v := range metadata {
+		merged[k] = v
+	}
+
+	return db.UpdateNote(Note{
+		PURL:      purl,
+		Namespace: namespace,
+		Message:   newMessage,
+		Metadata:  merged,
+	})
+}
+
+func encodeMetadata(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	data, _ := json.Marshal(m)
+	return string(data)
+}
+
+func decodeMetadata(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	var m map[string]string
+	if json.Unmarshal([]byte(s), &m) != nil {
+		return nil
+	}
+	return m
 }
 
 // BisectCandidate represents a commit that changed dependencies, for use in bisect.

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -153,6 +153,18 @@ func (db *DB) CreateSchema() error {
 	CREATE INDEX IF NOT EXISTS idx_vuln_packages_ecosystem_name ON vulnerability_packages(ecosystem, package_name);
 	CREATE INDEX IF NOT EXISTS idx_vuln_packages_vuln_id ON vulnerability_packages(vulnerability_id);
 	CREATE UNIQUE INDEX IF NOT EXISTS idx_vuln_packages_unique ON vulnerability_packages(vulnerability_id, ecosystem, package_name);
+
+	CREATE TABLE IF NOT EXISTS notes (
+		id INTEGER PRIMARY KEY,
+		purl TEXT NOT NULL,
+		namespace TEXT NOT NULL DEFAULT '',
+		message TEXT,
+		metadata TEXT,
+		created_at DATETIME,
+		updated_at DATETIME
+	);
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_purl_namespace ON notes(purl, namespace);
+	CREATE INDEX IF NOT EXISTS idx_notes_namespace ON notes(namespace);
 	`
 
 	if _, err := db.Exec(schema); err != nil {


### PR DESCRIPTION
Adds `git pkgs notes` with add, append, show, list, and remove subcommands. Notes are keyed on (purl, namespace) pairs and support freeform messages and structured key=value metadata stored as JSON.

Schema bumped from 7 to 8 with a new `notes` table. Unique index on (purl, namespace) allows one note per package per namespace.

Subcommands:
- `add` - create a note (errors on duplicate unless `--force`)
- `append` - append message text and merge metadata keys (creates if missing)
- `show` - display a note for a purl
- `list` - list all notes with `--namespace` and `--purl-filter` options
- `remove` - delete a note