### PR TITLE
Accept PURLs as package arguments in more commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ git pkgs vulns blame    # who introduced each vulnerability
 git pkgs outdated       # find packages with newer versions
 git pkgs update         # update all dependencies
 git pkgs add lodash     # add a package
+git pkgs why pkg:npm/lodash  # use a PURL instead of -e flag
 ```
 
 ## Commands
@@ -118,6 +119,7 @@ Gemfile (rubygems):
 ```bash
 git pkgs history                       # all dependency changes
 git pkgs history rails                 # changes for a specific package
+git pkgs history pkg:gem/rails         # same thing, using a PURL
 git pkgs history --author=alice        # filter by author
 git pkgs history --since=2024-01-01    # changes after date
 git pkgs history --ecosystem=rubygems  # filter by ecosystem
@@ -219,6 +221,7 @@ Manifest Files
 
 ```bash
 git pkgs why rails
+git pkgs why pkg:gem/rails
 ```
 
 This shows the commit that added the dependency along with the author and message.
@@ -266,9 +269,12 @@ git pkgs install --frozen     # CI mode (fail if lockfile would change)
 git pkgs add lodash           # add a package
 git pkgs add rails --dev      # add as dev dependency
 git pkgs add lodash 4.17.21   # add specific version
+git pkgs add pkg:npm/lodash@4.17.21  # same thing, using a PURL
 git pkgs remove lodash        # remove a package
+git pkgs remove pkg:npm/lodash       # remove using a PURL
 git pkgs update               # update all dependencies
 git pkgs update lodash        # update specific package
+git pkgs update pkg:npm/lodash       # update using a PURL
 git pkgs resolve              # print dependency graph
 ```
 
@@ -293,6 +299,7 @@ git pkgs browse lodash           # open in $EDITOR
 git pkgs browse lodash --path    # just print the path
 git pkgs browse lodash --open    # open in file browser
 git pkgs browse serde -m cargo   # specify manager
+git pkgs browse pkg:npm/lodash   # use a PURL
 ```
 
 Use `--path` for scripting:
@@ -337,6 +344,7 @@ git pkgs vulns exposure         # remediation metrics (CRA compliance)
 git pkgs vulns diff main feature # compare vulnerability state between refs
 git pkgs vulns log              # commits that introduced or fixed vulns
 git pkgs vulns history lodash   # vulnerability timeline for a package
+git pkgs vulns history pkg:npm/lodash  # same thing, using a PURL
 git pkgs vulns show CVE-2024-1234  # details about a specific CVE
 ```
 
@@ -416,6 +424,7 @@ Like `git show` but for dependencies. Shows what was added, modified, or removed
 
 ```bash
 git pkgs where rails           # find in manifest files
+git pkgs where pkg:gem/rails   # find using a PURL
 git pkgs where lodash -C 2     # show 2 lines of context
 git pkgs where express --ecosystem=npm
 ```
@@ -448,6 +457,8 @@ registry   https://crates.io/crates/serde/1.0.0
 ```
 
 When given a PURL, no database is needed. When given a plain package name, the database is searched for a matching dependency and the ecosystem is inferred. Use `--ecosystem` to disambiguate when a name appears in multiple ecosystems.
+
+Most commands that take a package name also accept PURLs. A PURL like `pkg:npm/lodash@4.17.21` replaces both the package name and `--ecosystem` flag. For example, `git pkgs why pkg:npm/lodash` is equivalent to `git pkgs why lodash -e npm`. Commands that accept PURLs: `why`, `history`, `where`, `browse`, `add`, `remove`, `update`, `urls`, and `vulns history`.
 
 ### Search dependencies
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -39,15 +39,21 @@ Examples:
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
-	pkg := args[0]
+	dev, _ := cmd.Flags().GetBool("dev")
+	managerOverride, _ := cmd.Flags().GetString("manager")
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+
+	ecosystem, pkg, purlVersion, err := ParsePackageArg(args[0], ecosystemFlag)
+	if err != nil {
+		return err
+	}
+
 	var version string
 	if len(args) > 1 {
 		version = args[1]
+	} else if purlVersion != "" {
+		version = purlVersion
 	}
-
-	dev, _ := cmd.Flags().GetBool("dev")
-	managerOverride, _ := cmd.Flags().GetString("manager")
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	quiet, _ := cmd.Flags().GetBool("quiet")
 	extra, _ := cmd.Flags().GetStringArray("extra")

--- a/cmd/browse.go
+++ b/cmd/browse.go
@@ -56,9 +56,13 @@ Examples:
 }
 
 func runBrowse(cmd *cobra.Command, args []string) error {
-	pkg := args[0]
 	managerOverride, _ := cmd.Flags().GetString("manager")
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+
+	ecosystem, pkg, _, err := ParsePackageArg(args[0], ecosystemFlag)
+	if err != nil {
+		return err
+	}
 	printPath, _ := cmd.Flags().GetBool("path")
 	openInBrowser, _ := cmd.Flags().GetBool("open")
 	timeout, _ := cmd.Flags().GetDuration("timeout")

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/purl"
 )
 
 func openDatabase() (*git.Repository, *database.DB, error) {
@@ -55,6 +56,20 @@ func isResolvedDependency(d database.Dependency) bool {
 
 func IsPURL(s string) bool {
 	return strings.HasPrefix(s, "pkg:")
+}
+
+func ParsePackageArg(arg, ecosystemFlag string) (ecosystem, name, version string, err error) {
+	if IsPURL(arg) {
+		p, err := purl.Parse(arg)
+		if err != nil {
+			return "", "", "", fmt.Errorf("parsing purl: %w", err)
+		}
+		ecosystem = purl.PURLTypeToEcosystem(p.Type)
+		name = p.FullName()
+		version = p.Version
+		return ecosystem, name, version, nil
+	}
+	return ecosystemFlag, arg, "", nil
 }
 
 func filterByEcosystem(deps []database.Dependency, ecosystem string) []database.Dependency {

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,0 +1,318 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/cmd"
+)
+
+func TestParsePackageArg(t *testing.T) {
+	t.Run("plain name passes through ecosystem flag", func(t *testing.T) {
+		eco, name, version, err := cmd.ParsePackageArg("lodash", "npm")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "npm" {
+			t.Errorf("ecosystem = %q, want %q", eco, "npm")
+		}
+		if name != "lodash" {
+			t.Errorf("name = %q, want %q", name, "lodash")
+		}
+		if version != "" {
+			t.Errorf("version = %q, want empty", version)
+		}
+	})
+
+	t.Run("plain name with empty ecosystem flag", func(t *testing.T) {
+		eco, name, version, err := cmd.ParsePackageArg("rails", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "" {
+			t.Errorf("ecosystem = %q, want empty", eco)
+		}
+		if name != "rails" {
+			t.Errorf("name = %q, want %q", name, "rails")
+		}
+		if version != "" {
+			t.Errorf("version = %q, want empty", version)
+		}
+	})
+
+	t.Run("PURL extracts ecosystem name and version", func(t *testing.T) {
+		eco, name, version, err := cmd.ParsePackageArg("pkg:cargo/serde@1.0.0", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "cargo" {
+			t.Errorf("ecosystem = %q, want %q", eco, "cargo")
+		}
+		if name != "serde" {
+			t.Errorf("name = %q, want %q", name, "serde")
+		}
+		if version != "1.0.0" {
+			t.Errorf("version = %q, want %q", version, "1.0.0")
+		}
+	})
+
+	t.Run("PURL without version", func(t *testing.T) {
+		eco, name, version, err := cmd.ParsePackageArg("pkg:npm/lodash", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "npm" {
+			t.Errorf("ecosystem = %q, want %q", eco, "npm")
+		}
+		if name != "lodash" {
+			t.Errorf("name = %q, want %q", name, "lodash")
+		}
+		if version != "" {
+			t.Errorf("version = %q, want empty", version)
+		}
+	})
+
+	t.Run("PURL with namespace", func(t *testing.T) {
+		eco, name, version, err := cmd.ParsePackageArg("pkg:npm/%40babel/core@7.24.0", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "npm" {
+			t.Errorf("ecosystem = %q, want %q", eco, "npm")
+		}
+		if name != "@babel/core" {
+			t.Errorf("name = %q, want %q", name, "@babel/core")
+		}
+		if version != "7.24.0" {
+			t.Errorf("version = %q, want %q", version, "7.24.0")
+		}
+	})
+
+	t.Run("PURL ignores ecosystem flag", func(t *testing.T) {
+		eco, name, _, err := cmd.ParsePackageArg("pkg:cargo/serde@1.0.0", "npm")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "cargo" {
+			t.Errorf("ecosystem = %q, want %q (flag should be ignored)", eco, "cargo")
+		}
+		if name != "serde" {
+			t.Errorf("name = %q, want %q", name, "serde")
+		}
+	})
+
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		_, _, _, err := cmd.ParsePackageArg("pkg:", "")
+		if err == nil {
+			t.Fatal("expected error for invalid PURL")
+		}
+		if !strings.Contains(err.Error(), "parsing purl") {
+			t.Errorf("error = %q, want it to contain 'parsing purl'", err.Error())
+		}
+	})
+
+	t.Run("gem PURL maps to rubygems ecosystem", func(t *testing.T) {
+		eco, name, _, err := cmd.ParsePackageArg("pkg:gem/rails@7.0.0", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "rubygems" {
+			t.Errorf("ecosystem = %q, want %q", eco, "rubygems")
+		}
+		if name != "rails" {
+			t.Errorf("name = %q, want %q", name, "rails")
+		}
+	})
+
+	t.Run("golang PURL with namespace", func(t *testing.T) {
+		eco, name, version, err := cmd.ParsePackageArg("pkg:golang/github.com/spf13/cobra@1.8.0", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if eco != "golang" {
+			t.Errorf("ecosystem = %q, want %q", eco, "golang")
+		}
+		if name != "github.com/spf13/cobra" {
+			t.Errorf("name = %q, want %q", name, "github.com/spf13/cobra")
+		}
+		if version != "1.8.0" {
+			t.Errorf("version = %q, want %q", version, "1.8.0")
+		}
+	})
+}
+
+func TestWhyAcceptsPURL(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	_, _, err := runCmd(t, "init")
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	t.Run("accepts PURL argument", func(t *testing.T) {
+		stdout, _, err := runCmd(t, "why", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("why with PURL failed: %v", err)
+		}
+		if !strings.Contains(stdout, "lodash") {
+			t.Errorf("expected 'lodash' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("PURL produces same result as ecosystem flag", func(t *testing.T) {
+		purlOut, _, err := runCmd(t, "why", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("why with PURL failed: %v", err)
+		}
+		flagOut, _, err := runCmd(t, "why", "lodash", "-e", "npm")
+		if err != nil {
+			t.Fatalf("why with flag failed: %v", err)
+		}
+		if purlOut != flagOut {
+			t.Errorf("PURL output differs from flag output.\nPURL: %s\nFlag: %s", purlOut, flagOut)
+		}
+	})
+
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		_, _, err := runCmd(t, "why", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}
+
+func TestHistoryAcceptsPURL(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	_, _, err := runCmd(t, "init")
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	t.Run("accepts PURL argument", func(t *testing.T) {
+		stdout, _, err := runCmd(t, "history", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("history with PURL failed: %v", err)
+		}
+		if !strings.Contains(stdout, "lodash") {
+			t.Errorf("expected 'lodash' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("PURL produces same result as ecosystem flag", func(t *testing.T) {
+		purlOut, _, err := runCmd(t, "history", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("history with PURL failed: %v", err)
+		}
+		flagOut, _, err := runCmd(t, "history", "lodash", "-e", "npm")
+		if err != nil {
+			t.Fatalf("history with flag failed: %v", err)
+		}
+		if purlOut != flagOut {
+			t.Errorf("PURL output differs from flag output.\nPURL: %s\nFlag: %s", purlOut, flagOut)
+		}
+	})
+
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		_, _, err := runCmd(t, "history", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}
+
+func TestWhereAcceptsPURL(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	t.Run("accepts PURL argument", func(t *testing.T) {
+		stdout, _, err := runCmd(t, "where", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("where with PURL failed: %v", err)
+		}
+		if !strings.Contains(stdout, "lodash") {
+			t.Errorf("expected 'lodash' in output, got: %s", stdout)
+		}
+	})
+
+	t.Run("PURL produces same result as ecosystem flag", func(t *testing.T) {
+		purlOut, _, err := runCmd(t, "where", "pkg:npm/lodash")
+		if err != nil {
+			t.Fatalf("where with PURL failed: %v", err)
+		}
+		flagOut, _, err := runCmd(t, "where", "lodash", "-e", "npm")
+		if err != nil {
+			t.Fatalf("where with flag failed: %v", err)
+		}
+		if purlOut != flagOut {
+			t.Errorf("PURL output differs from flag output.\nPURL: %s\nFlag: %s", purlOut, flagOut)
+		}
+	})
+
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		_, _, err := runCmd(t, "where", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}
+
+func TestAddAcceptsPURL(t *testing.T) {
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cleanup := chdir(t, tmpDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "add", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}
+
+func TestRemoveAcceptsPURL(t *testing.T) {
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cleanup := chdir(t, tmpDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "remove", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}
+
+func TestUpdateAcceptsPURL(t *testing.T) {
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cleanup := chdir(t, tmpDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "update", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}
+
+func TestBrowseAcceptsPURL(t *testing.T) {
+	t.Run("invalid PURL returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cleanup := chdir(t, tmpDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "browse", "pkg:")
+		if err == nil {
+			t.Error("expected error for invalid PURL")
+		}
+	})
+}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -29,12 +29,18 @@ Changes are shown in chronological order.`,
 }
 
 func runHistory(cmd *cobra.Command, args []string) error {
-	packageName := ""
-	if len(args) > 0 {
-		packageName = args[0]
-	}
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
 
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	var packageName, ecosystem string
+	if len(args) > 0 {
+		var err error
+		ecosystem, packageName, _, err = ParsePackageArg(args[0], ecosystemFlag)
+		if err != nil {
+			return err
+		}
+	} else {
+		ecosystem = ecosystemFlag
+	}
 	author, _ := cmd.Flags().GetString("author")
 	since, _ := cmd.Flags().GetString("since")
 	until, _ := cmd.Flags().GetString("until")

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -38,10 +38,13 @@ Examples:
 }
 
 func runRemove(cmd *cobra.Command, args []string) error {
-	pkg := args[0]
-
 	managerOverride, _ := cmd.Flags().GetString("manager")
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+
+	ecosystem, pkg, _, err := ParsePackageArg(args[0], ecosystemFlag)
+	if err != nil {
+		return err
+	}
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	quiet, _ := cmd.Flags().GetBool("quiet")
 	extra, _ := cmd.Flags().GetStringArray("extra")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -39,13 +39,19 @@ Examples:
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
-	var pkg string
-	if len(args) > 0 {
-		pkg = args[0]
-	}
-
 	managerOverride, _ := cmd.Flags().GetString("manager")
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+
+	var pkg, ecosystem string
+	if len(args) > 0 {
+		var err error
+		ecosystem, pkg, _, err = ParsePackageArg(args[0], ecosystemFlag)
+		if err != nil {
+			return err
+		}
+	} else {
+		ecosystem = ecosystemFlag
+	}
 	all, _ := cmd.Flags().GetBool("all")
 	dryRun, _ := cmd.Flags().GetBool("dry-run")
 	quiet, _ := cmd.Flags().GetBool("quiet")

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -1413,6 +1413,7 @@ Shows when the package was vulnerable and what vulnerabilities affected it.`,
 	}
 
 	historyCmd.Flags().StringP("branch", "b", "", "Branch to query (default: first tracked branch)")
+	historyCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
 	historyCmd.Flags().Int("limit", 50, "Maximum commits to check")
 	historyCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
 	parent.AddCommand(historyCmd)
@@ -1426,10 +1427,15 @@ type VulnHistoryEntry struct {
 }
 
 func runVulnsHistory(cmd *cobra.Command, args []string) error {
-	packageName := args[0]
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
 	branchName, _ := cmd.Flags().GetString("branch")
 	limit, _ := cmd.Flags().GetInt("limit")
 	format, _ := cmd.Flags().GetString("format")
+
+	ecosystem, packageName, _, err := ParsePackageArg(args[0], ecosystemFlag)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {
@@ -1464,6 +1470,9 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 		var pkgDep *database.Dependency
 		for _, d := range deps {
 			if !strings.EqualFold(d.Name, packageName) {
+				continue
+			}
+			if ecosystem != "" && !strings.EqualFold(d.Ecosystem, ecosystem) {
 				continue
 			}
 			if isResolvedDependency(d) {

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -41,8 +41,12 @@ type WhereMatch struct {
 }
 
 func runWhere(cmd *cobra.Command, args []string) error {
-	packageName := args[0]
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+
+	ecosystem, packageName, _, err := ParsePackageArg(args[0], ecosystemFlag)
+	if err != nil {
+		return err
+	}
 	context, _ := cmd.Flags().GetInt("context")
 	format, _ := cmd.Flags().GetString("format")
 	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")

--- a/cmd/why.go
+++ b/cmd/why.go
@@ -25,9 +25,13 @@ func addWhyCmd(parent *cobra.Command) {
 }
 
 func runWhy(cmd *cobra.Command, args []string) error {
-	packageName := args[0]
-	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
 	format, _ := cmd.Flags().GetString("format")
+
+	ecosystem, packageName, _, err := ParsePackageArg(args[0], ecosystemFlag)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {


### PR DESCRIPTION
Adds a shared ParsePackageArg helper and uses it in 8 commands so users can write `git pkgs why pkg:npm/lodash` instead of `git pkgs why lodash -e npm`.

When the argument starts with `pkg:`, the ecosystem and name are extracted from the PURL and the `--ecosystem` flag is ignored. Plain names work as before.

Commands updated: `why`, `history`, `where`, `browse`, `add`, `remove`, `update`, `vulns history`.

The `add` command also extracts the version from the PURL, so `git pkgs add pkg:npm/lodash@4.17.21` works like `git pkgs add lodash 4.17.21 -e npm`.

Also adds the missing `--ecosystem` flag to `vulns history`.

Closes #108