### PR TITLE
Add urls command

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,26 @@ Gemfile.lock:142:    rails (7.0.8)
 
 Like `grep` but scoped to manifest files that git-pkgs knows about.
 
+### Package URLs
+
+Show registry URLs for a package (registry page, download, documentation, PURL):
+
+```bash
+git pkgs urls pkg:cargo/serde@1.0.0           # from a PURL
+git pkgs urls lodash --ecosystem npm           # from the database
+git pkgs urls pkg:npm/express@4.19.0 -f json   # JSON output
+```
+
+Example output:
+```
+docs       https://docs.rs/serde/1.0.0
+download   https://static.crates.io/crates/serde/serde-1.0.0.crate
+purl       pkg:cargo/serde@1.0.0
+registry   https://crates.io/crates/serde/1.0.0
+```
+
+When given a PURL, no database is needed. When given a plain package name, the database is searched for a matching dependency and the ecosystem is inferred. Use `--ecosystem` to disambiguate when a name appears in multiple ecosystems.
+
 ### Search dependencies
 
 ```bash

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -53,6 +53,10 @@ func isResolvedDependency(d database.Dependency) bool {
 	return d.Requirement != "" && (d.ManifestKind == "lockfile" || d.Ecosystem == "golang")
 }
 
+func IsPURL(s string) bool {
+	return strings.HasPrefix(s, "pkg:")
+}
+
 func filterByEcosystem(deps []database.Dependency, ecosystem string) []database.Dependency {
 	if ecosystem == "" {
 		return deps

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,7 @@ func NewRootCmd() *cobra.Command {
 	addBisectCmd(cmd)
 	addEcosystemsCmd(cmd)
 	addNotesCmd(cmd)
+	addUrlsCmd(cmd)
 
 	// Package manager commands
 	addInstallCmd(cmd)

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/registries"
+	_ "github.com/git-pkgs/registries/all"
+	"github.com/spf13/cobra"
+)
+
+func addUrlsCmd(parent *cobra.Command) {
+	urlsCmd := &cobra.Command{
+		Use:   "urls <package>",
+		Short: "Show registry URLs for a package",
+		Long: `Display all known URLs for a package: registry page, download, documentation, and PURL.
+
+The package can be specified as a PURL (pkg:cargo/serde@1.0.0) or as a plain
+package name. When using a plain name, the database is searched for a matching
+dependency and the ecosystem and version are inferred from it.
+
+Examples:
+  git-pkgs urls pkg:cargo/serde@1.0.0
+  git-pkgs urls lodash --ecosystem npm
+  git-pkgs urls pkg:npm/express@4.19.0 --format json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runUrls,
+	}
+
+	urlsCmd.Flags().StringP("ecosystem", "e", "", "Filter/specify ecosystem (used for name lookups)")
+	urlsCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	parent.AddCommand(urlsCmd)
+}
+
+func runUrls(cmd *cobra.Command, args []string) error {
+	pkg := args[0]
+	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	format, _ := cmd.Flags().GetString("format")
+
+	var purlType, name, version string
+
+	if IsPURL(pkg) {
+		p, err := purl.Parse(pkg)
+		if err != nil {
+			return fmt.Errorf("parsing purl: %w", err)
+		}
+		purlType = p.Type
+		name = p.FullName()
+		version = p.Version
+	} else {
+		var err error
+		purlType, name, version, err = lookupPackage(pkg, ecosystem)
+		if err != nil {
+			return err
+		}
+	}
+
+	reg, err := registries.New(purlType, "", nil)
+	if err != nil {
+		return fmt.Errorf("unsupported ecosystem %q: %w", purlType, err)
+	}
+
+	urls := registries.BuildURLs(reg.URLs(), name, version)
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(urls)
+	default:
+		return outputUrlsText(cmd, urls)
+	}
+}
+
+func outputUrlsText(cmd *cobra.Command, urls map[string]string) error {
+	keys := make([]string, 0, len(urls))
+	for k := range urls {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-10s %s\n", k, urls[k])
+	}
+	return nil
+}
+
+func lookupPackage(name, ecosystem string) (purlType, pkgName, version string, err error) {
+	_, db, err := openDatabase()
+	if err != nil {
+		return "", "", "", err
+	}
+	defer func() { _ = db.Close() }()
+
+	branchInfo, err := db.GetDefaultBranch()
+	if err != nil {
+		return "", "", "", fmt.Errorf("getting branch: %w", err)
+	}
+
+	results, err := db.SearchDependencies(branchInfo.ID, name, ecosystem, false)
+	if err != nil {
+		return "", "", "", fmt.Errorf("searching dependencies: %w", err)
+	}
+
+	if len(results) == 0 {
+		if ecosystem != "" {
+			return "", "", "", fmt.Errorf("no %s dependency matching %q found", ecosystem, name)
+		}
+		return "", "", "", fmt.Errorf("no dependency matching %q found", name)
+	}
+
+	// Filter to exact name matches if any exist
+	var exact []struct{ eco, req string }
+	for _, r := range results {
+		if strings.EqualFold(r.Name, name) {
+			exact = append(exact, struct{ eco, req string }{r.Ecosystem, r.Requirement})
+		}
+	}
+
+	if len(exact) == 0 {
+		// No exact match, use the first result
+		exact = append(exact, struct{ eco, req string }{results[0].Ecosystem, results[0].Requirement})
+	}
+
+	// Deduplicate by ecosystem
+	seen := make(map[string]bool)
+	var unique []struct{ eco, req string }
+	for _, e := range exact {
+		if !seen[e.eco] {
+			seen[e.eco] = true
+			unique = append(unique, e)
+		}
+	}
+
+	if len(unique) > 1 && ecosystem == "" {
+		ecos := make([]string, len(unique))
+		for i, u := range unique {
+			ecos[i] = u.eco
+		}
+		return "", "", "", fmt.Errorf("ambiguous: %q found in multiple ecosystems (%s). Use --ecosystem to specify", name, strings.Join(ecos, ", "))
+	}
+
+	match := unique[0]
+	pt := purl.EcosystemToPURLType(match.eco)
+	return pt, name, match.req, nil
+}

--- a/cmd/urls_test.go
+++ b/cmd/urls_test.go
@@ -1,0 +1,150 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/cmd"
+)
+
+func TestIsPURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"pkg:cargo/serde@1.0.0", true},
+		{"pkg:npm/lodash", true},
+		{"pkg:npm/%40scope/pkg@1.0.0", true},
+		{"serde", false},
+		{"lodash", false},
+		{"", false},
+		{"package:npm/lodash", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := cmd.IsPURL(tt.input)
+			if got != tt.want {
+				t.Errorf("IsPURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUrlsPURL(t *testing.T) {
+	t.Run("returns urls for cargo purl", func(t *testing.T) {
+		stdout, _, err := runCmd(t, "urls", "pkg:cargo/serde@1.0.0")
+		if err != nil {
+			t.Fatalf("urls failed: %v", err)
+		}
+		if !strings.Contains(stdout, "registry") {
+			t.Errorf("expected 'registry' in output, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "purl") {
+			t.Errorf("expected 'purl' in output, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "crates.io") {
+			t.Errorf("expected 'crates.io' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("returns urls for npm purl", func(t *testing.T) {
+		stdout, _, err := runCmd(t, "urls", "pkg:npm/express@4.19.0")
+		if err != nil {
+			t.Fatalf("urls failed: %v", err)
+		}
+		if !strings.Contains(stdout, "npmjs") {
+			t.Errorf("expected 'npmjs' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("json format", func(t *testing.T) {
+		stdout, _, err := runCmd(t, "urls", "pkg:cargo/serde@1.0.0", "-f", "json")
+		if err != nil {
+			t.Fatalf("urls json failed: %v", err)
+		}
+
+		var urls map[string]string
+		if err := json.Unmarshal([]byte(stdout), &urls); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		if urls["registry"] == "" {
+			t.Error("expected registry URL in json output")
+		}
+		if urls["purl"] == "" {
+			t.Error("expected purl in json output")
+		}
+	})
+
+	t.Run("errors on invalid purl", func(t *testing.T) {
+		_, _, err := runCmd(t, "urls", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid purl")
+		}
+	})
+
+	t.Run("errors on unsupported ecosystem", func(t *testing.T) {
+		_, _, err := runCmd(t, "urls", "pkg:nonexistent/foo@1.0.0")
+		if err == nil {
+			t.Error("expected error for unsupported ecosystem")
+		}
+		if err != nil && !strings.Contains(err.Error(), "unsupported") {
+			t.Errorf("expected 'unsupported' in error, got: %v", err)
+		}
+	})
+}
+
+func TestUrlsNameLookup(t *testing.T) {
+	t.Run("looks up package by name", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "urls", "lodash", "-e", "npm")
+		if err != nil {
+			t.Fatalf("urls failed: %v", err)
+		}
+		if !strings.Contains(stdout, "npmjs") {
+			t.Errorf("expected 'npmjs' in output, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "registry") {
+			t.Errorf("expected 'registry' key in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("errors when package not found", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		_, _, err = runCmd(t, "urls", "nonexistent-package-xyz")
+		if err == nil {
+			t.Error("expected error for non-existent package")
+		}
+	})
+
+	t.Run("errors when no database exists", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "README.md", "# Test", "Initial commit")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "urls", "lodash")
+		if err == nil {
+			t.Error("expected error without database")
+		}
+	})
+}


### PR DESCRIPTION
Show all known URLs for a package: registry page, download, documentation, and PURL.

Accepts either a PURL (`pkg:cargo/serde@1.0.0`) or a plain package name. When given a name, searches the database for a matching dependency and infers the ecosystem and version. Supports `--ecosystem` for disambiguation and `--format json` for machine-readable output.

```
$ git-pkgs urls pkg:cargo/serde@1.0.0
docs       https://docs.rs/serde/1.0.0
download   https://static.crates.io/crates/serde/serde-1.0.0.crate
purl       pkg:cargo/serde@1.0.0
registry   https://crates.io/crates/serde/1.0.0
```

Also bumps registries to v0.2.5 for `BuildURLs` support and adds an `IsPURL` helper for reuse by other commands.