### PR TITLE
Fix diff not pairing version changes for duplicate packages

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -209,37 +209,81 @@ func computeDiff(fromDeps, toDeps []database.Dependency) *DiffResult {
 			continue
 		}
 
-		// Multiple versions on at least one side: compare version sets
-		fromVersions := make(map[string]bool, len(fromList))
+		// Multiple versions on at least one side: count occurrences of each
+		// version and pair net removals with net additions as Modified.
+		fromCounts := make(map[string]int, len(fromList))
 		for _, d := range fromList {
-			fromVersions[d.Requirement] = true
+			fromCounts[d.Requirement]++
 		}
-		toVersions := make(map[string]bool, len(toList))
+		toCounts := make(map[string]int, len(toList))
 		for _, d := range toList {
-			toVersions[d.Requirement] = true
+			toCounts[d.Requirement]++
 		}
 
-		for _, d := range toList {
-			if !fromVersions[d.Requirement] {
-				result.Added = append(result.Added, DiffEntry{
-					Name:           d.Name,
-					Ecosystem:      d.Ecosystem,
-					ManifestPath:   d.ManifestPath,
-					DependencyType: d.DependencyType,
-					ToRequirement:  d.Requirement,
-				})
+		// Use the first entry as a template for metadata.
+		ref := toList[0]
+
+		// Build lists of individual net removals and net additions.
+		var removedVersions []string
+		var addedVersions []string
+
+		// Versions that decreased in count or disappeared entirely.
+		for ver, fc := range fromCounts {
+			tc := toCounts[ver]
+			if delta := fc - tc; delta > 0 {
+				for i := 0; i < delta; i++ {
+					removedVersions = append(removedVersions, ver)
+				}
 			}
 		}
-		for _, d := range fromList {
-			if !toVersions[d.Requirement] {
-				result.Removed = append(result.Removed, DiffEntry{
-					Name:            d.Name,
-					Ecosystem:       d.Ecosystem,
-					ManifestPath:    d.ManifestPath,
-					DependencyType:  d.DependencyType,
-					FromRequirement: d.Requirement,
-				})
+		// Versions that increased in count or appeared for the first time.
+		for ver, tc := range toCounts {
+			fc := fromCounts[ver]
+			if delta := tc - fc; delta > 0 {
+				for i := 0; i < delta; i++ {
+					addedVersions = append(addedVersions, ver)
+				}
 			}
+		}
+
+		// Sort for deterministic pairing.
+		sort.Strings(removedVersions)
+		sort.Strings(addedVersions)
+
+		// Pair removals with additions as Modified.
+		paired := len(removedVersions)
+		if len(addedVersions) < paired {
+			paired = len(addedVersions)
+		}
+		for i := 0; i < paired; i++ {
+			result.Modified = append(result.Modified, DiffEntry{
+				Name:            ref.Name,
+				Ecosystem:       ref.Ecosystem,
+				ManifestPath:    ref.ManifestPath,
+				DependencyType:  ref.DependencyType,
+				FromRequirement: removedVersions[i],
+				ToRequirement:   addedVersions[i],
+			})
+		}
+		// Surplus additions.
+		for i := paired; i < len(addedVersions); i++ {
+			result.Added = append(result.Added, DiffEntry{
+				Name:           ref.Name,
+				Ecosystem:      ref.Ecosystem,
+				ManifestPath:   ref.ManifestPath,
+				DependencyType: ref.DependencyType,
+				ToRequirement:  addedVersions[i],
+			})
+		}
+		// Surplus removals.
+		for i := paired; i < len(removedVersions); i++ {
+			result.Removed = append(result.Removed, DiffEntry{
+				Name:            ref.Name,
+				Ecosystem:       ref.Ecosystem,
+				ManifestPath:    ref.ManifestPath,
+				DependencyType:  ref.DependencyType,
+				FromRequirement: removedVersions[i],
+			})
 		}
 	}
 

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -469,6 +469,103 @@ func TestComputeDiff_DuplicatePackageVersionsInLockfile(t *testing.T) {
 	}
 }
 
+func TestComputeDiff_MultiVersionUpgrade(t *testing.T) {
+	// glob exists at three versions; one version gets a patch bump.
+	// Should produce 1 Modified, not 1 Added + 1 Removed.
+	fromDeps := []database.Dependency{
+		{Name: "glob", Ecosystem: "npm", Requirement: "7.2.3", ManifestPath: "package-lock.json"},
+		{Name: "glob", Ecosystem: "npm", Requirement: "10.5.0", ManifestPath: "package-lock.json"},
+		{Name: "glob", Ecosystem: "npm", Requirement: "13.0.0", ManifestPath: "package-lock.json"},
+	}
+	toDeps := []database.Dependency{
+		{Name: "glob", Ecosystem: "npm", Requirement: "7.2.3", ManifestPath: "package-lock.json"},
+		{Name: "glob", Ecosystem: "npm", Requirement: "10.5.0", ManifestPath: "package-lock.json"},
+		{Name: "glob", Ecosystem: "npm", Requirement: "13.0.1", ManifestPath: "package-lock.json"},
+	}
+
+	result := computeDiff(fromDeps, toDeps)
+
+	if len(result.Added) != 0 {
+		t.Errorf("expected 0 added, got %d: %+v", len(result.Added), result.Added)
+	}
+	if len(result.Removed) != 0 {
+		t.Errorf("expected 0 removed, got %d: %+v", len(result.Removed), result.Removed)
+	}
+	if len(result.Modified) != 1 {
+		t.Fatalf("expected 1 modified, got %d: %+v", len(result.Modified), result.Modified)
+	}
+	if result.Modified[0].FromRequirement != "13.0.0" {
+		t.Errorf("expected FromRequirement '13.0.0', got %s", result.Modified[0].FromRequirement)
+	}
+	if result.Modified[0].ToRequirement != "13.0.1" {
+		t.Errorf("expected ToRequirement '13.0.1', got %s", result.Modified[0].ToRequirement)
+	}
+}
+
+func TestComputeDiff_VersionCountChangeWithUpgrade(t *testing.T) {
+	// isexe goes from 1 copy at 3.1.1 to 5 copies at 3.1.5.
+	// Should produce 1 Modified + 4 Added.
+	fromDeps := []database.Dependency{
+		{Name: "isexe", Ecosystem: "npm", Requirement: "3.1.1", ManifestPath: "package-lock.json"},
+	}
+	toDeps := []database.Dependency{
+		{Name: "isexe", Ecosystem: "npm", Requirement: "3.1.5", ManifestPath: "package-lock.json"},
+		{Name: "isexe", Ecosystem: "npm", Requirement: "3.1.5", ManifestPath: "package-lock.json"},
+		{Name: "isexe", Ecosystem: "npm", Requirement: "3.1.5", ManifestPath: "package-lock.json"},
+		{Name: "isexe", Ecosystem: "npm", Requirement: "3.1.5", ManifestPath: "package-lock.json"},
+		{Name: "isexe", Ecosystem: "npm", Requirement: "3.1.5", ManifestPath: "package-lock.json"},
+	}
+
+	result := computeDiff(fromDeps, toDeps)
+
+	if len(result.Removed) != 0 {
+		t.Errorf("expected 0 removed, got %d: %+v", len(result.Removed), result.Removed)
+	}
+	if len(result.Modified) != 1 {
+		t.Fatalf("expected 1 modified, got %d: %+v", len(result.Modified), result.Modified)
+	}
+	if result.Modified[0].FromRequirement != "3.1.1" {
+		t.Errorf("expected FromRequirement '3.1.1', got %s", result.Modified[0].FromRequirement)
+	}
+	if result.Modified[0].ToRequirement != "3.1.5" {
+		t.Errorf("expected ToRequirement '3.1.5', got %s", result.Modified[0].ToRequirement)
+	}
+	if len(result.Added) != 4 {
+		t.Errorf("expected 4 added, got %d: %+v", len(result.Added), result.Added)
+	}
+}
+
+func TestComputeDiff_MultiVersionMixed(t *testing.T) {
+	// Two versions on both sides. One version unchanged, the other upgraded.
+	// semver stays at 6.3.1 on both sides, 7.7.3 upgrades to 7.7.4.
+	fromDeps := []database.Dependency{
+		{Name: "semver", Ecosystem: "npm", Requirement: "6.3.1", ManifestPath: "package-lock.json"},
+		{Name: "semver", Ecosystem: "npm", Requirement: "7.7.3", ManifestPath: "package-lock.json"},
+	}
+	toDeps := []database.Dependency{
+		{Name: "semver", Ecosystem: "npm", Requirement: "6.3.1", ManifestPath: "package-lock.json"},
+		{Name: "semver", Ecosystem: "npm", Requirement: "7.7.4", ManifestPath: "package-lock.json"},
+	}
+
+	result := computeDiff(fromDeps, toDeps)
+
+	if len(result.Added) != 0 {
+		t.Errorf("expected 0 added, got %d: %+v", len(result.Added), result.Added)
+	}
+	if len(result.Removed) != 0 {
+		t.Errorf("expected 0 removed, got %d: %+v", len(result.Removed), result.Removed)
+	}
+	if len(result.Modified) != 1 {
+		t.Fatalf("expected 1 modified, got %d: %+v", len(result.Modified), result.Modified)
+	}
+	if result.Modified[0].FromRequirement != "7.7.3" {
+		t.Errorf("expected FromRequirement '7.7.3', got %s", result.Modified[0].FromRequirement)
+	}
+	if result.Modified[0].ToRequirement != "7.7.4" {
+		t.Errorf("expected ToRequirement '7.7.4', got %s", result.Modified[0].ToRequirement)
+	}
+}
+
 func containsString(s, substr string) bool {
 	for i := 0; i <= len(s)-len(substr); i++ {
 		if s[i:i+len(substr)] == substr {


### PR DESCRIPTION
When a package appears multiple times in a lockfile (npm deduplication), `git pkgs diff` was reporting version upgrades as separate Added/Removed entries instead of Modified.

The multi-version branch in `computeDiff` used boolean version sets (present or not), so it couldn't track count changes or pair a disappeared version with a new one. Replaced with count-based tracking that computes net changes per version and pairs removals with additions as Modified.

For example, `glob` at versions [7.2.3, 10.5.0, 13.0.0] changing to [7.2.3, 10.5.0, 13.0.1] now correctly shows `glob 13.0.0 -> 13.0.1` as Modified instead of a separate Removed + Added.

Fixes #102