### PR TITLE
Add origin column to notes table

### DIFF
--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -28,6 +28,7 @@ notes (e.g. "security", "audit", "review"). The default namespace is empty.`,
 	}
 	addCmd.Flags().StringP("message", "m", "", "Note message")
 	addCmd.Flags().String("namespace", "", "Note namespace for categorization")
+	addCmd.Flags().String("origin", "git-pkgs", "Tool or system that created this note")
 	addCmd.Flags().StringArray("set", nil, "Set metadata key=value pair")
 	addCmd.Flags().Bool("force", false, "Overwrite existing note")
 
@@ -40,6 +41,7 @@ notes (e.g. "security", "audit", "review"). The default namespace is empty.`,
 	}
 	appendCmd.Flags().StringP("message", "m", "", "Message to append")
 	appendCmd.Flags().String("namespace", "", "Note namespace for categorization")
+	appendCmd.Flags().String("origin", "git-pkgs", "Tool or system that created this note")
 	appendCmd.Flags().StringArray("set", nil, "Set metadata key=value pair")
 
 	showCmd := &cobra.Command{
@@ -88,6 +90,7 @@ func runNotesAdd(cmd *cobra.Command, args []string) error {
 	purl := args[0]
 	message, _ := cmd.Flags().GetString("message")
 	namespace, _ := cmd.Flags().GetString("namespace")
+	origin, _ := cmd.Flags().GetString("origin")
 	setPairs, _ := cmd.Flags().GetStringArray("set")
 	force, _ := cmd.Flags().GetBool("force")
 
@@ -115,6 +118,7 @@ func runNotesAdd(cmd *cobra.Command, args []string) error {
 		err = db.UpdateNote(database.Note{
 			PURL:      purl,
 			Namespace: namespace,
+			Origin:    origin,
 			Message:   message,
 			Metadata:  metadata,
 		})
@@ -122,6 +126,7 @@ func runNotesAdd(cmd *cobra.Command, args []string) error {
 		err = db.InsertNote(database.Note{
 			PURL:      purl,
 			Namespace: namespace,
+			Origin:    origin,
 			Message:   message,
 			Metadata:  metadata,
 		})
@@ -138,6 +143,7 @@ func runNotesAppend(cmd *cobra.Command, args []string) error {
 	purl := args[0]
 	message, _ := cmd.Flags().GetString("message")
 	namespace, _ := cmd.Flags().GetString("namespace")
+	origin, _ := cmd.Flags().GetString("origin")
 	setPairs, _ := cmd.Flags().GetStringArray("set")
 
 	metadata, err := parseMetadata(setPairs)
@@ -151,7 +157,7 @@ func runNotesAppend(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = db.Close() }()
 
-	if err := db.AppendNote(purl, namespace, message, metadata); err != nil {
+	if err := db.AppendNote(purl, namespace, origin, message, metadata); err != nil {
 		return fmt.Errorf("appending note: %w", err)
 	}
 
@@ -219,6 +225,9 @@ func runNotesList(cmd *cobra.Command, args []string) error {
 			line := n.PURL
 			if n.Namespace != "" {
 				line += " [" + n.Namespace + "]"
+			}
+			if n.Origin != "" && n.Origin != "git-pkgs" {
+				line += " (origin: " + n.Origin + ")"
 			}
 			if n.Message != "" {
 				first := strings.SplitN(n.Message, "\n", 2)[0]
@@ -292,6 +301,9 @@ func outputNoteText(cmd *cobra.Command, n *database.Note) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "PURL: %s\n", n.PURL)
 	if n.Namespace != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Namespace: %s\n", n.Namespace)
+	}
+	if n.Origin != "" {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Origin: %s\n", n.Origin)
 	}
 	if n.Message != "" {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\n%s\n", n.Message)

--- a/cmd/notes_test.go
+++ b/cmd/notes_test.go
@@ -505,6 +505,153 @@ func TestNotesNamespaces(t *testing.T) {
 	})
 }
 
+func TestNotesOrigin(t *testing.T) {
+	t.Run("default origin is git-pkgs", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "test note")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "-f", "json")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if note.Origin != "git-pkgs" {
+			t.Errorf("expected origin 'git-pkgs', got: %s", note.Origin)
+		}
+	})
+
+	t.Run("custom origin persists", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "from scanner", "--origin", "snyk")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "-f", "json")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if note.Origin != "snyk" {
+			t.Errorf("expected origin 'snyk', got: %s", note.Origin)
+		}
+	})
+
+	t.Run("origin shown in text output", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "test", "--origin", "custom-tool")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+		if !strings.Contains(stdout, "Origin: custom-tool") {
+			t.Errorf("expected 'Origin: custom-tool' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("custom origin shown in list output", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "test", "--origin", "external")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "list")
+		if err != nil {
+			t.Fatalf("list failed: %v", err)
+		}
+		if !strings.Contains(stdout, "(origin: external)") {
+			t.Errorf("expected '(origin: external)' in list output, got: %s", stdout)
+		}
+	})
+
+	t.Run("append preserves existing origin", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "add", "pkg:npm/lodash", "-m", "initial", "--origin", "snyk")
+		if err != nil {
+			t.Fatalf("add failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "append", "pkg:npm/lodash", "-m", "more info")
+		if err != nil {
+			t.Fatalf("append failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "-f", "json")
+		if err != nil {
+			t.Fatalf("show failed: %v", err)
+		}
+
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if note.Origin != "snyk" {
+			t.Errorf("expected origin 'snyk' preserved after append, got: %s", note.Origin)
+		}
+	})
+}
+
 func TestNotesNamespace(t *testing.T) {
 	t.Run("same purl different namespaces", func(t *testing.T) {
 		repoDir := createTestRepo(t)

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -2006,6 +2006,7 @@ type Note struct {
 	ID        int64             `json:"id"`
 	PURL      string            `json:"purl"`
 	Namespace string            `json:"namespace"`
+	Origin    string            `json:"origin"`
 	Message   string            `json:"message,omitempty"`
 	Metadata  map[string]string `json:"metadata,omitempty"`
 	CreatedAt string            `json:"created_at"`
@@ -2015,20 +2016,28 @@ type Note struct {
 func (db *DB) InsertNote(note Note) error {
 	now := time.Now().Format(time.RFC3339)
 	metadataJSON := encodeMetadata(note.Metadata)
+	origin := note.Origin
+	if origin == "" {
+		origin = "git-pkgs"
+	}
 	_, err := db.Exec(`
-		INSERT INTO notes (purl, namespace, message, metadata, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`, note.PURL, note.Namespace, note.Message, metadataJSON, now, now)
+		INSERT INTO notes (purl, namespace, origin, message, metadata, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, note.PURL, note.Namespace, origin, note.Message, metadataJSON, now, now)
 	return err
 }
 
 func (db *DB) UpdateNote(note Note) error {
 	now := time.Now().Format(time.RFC3339)
 	metadataJSON := encodeMetadata(note.Metadata)
+	origin := note.Origin
+	if origin == "" {
+		origin = "git-pkgs"
+	}
 	_, err := db.Exec(`
-		UPDATE notes SET message = ?, metadata = ?, updated_at = ?
+		UPDATE notes SET message = ?, metadata = ?, origin = ?, updated_at = ?
 		WHERE purl = ? AND namespace = ?
-	`, note.Message, metadataJSON, now, note.PURL, note.Namespace)
+	`, note.Message, metadataJSON, origin, now, note.PURL, note.Namespace)
 	return err
 }
 
@@ -2036,9 +2045,9 @@ func (db *DB) GetNote(purl, namespace string) (*Note, error) {
 	var n Note
 	var message, metadata sql.NullString
 	err := db.QueryRow(`
-		SELECT id, purl, namespace, message, metadata, created_at, updated_at
+		SELECT id, purl, namespace, origin, message, metadata, created_at, updated_at
 		FROM notes WHERE purl = ? AND namespace = ?
-	`, purl, namespace).Scan(&n.ID, &n.PURL, &n.Namespace, &message, &metadata, &n.CreatedAt, &n.UpdatedAt)
+	`, purl, namespace).Scan(&n.ID, &n.PURL, &n.Namespace, &n.Origin, &message, &metadata, &n.CreatedAt, &n.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -2055,7 +2064,7 @@ func (db *DB) GetNote(purl, namespace string) (*Note, error) {
 }
 
 func (db *DB) ListNotes(namespace, purlFilter string) ([]Note, error) {
-	query := "SELECT id, purl, namespace, message, metadata, created_at, updated_at FROM notes WHERE 1=1"
+	query := "SELECT id, purl, namespace, origin, message, metadata, created_at, updated_at FROM notes WHERE 1=1"
 	var args []any
 
 	if namespace != "" {
@@ -2079,7 +2088,7 @@ func (db *DB) ListNotes(namespace, purlFilter string) ([]Note, error) {
 	for rows.Next() {
 		var n Note
 		var message, metadata sql.NullString
-		if err := rows.Scan(&n.ID, &n.PURL, &n.Namespace, &message, &metadata, &n.CreatedAt, &n.UpdatedAt); err != nil {
+		if err := rows.Scan(&n.ID, &n.PURL, &n.Namespace, &n.Origin, &message, &metadata, &n.CreatedAt, &n.UpdatedAt); err != nil {
 			return nil, err
 		}
 		if message.Valid {
@@ -2138,7 +2147,7 @@ func (db *DB) DeleteNote(purl, namespace string) error {
 	return nil
 }
 
-func (db *DB) AppendNote(purl, namespace, message string, metadata map[string]string) error {
+func (db *DB) AppendNote(purl, namespace, origin, message string, metadata map[string]string) error {
 	existing, err := db.GetNote(purl, namespace)
 	if err != nil {
 		return err
@@ -2147,6 +2156,7 @@ func (db *DB) AppendNote(purl, namespace, message string, metadata map[string]st
 		return db.InsertNote(Note{
 			PURL:      purl,
 			Namespace: namespace,
+			Origin:    origin,
 			Message:   message,
 			Metadata:  metadata,
 		})
@@ -2172,6 +2182,7 @@ func (db *DB) AppendNote(purl, namespace, message string, metadata map[string]st
 	return db.UpdateNote(Note{
 		PURL:      purl,
 		Namespace: namespace,
+		Origin:    existing.Origin,
 		Message:   newMessage,
 		Metadata:  merged,
 	})

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -158,6 +158,7 @@ func (db *DB) CreateSchema() error {
 		id INTEGER PRIMARY KEY,
 		purl TEXT NOT NULL,
 		namespace TEXT NOT NULL DEFAULT '',
+		origin TEXT NOT NULL DEFAULT 'git-pkgs',
 		message TEXT,
 		metadata TEXT,
 		created_at DATETIME,


### PR DESCRIPTION
Adds an `origin` column to the notes table so external tools can declare provenance when writing notes. Defaults to "git-pkgs".

- New `--origin` flag on `notes add` and `notes append` subcommands
- Origin displayed in `notes show` text output and `notes list` (when non-default)
- Append preserves the existing note's origin
- JSON output includes the origin field