### PR TITLE
Fix UNIQUE constraint failure when branches share commits

### DIFF
--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -199,33 +199,59 @@ func (w *BatchWriter) flushPending(commits []pendingCommit, changes []pendingCha
 
 	now := time.Now()
 
-	// 1. Batch insert commits
+	// 1. Find commits that already exist so we can skip re-inserting their data
+	existingCommits, err := w.getCommitIDs(tx, commits)
+	if err != nil {
+		return fmt.Errorf("getting existing commit IDs: %w", err)
+	}
+
+	// 2. Batch insert commits (OR IGNORE skips existing ones)
 	if err := w.insertCommits(tx, now, commits); err != nil {
 		return fmt.Errorf("inserting commits: %w", err)
 	}
 
-	// 2. Get commit IDs by SHA
+	// 3. Get commit IDs by SHA (now includes newly inserted ones)
 	commitIDs, err := w.getCommitIDs(tx, commits)
 	if err != nil {
 		return fmt.Errorf("getting commit IDs: %w", err)
 	}
 
-	// 3. Batch insert branch_commits
+	// 4. Batch insert branch_commits
 	if err := w.insertBranchCommits(tx, commitIDs, commits); err != nil {
 		return fmt.Errorf("inserting branch commits: %w", err)
 	}
 
-	// 4. Ensure manifests exist and get their IDs
+	// 5. Filter out changes and snapshots for commits that already existed,
+	// since their data is already stored from another branch.
+	if len(existingCommits) > 0 {
+		newChanges := changes[:0]
+		for _, c := range changes {
+			if _, exists := existingCommits[c.sha]; !exists {
+				newChanges = append(newChanges, c)
+			}
+		}
+		changes = newChanges
+
+		newSnapshots := snapshots[:0]
+		for _, s := range snapshots {
+			if _, exists := existingCommits[s.sha]; !exists {
+				newSnapshots = append(newSnapshots, s)
+			}
+		}
+		snapshots = newSnapshots
+	}
+
+	// 6. Ensure manifests exist and get their IDs
 	if err := w.ensureManifests(tx, now, changes, snapshots); err != nil {
 		return fmt.Errorf("ensuring manifests: %w", err)
 	}
 
-	// 5. Batch insert changes
+	// 7. Batch insert changes
 	if err := w.insertChanges(tx, commitIDs, now, changes); err != nil {
 		return fmt.Errorf("inserting changes: %w", err)
 	}
 
-	// 6. Batch insert snapshots
+	// 8. Batch insert snapshots
 	if err := w.insertSnapshots(tx, commitIDs, now, snapshots); err != nil {
 		return fmt.Errorf("inserting snapshots: %w", err)
 	}
@@ -253,7 +279,7 @@ func (w *BatchWriter) insertCommits(tx *sql.Tx, now time.Time, pending []pending
 		batch := pending[start:end]
 
 		var sb strings.Builder
-		sb.WriteString("INSERT INTO commits (sha, message, author_name, author_email, committed_at, has_dependency_changes, created_at, updated_at) VALUES ")
+		sb.WriteString("INSERT OR IGNORE INTO commits (sha, message, author_name, author_email, committed_at, has_dependency_changes, created_at, updated_at) VALUES ")
 
 		args := make([]any, 0, len(batch)*columnsPerRow)
 		for i, pc := range batch {
@@ -490,7 +516,7 @@ func (w *BatchWriter) insertSnapshots(tx *sql.Tx, commitIDs map[string]int64, no
 		batch := pending[start:end]
 
 		var sb strings.Builder
-		sb.WriteString("INSERT INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, created_at, updated_at) VALUES ")
+		sb.WriteString("INSERT OR IGNORE INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, created_at, updated_at) VALUES ")
 
 		args := make([]any, 0, len(batch)*columnsPerRow)
 		for i, ps := range batch {

--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -365,7 +365,7 @@ func (w *BatchWriter) insertBranchCommits(tx *sql.Tx, commitIDs map[string]int64
 		batch := pending[start:end]
 
 		var sb strings.Builder
-		sb.WriteString("INSERT INTO branch_commits (branch_id, commit_id, position) VALUES ")
+		sb.WriteString("INSERT OR IGNORE INTO branch_commits (branch_id, commit_id, position) VALUES ")
 
 		args := make([]any, 0, len(batch)*columnsPerRow)
 		for i, pc := range batch {

--- a/internal/database/batch_writer_test.go
+++ b/internal/database/batch_writer_test.go
@@ -84,18 +84,18 @@ func TestFlushAsyncErrorPropagation(t *testing.T) {
 		t.Fatalf("first flush should succeed: %v", err)
 	}
 
-	// Insert the same commit again -- the unique SHA index will cause
-	// the background flush to fail.
+	// Insert the same commit again -- OR IGNORE means the duplicate is
+	// silently skipped rather than causing an error.
 	addTestCommitWithChange(writer, "err111")
 
 	writer.FlushAsync()
 
 	err := writer.WaitForFlush()
-	if err == nil {
-		t.Fatal("expected error from duplicate commit, got nil")
+	if err != nil {
+		t.Fatalf("second flush should succeed (OR IGNORE): %v", err)
 	}
 
-	// Verify the first commit is still there
+	// Verify the commit exists exactly once
 	var count int
 	if err := db.QueryRow("SELECT COUNT(*) FROM commits WHERE sha = 'err111'").Scan(&count); err != nil {
 		t.Fatalf("failed to query: %v", err)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -538,6 +538,123 @@ func TestBatchWriterSharedCommits(t *testing.T) {
 	}
 }
 
+func TestBatchWriterSharedCommitsMultiManifest(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "pkgs.sqlite3")
+
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sharedSHA := "multi456"
+	sharedCommit := database.CommitInfo{
+		SHA:     sharedSHA,
+		Message: "add npm and pip deps",
+	}
+	npmManifest := database.ManifestInfo{
+		Path:      "package-lock.json",
+		Ecosystem: "npm",
+		Kind:      "lockfile",
+	}
+	pipManifest := database.ManifestInfo{
+		Path:      "Pipfile.lock",
+		Ecosystem: "pip",
+		Kind:      "lockfile",
+	}
+	npmChange := database.ChangeInfo{
+		Name:       "express",
+		Ecosystem:  "npm",
+		ChangeType: "added",
+	}
+	pipChange := database.ChangeInfo{
+		Name:       "requests",
+		Ecosystem:  "pip",
+		ChangeType: "added",
+	}
+	npmSnapshot := database.SnapshotInfo{
+		ManifestPath: "package-lock.json",
+		Name:         "express",
+		Ecosystem:    "npm",
+		Requirement:  "4.18.0",
+	}
+	pipSnapshot := database.SnapshotInfo{
+		ManifestPath: "Pipfile.lock",
+		Name:         "requests",
+		Ecosystem:    "pip",
+		Requirement:  "2.31.0",
+	}
+
+	// Index on main with both manifests
+	w1 := database.NewBatchWriter(db)
+	if err := w1.CreateBranch("main"); err != nil {
+		t.Fatalf("failed to create main branch: %v", err)
+	}
+	w1.AddCommit(sharedCommit, true)
+	w1.IncrementDepCommitCount()
+	w1.AddChange(sharedSHA, npmManifest, npmChange)
+	w1.AddChange(sharedSHA, pipManifest, pipChange)
+	w1.AddSnapshot(sharedSHA, npmManifest, npmSnapshot)
+	w1.AddSnapshot(sharedSHA, pipManifest, pipSnapshot)
+	if err := w1.Flush(); err != nil {
+		t.Fatalf("flush on main failed: %v", err)
+	}
+
+	// Index same commit on feature — should not fail
+	w2 := database.NewBatchWriter(db)
+	if err := w2.CreateBranch("feature"); err != nil {
+		t.Fatalf("failed to create feature branch: %v", err)
+	}
+	w2.AddCommit(sharedCommit, true)
+	w2.IncrementDepCommitCount()
+	w2.AddChange(sharedSHA, npmManifest, npmChange)
+	w2.AddChange(sharedSHA, pipManifest, pipChange)
+	w2.AddSnapshot(sharedSHA, npmManifest, npmSnapshot)
+	w2.AddSnapshot(sharedSHA, pipManifest, pipSnapshot)
+	if err := w2.Flush(); err != nil {
+		t.Fatalf("flush on feature failed: %v", err)
+	}
+
+	// Commit linked to both branches
+	var branchCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM branch_commits WHERE commit_id = (SELECT id FROM commits WHERE sha = ?)", sharedSHA).Scan(&branchCount)
+	if err != nil {
+		t.Fatalf("failed to count branch_commits: %v", err)
+	}
+	if branchCount != 2 {
+		t.Errorf("expected commit linked to 2 branches, got %d", branchCount)
+	}
+
+	// Exactly 2 change rows (one per manifest, not duplicated)
+	var changeCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM dependency_changes").Scan(&changeCount)
+	if err != nil {
+		t.Fatalf("failed to count changes: %v", err)
+	}
+	if changeCount != 2 {
+		t.Errorf("expected 2 change rows (npm + pip), got %d", changeCount)
+	}
+
+	// Exactly 2 snapshot rows (one per manifest, not duplicated)
+	var snapCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots").Scan(&snapCount)
+	if err != nil {
+		t.Fatalf("failed to count snapshots: %v", err)
+	}
+	if snapCount != 2 {
+		t.Errorf("expected 2 snapshot rows (npm + pip), got %d", snapCount)
+	}
+
+	// Verify both ecosystems present in snapshots
+	var npmSnapCount, pipSnapCount int
+	_ = db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem = 'npm'").Scan(&npmSnapCount)
+	_ = db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem = 'pip'").Scan(&pipSnapCount)
+	if npmSnapCount != 1 || pipSnapCount != 1 {
+		t.Errorf("expected 1 npm and 1 pip snapshot, got npm=%d pip=%d", npmSnapCount, pipSnapCount)
+	}
+}
+
 func TestNewWriterClose(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "pkgs.sqlite3")

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -459,6 +459,85 @@ func TestGetDependenciesAtCommit(t *testing.T) {
 	}
 }
 
+func TestBatchWriterSharedCommits(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "pkgs.sqlite3")
+
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sharedSHA := "shared123"
+	sharedCommit := database.CommitInfo{
+		SHA:     sharedSHA,
+		Message: "shared commit",
+	}
+	manifest := database.ManifestInfo{
+		Path:      "package-lock.json",
+		Ecosystem: "npm",
+		Kind:      "lockfile",
+	}
+	change := database.ChangeInfo{
+		Name:       "lodash",
+		Ecosystem:  "npm",
+		ChangeType: "added",
+	}
+	snapshot := database.SnapshotInfo{
+		ManifestPath: "package-lock.json",
+		Name:         "lodash",
+		Ecosystem:    "npm",
+		Requirement:  "4.17.21",
+	}
+
+	// Index shared commit on branch "main"
+	w1 := database.NewBatchWriter(db)
+	if err := w1.CreateBranch("main"); err != nil {
+		t.Fatalf("failed to create main branch: %v", err)
+	}
+	w1.AddCommit(sharedCommit, true)
+	w1.IncrementDepCommitCount()
+	w1.AddChange(sharedSHA, manifest, change)
+	w1.AddSnapshot(sharedSHA, manifest, snapshot)
+	if err := w1.Flush(); err != nil {
+		t.Fatalf("flush on main failed: %v", err)
+	}
+
+	// Index the same commit on branch "feature" — should not fail
+	w2 := database.NewBatchWriter(db)
+	if err := w2.CreateBranch("feature"); err != nil {
+		t.Fatalf("failed to create feature branch: %v", err)
+	}
+	w2.AddCommit(sharedCommit, true)
+	w2.IncrementDepCommitCount()
+	w2.AddChange(sharedSHA, manifest, change)
+	w2.AddSnapshot(sharedSHA, manifest, snapshot)
+	if err := w2.Flush(); err != nil {
+		t.Fatalf("flush on feature failed: %v", err)
+	}
+
+	// Verify the commit is linked to both branches
+	var branchCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM branch_commits WHERE commit_id = (SELECT id FROM commits WHERE sha = ?)", sharedSHA).Scan(&branchCount)
+	if err != nil {
+		t.Fatalf("failed to count branch_commits: %v", err)
+	}
+	if branchCount != 2 {
+		t.Errorf("expected commit linked to 2 branches, got %d", branchCount)
+	}
+
+	// Verify no duplicate dependency_changes
+	var changeCount int
+	err = db.QueryRow("SELECT COUNT(*) FROM dependency_changes WHERE name = 'lodash'").Scan(&changeCount)
+	if err != nil {
+		t.Fatalf("failed to count changes: %v", err)
+	}
+	if changeCount != 1 {
+		t.Errorf("expected 1 change row, got %d", changeCount)
+	}
+}
+
 func TestNewWriterClose(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "pkgs.sqlite3")

--- a/internal/database/writer.go
+++ b/internal/database/writer.go
@@ -79,7 +79,7 @@ func NewWriter(db *DB) (*Writer, error) {
 	}
 
 	branchCommitStmt, err := prepare(`
-		INSERT INTO branch_commits (branch_id, commit_id, position)
+		INSERT OR IGNORE INTO branch_commits (branch_id, commit_id, position)
 		VALUES (?, ?, ?)
 	`)
 	if err != nil {
@@ -103,7 +103,7 @@ func NewWriter(db *DB) (*Writer, error) {
 	}
 
 	snapshotStmt, err := prepare(`
-		INSERT INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, created_at, updated_at)
+		INSERT OR IGNORE INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`)
 	if err != nil {


### PR DESCRIPTION
When adding a branch that shares commits with an already-indexed branch (e.g. via `git pkgs branch add`), the batch writer tried to re-insert those commits, hitting `UNIQUE constraint failed: commits.sha`.

Now it checks which commits already exist before inserting, skips their changes and snapshots, and uses `INSERT OR IGNORE` on the commits and snapshots tables as a safety net.

Reported by @benknoble in #151.