### PR TITLE
Update install instructions for homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ The core commands (`list`, `history`, `blame`, `diff`, `stale`, etc.) work entir
 ## Installation
 
 ```bash
-brew tap git-pkgs/git-pkgs
 brew install git-pkgs
 ```
 


### PR DESCRIPTION
git-pkgs is now in homebrew-core (https://github.com/Homebrew/homebrew-core/pull/270236), so the tap is no longer needed.