### PR TITLE
Bump packageurl-go to v0.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
-	github.com/git-pkgs/packageurl-go v0.2.1 // indirect
+	github.com/git-pkgs/packageurl-go v0.3.1 // indirect
 	github.com/github/go-spdx/v2 v2.4.0 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/git-pkgs/managers v0.8.0 h1:BrSA5gWGKASptnn5/e0ZhjKjFp+z1FXtEq4OvROg/
 github.com/git-pkgs/managers v0.8.0/go.mod h1:8DR7tIQEEyPyJ7QGzStVbovnGl7tAJcrhQLzjQPzFzc=
 github.com/git-pkgs/manifests v0.4.1 h1:CWml+TrRXVzrfNJ2pTNKLqyi+9y/BFiQP/BX3pL4pPQ=
 github.com/git-pkgs/manifests v0.4.1/go.mod h1:7SPFwU9diUG1Az682/p4ZupHJkfpbWKwRvNPwCcOeVs=
-github.com/git-pkgs/packageurl-go v0.2.1 h1:j6VnjJiYS9b1nTLfJGsG6SLaA7Nk6Io+ta8grOyTa4o=
-github.com/git-pkgs/packageurl-go v0.2.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
+github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
+github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/purl v0.1.8 h1:iyjEHM2WIZUL9A3+q9ylrabqILsN4nOay9X6jfEjmzQ=
 github.com/git-pkgs/purl v0.1.8/go.mod h1:ihlHw3bnSLXat+9Nl9MsJZBYiG7s3NkwmvE3L/Es/sI=
 github.com/git-pkgs/registries v0.2.6 h1:hXPQ47mOzrgtZleOimydwpQjj/NJkU9P/4sTa0n6wTI=


### PR DESCRIPTION
Picks up the fork's corrected module path and the v0.3.0 changes: improved percent-encoding, lexicographic qualifier sorting, new purl types (otp, vscode-extension, yocto), and 3-30x faster parsing/serialization.