### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "git-pkgs",
+  "image": "mcr.microsoft.com/devcontainers/go:1-1.25-bookworm",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a devcontainer so the project works in GitHub Codespaces and with AI coding agents. Uses the official Go 1.25 devcontainer image.