### PR TITLE
Skip browse editor test when yarn is not installed

### DIFF
--- a/cmd/browse_test.go
+++ b/cmd/browse_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -178,6 +179,10 @@ func TestBrowsePathNotSupported(t *testing.T) {
 }
 
 func TestBrowseNoEditor(t *testing.T) {
+	if _, err := exec.LookPath("yarn"); err != nil {
+		t.Skip("yarn not installed")
+	}
+
 	tmpDir := t.TempDir()
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "package-lock.json"), []byte("{}"), 0644); err != nil {
@@ -198,7 +203,7 @@ func TestBrowseNoEditor(t *testing.T) {
 	t.Setenv("VISUAL", "")
 
 	rootCmd := cmd.NewRootCmd()
-	rootCmd.SetArgs([]string{"browse", "lodash", "-m", "yarn"}) // yarn uses template, no CLI needed
+	rootCmd.SetArgs([]string{"browse", "lodash", "-m", "yarn"})
 
 	var stdout bytes.Buffer
 	rootCmd.SetOut(&stdout)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/git-pkgs/changelog v0.1.1
 	github.com/git-pkgs/enrichment v0.1.5
 	github.com/git-pkgs/gitignore v1.1.0
-	github.com/git-pkgs/managers v0.7.0
+	github.com/git-pkgs/managers v0.8.0
 	github.com/git-pkgs/manifests v0.4.0
 	github.com/git-pkgs/purl v0.1.8
 	github.com/git-pkgs/registries v0.2.6

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/git-pkgs/gitignore v1.1.0 h1:oEFBmITV1H6TsmcguHCSpgJP0iGe+TgaSZ/p6H10
 github.com/git-pkgs/gitignore v1.1.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/managers v0.7.0 h1:Ga6LShs9ba+TaEAxiFZZA+rOY/AcplCh3piWYbgK5A0=
 github.com/git-pkgs/managers v0.7.0/go.mod h1:8DR7tIQEEyPyJ7QGzStVbovnGl7tAJcrhQLzjQPzFzc=
+github.com/git-pkgs/managers v0.8.0 h1:BrSA5gWGKASptnn5/e0ZhjKjFp+z1FXtEq4OvROg/I8=
+github.com/git-pkgs/managers v0.8.0/go.mod h1:8DR7tIQEEyPyJ7QGzStVbovnGl7tAJcrhQLzjQPzFzc=
 github.com/git-pkgs/manifests v0.4.0 h1:S6yz1N2AV5DzCVzMIniC8PdX4Mh7zGbcVc+9kkUaHeY=
 github.com/git-pkgs/manifests v0.4.0/go.mod h1:7SPFwU9diUG1Az682/p4ZupHJkfpbWKwRvNPwCcOeVs=
 github.com/git-pkgs/packageurl-go v0.2.1 h1:j6VnjJiYS9b1nTLfJGsG6SLaA7Nk6Io+ta8grOyTa4o=


### PR DESCRIPTION
The test depends on yarn being available to run the path lookup. CI runners have yarn pre-installed so it passed there, but it fails in environments without yarn. Skip instead of failing.

Also bumps managers to v0.8.0 which respects RequireCLI for explicit manager selection (git-pkgs/managers#10).