### PR TITLE
chore: speed up vuln sync

### DIFF
--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -15,6 +17,7 @@ import (
 	"github.com/git-pkgs/vers"
 	"github.com/git-pkgs/vulns"
 	"github.com/git-pkgs/vulns/osv"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -103,10 +106,11 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return syncVulnerabilitiesForDeps(db, lockfileDeps, force, quiet, cmd.OutOrStdout())
+	source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+	return syncVulnerabilitiesForDeps(db, source, lockfileDeps, force, quiet, cmd.OutOrStdout())
 }
 
-func syncVulnerabilitiesForDeps(db *database.DB, lockfileDeps []database.Dependency, force, quiet bool, w io.Writer) error {
+func syncVulnerabilitiesForDeps(db *database.DB, source vulns.Source, lockfileDeps []database.Dependency, force, quiet bool, w io.Writer) error {
 	if len(lockfileDeps) == 0 {
 		if !quiet {
 			_, _ = fmt.Fprintln(w, "No lockfile dependencies to sync.")
@@ -128,7 +132,6 @@ func syncVulnerabilitiesForDeps(db *database.DB, lockfileDeps []database.Depende
 		_, _ = fmt.Fprintf(w, "Syncing vulnerabilities for %d packages...\n", len(uniquePkgs))
 	}
 
-	source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -162,10 +165,58 @@ func syncVulnerabilitiesForDeps(db *database.DB, lockfileDeps []database.Depende
 		return fmt.Errorf("querying OSV: %w", err)
 	}
 
-	// Collect unique vuln IDs and fetch full details
+	// Collect unique vuln IDs across all batch results
+	uniqueVulnIDs := make(map[string]bool)
+	for _, batchVulns := range results {
+		for _, v := range batchVulns {
+			uniqueVulnIDs[v.ID] = true
+		}
+	}
+
+	// Fetch all unique vulnerability details concurrently
+	fetchedVulns := make(map[string]*vulns.Vulnerability)
+	var mu sync.Mutex
+
+	isTTY := false
+	if f, ok := w.(*os.File); ok {
+		isTTY = isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+	}
+
+	totalToFetch := len(uniqueVulnIDs)
+	var fetchCount int
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 20)
+
+	for id := range uniqueVulnIDs {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer func() { <-sem; wg.Done() }()
+
+			fullVuln, err := source.Get(ctx, id)
+
+			mu.Lock()
+			defer mu.Unlock()
+			fetchCount++
+			if err == nil && fullVuln != nil {
+				fetchedVulns[id] = fullVuln
+			}
+			if isTTY && !quiet {
+				_, _ = fmt.Fprintf(w, "\rFetching vulnerability details... %d/%d", fetchCount, totalToFetch)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if isTTY && !quiet && totalToFetch > 0 {
+		_, _ = fmt.Fprintf(w, "\r\033[K")
+	}
+
+	// Clear existing vulns and store results
+	now := time.Now().Format(time.RFC3339)
 	seenVulns := make(map[string]bool)
 	totalVulns := 0
-	now := time.Now().Format(time.RFC3339)
 
 	for i, batchVulns := range results {
 		key := queryKeys[i]
@@ -177,13 +228,29 @@ func syncVulnerabilitiesForDeps(db *database.DB, lockfileDeps []database.Depende
 
 		for _, v := range batchVulns {
 			if seenVulns[v.ID] {
+				// Still insert the package mapping for deduped vulns
+				fullVuln := fetchedVulns[v.ID]
+				if fullVuln == nil {
+					continue
+				}
+				fixedVersion := fullVuln.FixedVersion(key.ecosystem, key.name)
+				affectedVersions := buildVersRange(fullVuln, key.ecosystem, key.name)
+				vpRecord := database.VulnerabilityPackage{
+					VulnerabilityID:  fullVuln.ID,
+					Ecosystem:        key.ecosystem,
+					PackageName:      key.name,
+					AffectedVersions: affectedVersions,
+					FixedVersions:    fixedVersion,
+				}
+				if err := db.InsertVulnerabilityPackage(vpRecord); err != nil {
+					return fmt.Errorf("inserting vulnerability package: %w", err)
+				}
 				continue
 			}
 			seenVulns[v.ID] = true
 
-			// Fetch full vulnerability details
-			fullVuln, err := source.Get(ctx, v.ID)
-			if err != nil || fullVuln == nil {
+			fullVuln := fetchedVulns[v.ID]
+			if fullVuln == nil {
 				continue
 			}
 
@@ -341,7 +408,8 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 
 	// Auto-sync before cached scan (skip for --live and --no-sync)
 	if !live && !noSync && db != nil {
-		if err := syncVulnerabilitiesForDeps(db, lockfileDeps, false, false, cmd.OutOrStdout()); err != nil {
+		source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+		if err := syncVulnerabilitiesForDeps(db, source, lockfileDeps, false, false, cmd.OutOrStdout()); err != nil {
 			return fmt.Errorf("syncing vulnerabilities: %w", err)
 		}
 	}
@@ -587,11 +655,11 @@ type SARIFDriver struct {
 }
 
 type SARIFRule struct {
-	ID               string           `json:"id"`
-	ShortDescription SARIFMessage     `json:"shortDescription"`
-	FullDescription  SARIFMessage     `json:"fullDescription,omitempty"`
-	Help             SARIFMessage     `json:"help,omitempty"`
-	Properties       map[string]any   `json:"properties,omitempty"`
+	ID               string         `json:"id"`
+	ShortDescription SARIFMessage   `json:"shortDescription"`
+	FullDescription  SARIFMessage   `json:"fullDescription,omitempty"`
+	Help             SARIFMessage   `json:"help,omitempty"`
+	Properties       map[string]any `json:"properties,omitempty"`
 }
 
 type SARIFResult struct {
@@ -711,11 +779,11 @@ type VulnShowResult struct {
 }
 
 type VulnShowExposure struct {
-	Affected        bool     `json:"affected"`
-	AffectedPackage string   `json:"affected_package,omitempty"`
-	CurrentVersion  string   `json:"current_version,omitempty"`
-	FixedVersion    string   `json:"fixed_version,omitempty"`
-	Commit          string   `json:"commit,omitempty"`
+	Affected        bool   `json:"affected"`
+	AffectedPackage string `json:"affected_package,omitempty"`
+	CurrentVersion  string `json:"current_version,omitempty"`
+	FixedVersion    string `json:"fixed_version,omitempty"`
+	Commit          string `json:"commit,omitempty"`
 }
 
 func runVulnsShow(cmd *cobra.Command, args []string) error {
@@ -915,8 +983,8 @@ Defaults to comparing HEAD~1 with HEAD.`,
 }
 
 type VulnsDiffResult struct {
-	Added   []VulnResult `json:"added"`
-	Fixed   []VulnResult `json:"fixed"`
+	Added []VulnResult `json:"added"`
+	Fixed []VulnResult `json:"fixed"`
 }
 
 func runVulnsDiff(cmd *cobra.Command, args []string) error {
@@ -1264,12 +1332,12 @@ Shows a timeline of how vulnerabilities have changed over time.`,
 }
 
 type VulnLogEntry struct {
-	SHA         string       `json:"sha"`
-	Message     string       `json:"message"`
-	Author      string       `json:"author"`
-	Date        string       `json:"date"`
-	Introduced  []VulnResult `json:"introduced,omitempty"`
-	Fixed       []VulnResult `json:"fixed,omitempty"`
+	SHA        string       `json:"sha"`
+	Message    string       `json:"message"`
+	Author     string       `json:"author"`
+	Date       string       `json:"date"`
+	Introduced []VulnResult `json:"introduced,omitempty"`
+	Fixed      []VulnResult `json:"fixed,omitempty"`
 }
 
 func runVulnsLog(cmd *cobra.Command, args []string) error {
@@ -1312,7 +1380,6 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No commits with dependency changes found.")
 		return nil
 	}
-
 
 	minSeverity := 4
 	if severity != "" {
@@ -1836,7 +1903,6 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-
 	minSeverity := 4
 	if severity != "" {
 		if order, ok := severityOrder[strings.ToLower(severity)]; ok {
@@ -1934,10 +2000,10 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 }
 
 type PraiseAuthorSummary struct {
-	Author        string         `json:"author"`
-	TotalFixes    int            `json:"total_fixes"`
-	BySeverity    map[string]int `json:"by_severity"`
-	UniquePackages int           `json:"unique_packages"`
+	Author         string         `json:"author"`
+	TotalFixes     int            `json:"total_fixes"`
+	BySeverity     map[string]int `json:"by_severity"`
+	UniquePackages int            `json:"unique_packages"`
 }
 
 type PraiseSummary struct {

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -1,10 +1,207 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/vulns"
 )
+
+// mockSource implements vulns.Source for testing.
+type mockSource struct {
+	vulns    map[string]*vulns.Vulnerability // ID -> full vuln
+	batchRes [][]vulns.Vulnerability         // QueryBatch results
+	getCalls atomic.Int64
+}
+
+func (m *mockSource) Name() string { return "mock" }
+
+func (m *mockSource) Query(_ context.Context, _ *purl.PURL) ([]vulns.Vulnerability, error) {
+	return nil, nil
+}
+
+func (m *mockSource) QueryBatch(_ context.Context, _ []*purl.PURL) ([][]vulns.Vulnerability, error) {
+	return m.batchRes, nil
+}
+
+func (m *mockSource) Get(_ context.Context, id string) (*vulns.Vulnerability, error) {
+	m.getCalls.Add(1)
+	if v, ok := m.vulns[id]; ok {
+		return v, nil
+	}
+	return nil, fmt.Errorf("not found: %s", id)
+}
+
+func newTestDB(t *testing.T) *database.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestSyncVulnerabilitiesForDeps(t *testing.T) {
+	now := time.Now()
+
+	vuln1 := &vulns.Vulnerability{
+		ID:        "GHSA-0001",
+		Summary:   "Test vuln 1",
+		Published: now,
+		Modified:  now,
+		Affected: []vulns.Affected{{
+			Package: vulns.Package{Ecosystem: "npm", Name: "foo"},
+			Ranges: []vulns.Range{{
+				Type:   "ECOSYSTEM",
+				Events: []vulns.Event{{Introduced: "0"}, {Fixed: "1.2.0"}},
+			}},
+		}},
+	}
+	vuln2 := &vulns.Vulnerability{
+		ID:        "GHSA-0002",
+		Summary:   "Test vuln 2",
+		Published: now,
+		Modified:  now,
+		Affected: []vulns.Affected{{
+			Package: vulns.Package{Ecosystem: "npm", Name: "bar"},
+			Ranges: []vulns.Range{{
+				Type:   "ECOSYSTEM",
+				Events: []vulns.Event{{Introduced: "1.0.0"}, {Fixed: "2.0.0"}},
+			}},
+		}},
+	}
+
+	// vuln3 affects both foo and bar (shared vuln)
+	vuln3 := &vulns.Vulnerability{
+		ID:        "GHSA-0003",
+		Summary:   "Shared vuln",
+		Published: now,
+		Modified:  now,
+		Affected: []vulns.Affected{
+			{
+				Package: vulns.Package{Ecosystem: "npm", Name: "foo"},
+				Ranges: []vulns.Range{{
+					Type:   "ECOSYSTEM",
+					Events: []vulns.Event{{Introduced: "0"}, {Fixed: "3.0.0"}},
+				}},
+			},
+			{
+				Package: vulns.Package{Ecosystem: "npm", Name: "bar"},
+				Ranges: []vulns.Range{{
+					Type:   "ECOSYSTEM",
+					Events: []vulns.Event{{Introduced: "0"}, {Fixed: "3.0.0"}},
+				}},
+			},
+		},
+	}
+
+	source := &mockSource{
+		vulns: map[string]*vulns.Vulnerability{
+			"GHSA-0001": vuln1,
+			"GHSA-0002": vuln2,
+			"GHSA-0003": vuln3,
+		},
+		// batch results: foo has vuln1+vuln3, bar has vuln2+vuln3
+		batchRes: [][]vulns.Vulnerability{
+			{{ID: "GHSA-0001"}, {ID: "GHSA-0003"}},
+			{{ID: "GHSA-0002"}, {ID: "GHSA-0003"}},
+		},
+	}
+
+	deps := []database.Dependency{
+		{Ecosystem: "npm", Name: "foo", Requirement: "1.0.0", ManifestPath: "package-lock.json", ManifestKind: "lockfile"},
+		{Ecosystem: "npm", Name: "bar", Requirement: "1.5.0", ManifestPath: "package-lock.json", ManifestKind: "lockfile"},
+	}
+
+	db := newTestDB(t)
+	var buf bytes.Buffer
+
+	err := syncVulnerabilitiesForDeps(db, source, deps, true, false, &buf)
+	if err != nil {
+		t.Fatalf("syncVulnerabilitiesForDeps() error = %v", err)
+	}
+
+	// Shared vuln GHSA-0003 should only be fetched once (3 unique IDs = 3 Get calls)
+	if got := source.getCalls.Load(); got != 3 {
+		t.Errorf("expected 3 Get calls (one per unique vuln), got %d", got)
+	}
+
+	// Verify vulns were stored for foo
+	fooVulns, err := db.GetVulnerabilitiesForPackage("npm", "foo")
+	if err != nil {
+		t.Fatalf("GetVulnerabilitiesForPackage(foo) error = %v", err)
+	}
+	if len(fooVulns) != 2 {
+		t.Errorf("expected 2 vulns for foo, got %d", len(fooVulns))
+	}
+
+	// Verify vulns were stored for bar
+	barVulns, err := db.GetVulnerabilitiesForPackage("npm", "bar")
+	if err != nil {
+		t.Fatalf("GetVulnerabilitiesForPackage(bar) error = %v", err)
+	}
+	if len(barVulns) != 2 {
+		t.Errorf("expected 2 vulns for bar, got %d", len(barVulns))
+	}
+
+	// Verify output mentions both packages
+	output := buf.String()
+	if !strings.Contains(output, "Syncing vulnerabilities for 2 packages") {
+		t.Errorf("expected sync message in output, got: %s", output)
+	}
+	if !strings.Contains(output, "Synced 3 vulnerabilities for 2 packages") {
+		t.Errorf("expected summary message in output, got: %s", output)
+	}
+}
+
+func TestSyncVulnerabilitiesForDeps_NoDeps(t *testing.T) {
+	db := newTestDB(t)
+	var buf bytes.Buffer
+
+	source := &mockSource{}
+	err := syncVulnerabilitiesForDeps(db, source, nil, true, false, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "No lockfile dependencies to sync.") {
+		t.Errorf("expected no-deps message, got: %s", buf.String())
+	}
+}
+
+func TestSyncVulnerabilitiesForDeps_QuietMode(t *testing.T) {
+	now := time.Now()
+	source := &mockSource{
+		vulns: map[string]*vulns.Vulnerability{
+			"GHSA-0001": {ID: "GHSA-0001", Summary: "Test", Published: now, Modified: now},
+		},
+		batchRes: [][]vulns.Vulnerability{{{ID: "GHSA-0001"}}},
+	}
+
+	deps := []database.Dependency{
+		{Ecosystem: "npm", Name: "foo", Requirement: "1.0.0", ManifestPath: "package-lock.json", ManifestKind: "lockfile"},
+	}
+
+	db := newTestDB(t)
+	var buf bytes.Buffer
+
+	err := syncVulnerabilitiesForDeps(db, source, deps, true, true, &buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output in quiet mode, got: %s", buf.String())
+	}
+}
 
 func TestBuildVersRange(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
With the added automatic sync behavior introduced in #132, we can now experience the latency when the vulnerability data isn't cached.

This refactor does a few things:

- Add test coverage for `syncVulnerabilitiesForDeps` by extending the signature to accept an injected `source` database instead of having to instantiate inline
- Batch-collection of vulnerabilities in groups of 20 to speed up total execution time for large volumes of dependencies
- Console progress updater while downloading so the user gets some visual feedback