### PR TITLE
Enable gofmt formatter in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+
+formatters:
+  enable:
+    - gofmt

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -110,12 +110,12 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 // diffBetweenCommits compares dependencies between two commits using on-demand indexing.
 func diffBetweenCommits(repo *git.Repository, fromRef, toRef string) (*DiffResult, error) {
-	fromDeps, err := repo.GetDependencies( fromRef, "")
+	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
 	}
 
-	toDeps, err := repo.GetDependencies( toRef, "")
+	toDeps, err := repo.GetDependencies(toRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", toRef, err)
 	}

--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/git-pkgs/manifests"
 	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/manifests"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
 	"github.com/spf13/cobra"

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -57,7 +57,6 @@ type LicenseInfo struct {
 	FlagReason   string   `json:"flag_reason,omitempty"`
 }
 
-
 func runLicenses(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")

--- a/cmd/managers.go
+++ b/cmd/managers.go
@@ -47,8 +47,8 @@ type lockfileMapping struct {
 type ecosystemConfig struct {
 	Ecosystem string
 	Manifest  string
-	Default   string              // default manager when only manifest exists
-	Lockfiles []lockfileMapping   // in priority order (first match wins)
+	Default   string            // default manager when only manifest exists
+	Lockfiles []lockfileMapping // in priority order (first match wins)
 }
 
 // ecosystems defines detection rules organized by ecosystem/purl type.
@@ -164,7 +164,7 @@ var ecosystemConfigs = []ecosystemConfig{
 	},
 	{
 		Ecosystem: "hackage",
-		Manifest:  "",  // uses suffix match *.cabal
+		Manifest:  "", // uses suffix match *.cabal
 		Default:   "cabal",
 		Lockfiles: []lockfileMapping{
 			{"cabal.project.freeze", "cabal"},

--- a/cmd/managers_test.go
+++ b/cmd/managers_test.go
@@ -139,7 +139,7 @@ func TestDetectManagers(t *testing.T) {
 		{
 			name: "nuget from packages.lock.json",
 			files: map[string]string{
-				"packages.config":   "<packages></packages>",
+				"packages.config":    "<packages></packages>",
 				"packages.lock.json": "{}",
 			},
 			expected: []string{"nuget"},

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/vers"

--- a/cmd/remove_internal_test.go
+++ b/cmd/remove_internal_test.go
@@ -35,10 +35,10 @@ func TestFindDepInTree(t *testing.T) {
 	}
 
 	tests := []struct {
-		name            string
-		pkg             string
-		wantDirect      bool
-		wantTransitive  bool
+		name           string
+		pkg            string
+		wantDirect     bool
+		wantTransitive bool
 	}{
 		{
 			name:           "direct dep found",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,10 +47,10 @@ func Execute() error {
 
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:              "git-pkgs",
-		Version:          versionStr,
-		Short:            shortDesc,
-		Long:             longDesc,
+		Use:               "git-pkgs",
+		Version:           versionStr,
+		Short:             shortDesc,
+		Long:              longDesc,
 		SilenceUsage:      true,
 		PersistentPreRun:  preRun,
 		PersistentPostRun: postRun,

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
 	"github.com/spf13/cobra"
@@ -36,15 +36,15 @@ The SBOM includes all dependencies and optionally enriched license information.`
 
 // CycloneDX BOM structure
 type CycloneDXBOM struct {
-	XMLName      xml.Name                  `xml:"bom" json:"-"`
-	XMLNS        string                    `xml:"xmlns,attr" json:"-"`
-	Version      int                       `xml:"version,attr" json:"version"`
-	BOMFormat    string                    `xml:"-" json:"bomFormat"`
-	SpecVersion  string                    `xml:"-" json:"specVersion"`
-	SerialNumber string                    `xml:"serialNumber,attr,omitempty" json:"serialNumber,omitempty"`
-	Metadata     *CycloneDXMetadata        `xml:"metadata,omitempty" json:"metadata,omitempty"`
-	Components   []CycloneDXComponent      `xml:"components>component" json:"components"`
-	Dependencies []CycloneDXDependency     `xml:"dependencies>dependency,omitempty" json:"dependencies,omitempty"`
+	XMLName      xml.Name              `xml:"bom" json:"-"`
+	XMLNS        string                `xml:"xmlns,attr" json:"-"`
+	Version      int                   `xml:"version,attr" json:"version"`
+	BOMFormat    string                `xml:"-" json:"bomFormat"`
+	SpecVersion  string                `xml:"-" json:"specVersion"`
+	SerialNumber string                `xml:"serialNumber,attr,omitempty" json:"serialNumber,omitempty"`
+	Metadata     *CycloneDXMetadata    `xml:"metadata,omitempty" json:"metadata,omitempty"`
+	Components   []CycloneDXComponent  `xml:"components>component" json:"components"`
+	Dependencies []CycloneDXDependency `xml:"dependencies>dependency,omitempty" json:"dependencies,omitempty"`
 }
 
 type CycloneDXMetadata struct {
@@ -81,13 +81,13 @@ type CycloneDXDependency struct {
 
 // SPDX structure
 type SPDXSBOM struct {
-	SPDXVersion       string            `json:"spdxVersion"`
-	DataLicense       string            `json:"dataLicense"`
-	SPDXID            string            `json:"SPDXID"`
-	Name              string            `json:"name"`
-	DocumentNamespace string            `json:"documentNamespace"`
-	CreationInfo      SPDXCreationInfo  `json:"creationInfo"`
-	Packages          []SPDXPackage     `json:"packages"`
+	SPDXVersion       string             `json:"spdxVersion"`
+	DataLicense       string             `json:"dataLicense"`
+	SPDXID            string             `json:"SPDXID"`
+	Name              string             `json:"name"`
+	DocumentNamespace string             `json:"documentNamespace"`
+	CreationInfo      SPDXCreationInfo   `json:"creationInfo"`
+	Packages          []SPDXPackage      `json:"packages"`
 	Relationships     []SPDXRelationship `json:"relationships,omitempty"`
 }
 
@@ -97,12 +97,12 @@ type SPDXCreationInfo struct {
 }
 
 type SPDXPackage struct {
-	SPDXID           string `json:"SPDXID"`
-	Name             string `json:"name"`
-	VersionInfo      string `json:"versionInfo,omitempty"`
-	DownloadLocation string `json:"downloadLocation"`
-	LicenseConcluded string `json:"licenseConcluded,omitempty"`
-	LicenseDeclared  string `json:"licenseDeclared,omitempty"`
+	SPDXID           string            `json:"SPDXID"`
+	Name             string            `json:"name"`
+	VersionInfo      string            `json:"versionInfo,omitempty"`
+	DownloadLocation string            `json:"downloadLocation"`
+	LicenseConcluded string            `json:"licenseConcluded,omitempty"`
+	LicenseDeclared  string            `json:"licenseDeclared,omitempty"`
 	ExternalRefs     []SPDXExternalRef `json:"externalRefs,omitempty"`
 }
 

--- a/internal/bisect/state.go
+++ b/internal/bisect/state.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	stateFile     = "PKGS_BISECT_STATE"
-	logFile       = "PKGS_BISECT_LOG"
+	stateFile      = "PKGS_BISECT_STATE"
+	logFile        = "PKGS_BISECT_LOG"
 	candidatesFile = "PKGS_BISECT_CANDIDATES"
 )
 

--- a/internal/bisect/state_test.go
+++ b/internal/bisect/state_test.go
@@ -203,13 +203,13 @@ func TestManager_IsGood(t *testing.T) {
 		sha      string
 		expected bool
 	}{
-		{"abc123def456", true},           // exact match
-		{"abc123", true},                 // prefix match
-		{"abc123def456789", true},        // sha is prefix of good rev
-		{"111222333444", true},           // exact match second rev
-		{"111222", true},                 // prefix match second rev
-		{"bad123", false},                // not in list
-		{"abc124", false},                // similar but different
+		{"abc123def456", true},    // exact match
+		{"abc123", true},          // prefix match
+		{"abc123def456789", true}, // sha is prefix of good rev
+		{"111222333444", true},    // exact match second rev
+		{"111222", true},          // prefix match second rev
+		{"bad123", false},         // not in list
+		{"abc124", false},         // similar but different
 	}
 
 	for _, tc := range tests {
@@ -231,11 +231,11 @@ func TestManager_IsBad(t *testing.T) {
 		sha      string
 		expected bool
 	}{
-		{"bad123def456", true},           // exact match
-		{"bad123", true},                 // prefix match
-		{"bad123def456789", true},        // sha is prefix of bad rev
-		{"good123", false},               // different
-		{"bad124", false},                // similar but different
+		{"bad123def456", true},    // exact match
+		{"bad123", true},          // prefix match
+		{"bad123def456789", true}, // sha is prefix of bad rev
+		{"good123", false},        // different
+		{"bad124", false},         // similar but different
 	}
 
 	for _, tc := range tests {
@@ -259,7 +259,7 @@ func TestManager_IsSkipped(t *testing.T) {
 	}{
 		{"skip123", true},
 		{"skip456", true},
-		{"skip12", true},   // prefix
+		{"skip12", true}, // prefix
 		{"other123", false},
 	}
 

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -584,11 +584,11 @@ type NameCount struct {
 }
 
 type AuthorStats struct {
-	Name     string         `json:"name"`
-	Email    string         `json:"email"`
-	Commits  int            `json:"commits"`
-	Changes  int            `json:"changes"`
-	ByType   map[string]int `json:"by_type"`
+	Name    string         `json:"name"`
+	Email   string         `json:"email"`
+	Commits int            `json:"commits"`
+	Changes int            `json:"changes"`
+	ByType  map[string]int `json:"by_type"`
 }
 
 type StatsOptions struct {
@@ -2421,4 +2421,3 @@ func (db *DB) StoreSnapshot(branchID int64, commit CommitInfo, snapshots []Snaps
 
 	return tx.Commit()
 }
-

--- a/internal/database/writer.go
+++ b/internal/database/writer.go
@@ -41,15 +41,15 @@ type SnapshotInfo struct {
 }
 
 type Writer struct {
-	db              *DB
-	branchID        int64
-	commitStmt      *sql.Stmt
+	db               *DB
+	branchID         int64
+	commitStmt       *sql.Stmt
 	branchCommitStmt *sql.Stmt
-	manifestStmt    *sql.Stmt
-	changeStmt      *sql.Stmt
-	snapshotStmt    *sql.Stmt
-	manifestCache   map[string]int64
-	position        int
+	manifestStmt     *sql.Stmt
+	changeStmt       *sql.Stmt
+	snapshotStmt     *sql.Stmt
+	manifestCache    map[string]int64
+	position         int
 }
 
 func NewWriter(db *DB) (*Writer, error) {
@@ -111,13 +111,13 @@ func NewWriter(db *DB) (*Writer, error) {
 	}
 
 	return &Writer{
-		db:              db,
-		commitStmt:      commitStmt,
+		db:               db,
+		commitStmt:       commitStmt,
 		branchCommitStmt: branchCommitStmt,
-		manifestStmt:    manifestStmt,
-		changeStmt:      changeStmt,
-		snapshotStmt:    snapshotStmt,
-		manifestCache:   make(map[string]int64),
+		manifestStmt:     manifestStmt,
+		changeStmt:       changeStmt,
+		snapshotStmt:     snapshotStmt,
+		manifestCache:    make(map[string]int64),
 	}, nil
 }
 

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -507,18 +507,18 @@ func TestNpmMultipleVersionsSurviveModifiedLockfile(t *testing.T) {
 	// in a single lockfile (nested node_modules). Verify these survive
 	// when the lockfile is modified across a merge commit.
 	lock1 := samplePackageLockJSON(map[string]string{
-		"isexe":                      "3.1.1",
+		"isexe":                       "3.1.1",
 		"some-pkg/node_modules/isexe": "2.0.0",
-		"lodash":                     "4.17.21",
+		"lodash":                      "4.17.21",
 	})
 	addFileAndCommit(t, repoDir, "package-lock.json", lock1, "Add lockfile")
 
 	// Feature branch: update lodash
 	gitRun(t, repoDir, "checkout", "-b", "feature")
 	lock2 := samplePackageLockJSON(map[string]string{
-		"isexe":                      "3.1.1",
+		"isexe":                       "3.1.1",
 		"some-pkg/node_modules/isexe": "2.0.0",
-		"lodash":                     "4.17.22",
+		"lodash":                      "4.17.22",
 	})
 	addFileAndCommit(t, repoDir, "package-lock.json", lock2, "Update lodash")
 
@@ -528,9 +528,9 @@ func TestNpmMultipleVersionsSurviveModifiedLockfile(t *testing.T) {
 
 	// Another change on main
 	lock3 := samplePackageLockJSON(map[string]string{
-		"isexe":                      "3.1.1",
+		"isexe":                       "3.1.1",
 		"some-pkg/node_modules/isexe": "2.0.0",
-		"lodash":                     "4.17.23",
+		"lodash":                      "4.17.23",
 	})
 	addFileAndCommit(t, repoDir, "package-lock.json", lock3, "Update lodash again")
 


### PR DESCRIPTION
Add .golangci.yml with the gofmt formatter enabled and apply formatting fixes across the codebase. The existing `golangci-lint run` CI step picks up formatters from config, so no workflow changes needed.

Closes #143