### PR TITLE
Refuse removal of transitive dependencies

### DIFF
--- a/cmd/managers.go
+++ b/cmd/managers.go
@@ -452,7 +452,7 @@ func RunManagerCommand(ctx context.Context, dir, managerName, operation string, 
 	}
 
 	if result.ExitCode != 0 {
-		return fmt.Errorf("command failed with exit code %d", result.ExitCode)
+		return fmt.Errorf("command failed with exit code %d: %s", result.ExitCode, strings.TrimSpace(result.Stderr))
 	}
 
 	return nil
@@ -484,7 +484,7 @@ func RunManagerCommands(ctx context.Context, dir, managerName, operation string,
 		}
 
 		if result.ExitCode != 0 {
-			return fmt.Errorf("command failed with exit code %d", result.ExitCode)
+			return fmt.Errorf("command failed with exit code %d: %s", result.ExitCode, strings.TrimSpace(result.Stderr))
 		}
 	}
 

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"time"
 
 	"github.com/git-pkgs/managers"
+	"github.com/git-pkgs/resolve"
+	_ "github.com/git-pkgs/resolve/parsers"
 	"github.com/spf13/cobra"
 )
 
@@ -102,6 +105,11 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Check if the package is a transitive dependency before removing
+	if err := checkTransitiveDep(dir, mgr.Name, pkg); err != nil {
+		return err
+	}
+
 	if !quiet {
 		for _, c := range builtCmds {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Running: %v\n", c)
@@ -116,4 +124,63 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// checkTransitiveDep runs the manager's resolve command and checks whether pkg
+// is a direct or transitive dependency. Returns an error only when the package
+// is found exclusively as a transitive dep. If resolve isn't supported or fails,
+// the check is silently skipped so removal can proceed.
+func checkTransitiveDep(dir, managerName, pkg string) error {
+	resolveInput := managers.CommandInput{}
+	_, err := BuildCommands(managerName, "resolve", resolveInput)
+	if err != nil {
+		return nil // resolve not supported, skip check
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultResolveTimeout)
+	defer cancel()
+
+	var stdout bytes.Buffer
+	if err := RunManagerCommands(ctx, dir, managerName, "resolve", resolveInput, &stdout, &bytes.Buffer{}); err != nil {
+		return nil // resolve failed, skip check
+	}
+
+	result, err := resolve.Parse(managerName, stdout.Bytes())
+	if err != nil {
+		return nil // parse failed, skip check
+	}
+
+	isDirect, isTransitive := findDepInTree(result.Direct, pkg)
+	if !isDirect && isTransitive {
+		return fmt.Errorf("cannot remove %s: it is a transitive dependency -- remove the direct dependency that requires it instead", pkg)
+	}
+
+	return nil
+}
+
+// findDepInTree searches the dependency tree for a package by name.
+// Returns whether the package appears as a direct dependency and/or as a
+// transitive dependency (nested under any direct dep).
+func findDepInTree(direct []*resolve.Dep, name string) (isDirect bool, isTransitive bool) {
+	for _, dep := range direct {
+		if dep.Name == name {
+			isDirect = true
+		}
+		if hasTransitiveDep(dep.Deps, name) {
+			isTransitive = true
+		}
+	}
+	return isDirect, isTransitive
+}
+
+func hasTransitiveDep(deps []*resolve.Dep, name string) bool {
+	for _, dep := range deps {
+		if dep.Name == name {
+			return true
+		}
+		if hasTransitiveDep(dep.Deps, name) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/remove_internal_test.go
+++ b/cmd/remove_internal_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/git-pkgs/resolve"
+)
+
+func TestFindDepInTree(t *testing.T) {
+	tree := []*resolve.Dep{
+		{
+			Name:    "express",
+			Version: "4.18.2",
+			Deps: []*resolve.Dep{
+				{
+					Name:    "accepts",
+					Version: "1.3.8",
+					Deps: []*resolve.Dep{
+						{
+							Name:    "mime-types",
+							Version: "2.1.35",
+						},
+					},
+				},
+				{
+					Name:    "body-parser",
+					Version: "1.20.1",
+				},
+			},
+		},
+		{
+			Name:    "lodash",
+			Version: "4.17.21",
+		},
+	}
+
+	tests := []struct {
+		name            string
+		pkg             string
+		wantDirect      bool
+		wantTransitive  bool
+	}{
+		{
+			name:           "direct dep found",
+			pkg:            "express",
+			wantDirect:     true,
+			wantTransitive: false,
+		},
+		{
+			name:           "direct dep without children",
+			pkg:            "lodash",
+			wantDirect:     true,
+			wantTransitive: false,
+		},
+		{
+			name:           "transitive dep at depth 1",
+			pkg:            "accepts",
+			wantDirect:     false,
+			wantTransitive: true,
+		},
+		{
+			name:           "transitive dep at depth 2",
+			pkg:            "mime-types",
+			wantDirect:     false,
+			wantTransitive: true,
+		},
+		{
+			name:           "not found at all",
+			pkg:            "not-a-dep",
+			wantDirect:     false,
+			wantTransitive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isDirect, isTransitive := findDepInTree(tree, tt.pkg)
+			if isDirect != tt.wantDirect {
+				t.Errorf("isDirect = %v, want %v", isDirect, tt.wantDirect)
+			}
+			if isTransitive != tt.wantTransitive {
+				t.Errorf("isTransitive = %v, want %v", isTransitive, tt.wantTransitive)
+			}
+		})
+	}
+}
+
+func TestFindDepInTreeEmpty(t *testing.T) {
+	isDirect, isTransitive := findDepInTree(nil, "anything")
+	if isDirect {
+		t.Error("isDirect should be false for empty tree")
+	}
+	if isTransitive {
+		t.Error("isTransitive should be false for empty tree")
+	}
+}


### PR DESCRIPTION
Before running the package manager's remove command, resolve the dependency tree and check whether the target package is direct or transitive. If it only appears as a transitive dep, return a clear error telling the user to remove the direct dependency instead.

The check is skipped when `--dry-run` is set, when the manager doesn't support resolve, or when resolve fails for any reason.

Also includes stderr in `RunManagerCommand(s)` error messages so callers get the actual failure reason instead of just an exit code.

Closes #127