### PR TITLE
Add public database package for extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ Commands that run package managers (`install`, `add`, `remove`, `update`) delega
 
 ## Go library
 
-The `database` package provides typed, read-only access to the git-pkgs SQLite database for extensions and external tools written in Go:
+The `database` package provides typed access to the git-pkgs SQLite database for extensions, the proxy, and other tools written in Go:
 
 ```go
 import "github.com/git-pkgs/git-pkgs/database"
@@ -740,7 +740,7 @@ for _, d := range deps {
 
 `OpenReadOnly` opens the database in SQLite read-only mode and validates the schema version, so extensions built against one version won't silently produce wrong results against another.
 
-`Open` is also available for tools that manage their own write paths and don't need schema validation.
+`Open` is available for tools like the proxy that manage their own write paths and don't need schema validation. The package also provides shared `Package` and `Version` types with upsert methods, so tools that manage the packages and versions tables stay in sync with the git-pkgs schema.
 
 See the [package documentation](https://pkg.go.dev/github.com/git-pkgs/git-pkgs/database) for all available query methods.
 

--- a/README.md
+++ b/README.md
@@ -718,6 +718,32 @@ Commands that run package managers (`install`, `add`, `remove`, `update`) delega
 
 **Author mapping** via `.mailmap` is supported. If your repository has a [`.mailmap` file](https://git-scm.com/docs/gitmailmap), author identities are resolved to their canonical names when indexing commits. This helps deduplicate contributors in `blame`, `history`, and `stats` output.
 
+## Go library
+
+The `database` package provides typed, read-only access to the git-pkgs SQLite database for extensions and external tools written in Go:
+
+```go
+import "github.com/git-pkgs/git-pkgs/database"
+
+db, err := database.OpenReadOnly(".git/pkgs.sqlite3")
+if err != nil {
+    log.Fatal(err)
+}
+defer db.Close()
+
+branch, _ := db.GetDefaultBranch()
+deps, _ := db.GetLatestDependencies(branch.ID)
+for _, d := range deps {
+    fmt.Printf("%s %s %s\n", d.Ecosystem, d.Name, d.Requirement)
+}
+```
+
+`OpenReadOnly` opens the database in SQLite read-only mode and validates the schema version, so extensions built against one version won't silently produce wrong results against another.
+
+`Open` is also available for tools that manage their own write paths and don't need schema validation.
+
+See the [package documentation](https://pkg.go.dev/github.com/git-pkgs/git-pkgs/database) for all available query methods.
+
 ## Supported ecosystems
 
 git-pkgs uses [github.com/git-pkgs/manifests](https://github.com/git-pkgs/manifests) for parsing, supporting:

--- a/database/database.go
+++ b/database/database.go
@@ -1,0 +1,118 @@
+// Package database provides read-only access to git-pkgs dependency databases.
+//
+// Extensions and external tools can use this package to query dependency data
+// without shelling out to CLI commands or opening raw SQLite connections.
+//
+// Use [OpenReadOnly] for extensions that only need to read data. It opens the
+// database in SQLite read-only mode and validates the schema version on open,
+// returning an error if the database was created by an incompatible version of
+// git-pkgs.
+//
+// Use [Open] for tools like the proxy that manage their own write paths and
+// need shared connection helpers without schema validation.
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+
+	_ "modernc.org/sqlite"
+)
+
+const SchemaVersion = 8
+
+// DB provides read-only access to a git-pkgs dependency database.
+// The underlying *sql.DB is unexported to prevent callers from
+// running arbitrary SQL against the database.
+type DB struct {
+	db   *sql.DB
+	path string
+}
+
+// Exists checks if a database file exists at the given path.
+func Exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Open opens a database with read pragmas applied (WAL, synchronous=NORMAL).
+// This does not validate the schema version. Use this for tools that manage
+// their own schema or write paths.
+func Open(path string) (*DB, error) {
+	sqlDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	db := &DB{db: sqlDB, path: path}
+	if err := db.OptimizeForReads(); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("optimizing database: %w", err)
+	}
+
+	return db, nil
+}
+
+// OpenReadOnly opens a database in read-only mode and validates that the
+// schema version matches SchemaVersion. Returns an error if the database
+// has a different schema version than expected.
+func OpenReadOnly(path string) (*DB, error) {
+	uri := "file:" + path + "?mode=ro"
+	sqlDB, err := sql.Open("sqlite", uri)
+	if err != nil {
+		return nil, fmt.Errorf("opening database: %w", err)
+	}
+
+	db := &DB{db: sqlDB, path: path}
+	if err := db.OptimizeForReads(); err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("optimizing database: %w", err)
+	}
+
+	version, err := db.SchemaVersion()
+	if err != nil {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("reading schema version: %w", err)
+	}
+	if version != SchemaVersion {
+		_ = sqlDB.Close()
+		return nil, fmt.Errorf("schema version mismatch: database has version %d, expected %d", version, SchemaVersion)
+	}
+
+	return db, nil
+}
+
+// Close closes the database connection.
+func (db *DB) Close() error {
+	return db.db.Close()
+}
+
+// SchemaVersion reads the schema version from the database.
+func (db *DB) SchemaVersion() (int, error) {
+	var version int
+	err := db.db.QueryRow("SELECT version FROM schema_info LIMIT 1").Scan(&version)
+	if err != nil {
+		return 0, err
+	}
+	return version, nil
+}
+
+// OptimizeForReads sets pragmas for read-optimized access.
+func (db *DB) OptimizeForReads() error {
+	_, err := db.db.Exec(`
+		PRAGMA synchronous = NORMAL;
+		PRAGMA journal_mode = WAL;
+	`)
+	return err
+}
+
+// OptimizeForBulkWrites sets pragmas for bulk write performance.
+func (db *DB) OptimizeForBulkWrites() error {
+	_, err := db.db.Exec(`
+		PRAGMA synchronous = OFF;
+		PRAGMA journal_mode = WAL;
+		PRAGMA cache_size = -64000;
+	`)
+	return err
+}

--- a/database/database.go
+++ b/database/database.go
@@ -1,15 +1,15 @@
-// Package database provides read-only access to git-pkgs dependency databases.
+// Package database provides shared database access for git-pkgs and extensions.
 //
-// Extensions and external tools can use this package to query dependency data
-// without shelling out to CLI commands or opening raw SQLite connections.
+// This package serves two audiences:
 //
-// Use [OpenReadOnly] for extensions that only need to read data. It opens the
-// database in SQLite read-only mode and validates the schema version on open,
-// returning an error if the database was created by an incompatible version of
-// git-pkgs.
+// Extensions and external tools use [OpenReadOnly] to query dependency data
+// without shelling out to CLI commands. It opens the database in SQLite
+// read-only mode and validates the schema version on open, returning an error
+// if the database was created by an incompatible version of git-pkgs.
 //
-// Use [Open] for tools like the proxy that manage their own write paths and
-// need shared connection helpers without schema validation.
+// Tools like the proxy use [Open] for read-write access to the shared
+// packages and versions tables, along with shared types and query methods
+// that keep both projects in sync.
 package database
 
 import (
@@ -17,16 +17,15 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/jmoiron/sqlx"
 	_ "modernc.org/sqlite"
 )
 
 const SchemaVersion = 8
 
-// DB provides read-only access to a git-pkgs dependency database.
-// The underlying *sql.DB is unexported to prevent callers from
-// running arbitrary SQL against the database.
+// DB provides access to a git-pkgs dependency database.
 type DB struct {
-	db   *sql.DB
+	db   *sqlx.DB
 	path string
 }
 
@@ -40,10 +39,12 @@ func Exists(path string) bool {
 // This does not validate the schema version. Use this for tools that manage
 // their own schema or write paths.
 func Open(path string) (*DB, error) {
-	sqlDB, err := sql.Open("sqlite", path)
+	sqlDB, err := sqlx.Open("sqlite", path+"?_busy_timeout=5000")
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
+
+	sqlDB.SetMaxOpenConns(1)
 
 	db := &DB{db: sqlDB, path: path}
 	if err := db.OptimizeForReads(); err != nil {
@@ -59,7 +60,7 @@ func Open(path string) (*DB, error) {
 // has a different schema version than expected.
 func OpenReadOnly(path string) (*DB, error) {
 	uri := "file:" + path + "?mode=ro"
-	sqlDB, err := sql.Open("sqlite", uri)
+	sqlDB, err := sqlx.Open("sqlite", uri)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)
 	}
@@ -88,14 +89,36 @@ func (db *DB) Close() error {
 	return db.db.Close()
 }
 
+// SQLX returns the underlying *sqlx.DB for callers that need direct access.
+// Use this when you need to run queries not covered by the built-in methods.
+func (db *DB) SQLX() *sqlx.DB {
+	return db.db
+}
+
+// Rebind transforms a query from ? placeholders to the appropriate bindvar
+// type for the database driver.
+func (db *DB) Rebind(query string) string {
+	return db.db.Rebind(query)
+}
+
+// Exec executes a query without returning any rows.
+func (db *DB) Exec(query string, args ...any) (sql.Result, error) {
+	return db.db.Exec(query, args...)
+}
+
 // SchemaVersion reads the schema version from the database.
 func (db *DB) SchemaVersion() (int, error) {
 	var version int
-	err := db.db.QueryRow("SELECT version FROM schema_info LIMIT 1").Scan(&version)
+	err := db.db.Get(&version, "SELECT version FROM schema_info LIMIT 1")
 	if err != nil {
 		return 0, err
 	}
 	return version, nil
+}
+
+// Path returns the database file path.
+func (db *DB) Path() string {
+	return db.path
 }
 
 // OptimizeForReads sets pragmas for read-optimized access.

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -1,0 +1,122 @@
+package database_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/database"
+	idb "github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func createTestDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := idb.Create(dbPath)
+	if err != nil {
+		t.Fatalf("creating test database: %v", err)
+	}
+	_ = db.Close()
+	return dbPath
+}
+
+func TestExists(t *testing.T) {
+	t.Run("returns false when no database", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+		if database.Exists(dbPath) {
+			t.Error("expected database to not exist")
+		}
+	})
+
+	t.Run("returns true when database exists", func(t *testing.T) {
+		dbPath := createTestDB(t)
+		if !database.Exists(dbPath) {
+			t.Error("expected database to exist")
+		}
+	})
+}
+
+func TestOpen(t *testing.T) {
+	t.Run("opens existing database", func(t *testing.T) {
+		dbPath := createTestDB(t)
+
+		db, err := database.Open(dbPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		version, err := db.SchemaVersion()
+		if err != nil {
+			t.Fatalf("reading schema version: %v", err)
+		}
+		if version != database.SchemaVersion {
+			t.Errorf("got version %d, want %d", version, database.SchemaVersion)
+		}
+	})
+
+	t.Run("does not validate schema version", func(t *testing.T) {
+		// Open does not reject mismatched versions -- that's OpenReadOnly's job.
+		dbPath := createTestDB(t)
+		db, err := database.Open(dbPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_ = db.Close()
+	})
+}
+
+func TestOpenReadOnly(t *testing.T) {
+	t.Run("opens database in read-only mode", func(t *testing.T) {
+		dbPath := createTestDB(t)
+
+		db, err := database.OpenReadOnly(dbPath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		version, err := db.SchemaVersion()
+		if err != nil {
+			t.Fatalf("reading schema version: %v", err)
+		}
+		if version != database.SchemaVersion {
+			t.Errorf("got version %d, want %d", version, database.SchemaVersion)
+		}
+	})
+
+	t.Run("rejects wrong schema version", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+
+		// Create a database with a different schema version
+		internalDB, err := idb.Create(dbPath)
+		if err != nil {
+			t.Fatalf("creating test database: %v", err)
+		}
+		// Manually change schema version
+		_, err = internalDB.Exec("UPDATE schema_info SET version = 999")
+		if err != nil {
+			t.Fatalf("updating schema version: %v", err)
+		}
+		_ = internalDB.Close()
+
+		_, err = database.OpenReadOnly(dbPath)
+		if err == nil {
+			t.Fatal("expected error for wrong schema version")
+		}
+	})
+
+	t.Run("returns error for non-existent file", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "nonexistent.sqlite3")
+		_, err := database.OpenReadOnly(dbPath)
+		if err == nil {
+			t.Fatal("expected error for non-existent file")
+		}
+	})
+}
+
+func TestSchemaVersionConst(t *testing.T) {
+	if database.SchemaVersion != idb.SchemaVersion {
+		t.Errorf("public SchemaVersion %d != internal SchemaVersion %d",
+			database.SchemaVersion, idb.SchemaVersion)
+	}
+}

--- a/database/helpers.go
+++ b/database/helpers.go
@@ -1,0 +1,54 @@
+package database
+
+import "encoding/json"
+
+func splitCommaList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := make([]string, 0)
+	for _, p := range splitString(s, ",") {
+		p = trimSpace(p)
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}
+
+func splitString(s, sep string) []string {
+	var result []string
+	start := 0
+	for i := 0; i <= len(s)-len(sep); i++ {
+		if s[i:i+len(sep)] == sep {
+			result = append(result, s[start:i])
+			start = i + len(sep)
+			i += len(sep) - 1
+		}
+	}
+	result = append(result, s[start:])
+	return result
+}
+
+func trimSpace(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n') {
+		end--
+	}
+	return s[start:end]
+}
+
+func decodeMetadata(s string) map[string]string {
+	if s == "" {
+		return nil
+	}
+	var m map[string]string
+	if json.Unmarshal([]byte(s), &m) != nil {
+		return nil
+	}
+	return m
+}

--- a/database/queries.go
+++ b/database/queries.go
@@ -84,7 +84,7 @@ func (db *DB) GetVersionByPURL(purl string) (*Version, error) {
 	var v Version
 	err := db.db.Get(&v, `
 		SELECT id, purl, package_purl, license, published_at,
-		       integrity, source, enriched_at, created_at, updated_at
+		       integrity, yanked, source, enriched_at, created_at, updated_at
 		FROM versions WHERE purl = ?
 	`, purl)
 	if err == sql.ErrNoRows {
@@ -101,7 +101,7 @@ func (db *DB) GetVersionsByPackagePURL(packagePURL string) ([]Version, error) {
 	var versions []Version
 	err := db.db.Select(&versions, `
 		SELECT id, purl, package_purl, license, published_at,
-		       integrity, source, enriched_at, created_at, updated_at
+		       integrity, yanked, source, enriched_at, created_at, updated_at
 		FROM versions WHERE package_purl = ?
 		ORDER BY created_at DESC
 	`, packagePURL)
@@ -116,17 +116,18 @@ func (db *DB) UpsertVersion(v *Version) error {
 	now := time.Now()
 	_, err := db.db.Exec(`
 		INSERT INTO versions (purl, package_purl, license, published_at,
-		                      integrity, source, enriched_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		                      integrity, yanked, source, enriched_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(purl) DO UPDATE SET
 			license = excluded.license,
 			published_at = excluded.published_at,
 			integrity = excluded.integrity,
+			yanked = excluded.yanked,
 			source = excluded.source,
 			enriched_at = excluded.enriched_at,
 			updated_at = excluded.updated_at
 	`, v.PURL, v.PackagePURL, v.License, v.PublishedAt,
-		v.Integrity, v.Source, v.EnrichedAt, now, now)
+		v.Integrity, v.Yanked, v.Source, v.EnrichedAt, now, now)
 	if err != nil {
 		return fmt.Errorf("upserting version: %w", err)
 	}

--- a/database/queries.go
+++ b/database/queries.go
@@ -7,6 +7,134 @@ import (
 	"time"
 )
 
+// Shared package queries. These are used by both git-pkgs and the proxy.
+
+// GetPackageByPURL returns a package by its PURL.
+func (db *DB) GetPackageByPURL(purl string) (*Package, error) {
+	var pkg Package
+	err := db.db.Get(&pkg, `
+		SELECT id, purl, ecosystem, name, latest_version, license,
+		       description, homepage, repository_url, registry_url,
+		       supplier_name, supplier_type, source, enriched_at,
+		       vulns_synced_at, created_at, updated_at
+		FROM packages WHERE purl = ?
+	`, purl)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &pkg, nil
+}
+
+// GetPackageByEcosystemName returns a package by ecosystem and name.
+func (db *DB) GetPackageByEcosystemName(ecosystem, name string) (*Package, error) {
+	var pkg Package
+	err := db.db.Get(&pkg, `
+		SELECT id, purl, ecosystem, name, latest_version, license,
+		       description, homepage, repository_url, registry_url,
+		       supplier_name, supplier_type, source, enriched_at,
+		       vulns_synced_at, created_at, updated_at
+		FROM packages WHERE ecosystem = ? AND name = ?
+	`, ecosystem, name)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &pkg, nil
+}
+
+// UpsertPackage inserts or updates a package record.
+func (db *DB) UpsertPackage(pkg *Package) error {
+	now := time.Now()
+	_, err := db.db.Exec(`
+		INSERT INTO packages (purl, ecosystem, name, latest_version, license,
+		                      description, homepage, repository_url, registry_url,
+		                      supplier_name, supplier_type, source, enriched_at,
+		                      created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(purl) DO UPDATE SET
+			latest_version = excluded.latest_version,
+			license = excluded.license,
+			description = excluded.description,
+			homepage = excluded.homepage,
+			repository_url = excluded.repository_url,
+			registry_url = excluded.registry_url,
+			supplier_name = excluded.supplier_name,
+			supplier_type = excluded.supplier_type,
+			source = excluded.source,
+			enriched_at = excluded.enriched_at,
+			updated_at = excluded.updated_at
+	`, pkg.PURL, pkg.Ecosystem, pkg.Name, pkg.LatestVersion, pkg.License,
+		pkg.Description, pkg.Homepage, pkg.RepositoryURL, pkg.RegistryURL,
+		pkg.SupplierName, pkg.SupplierType, pkg.Source, pkg.EnrichedAt, now, now)
+	if err != nil {
+		return fmt.Errorf("upserting package: %w", err)
+	}
+	return nil
+}
+
+// Shared version queries.
+
+// GetVersionByPURL returns a version by its PURL.
+func (db *DB) GetVersionByPURL(purl string) (*Version, error) {
+	var v Version
+	err := db.db.Get(&v, `
+		SELECT id, purl, package_purl, license, published_at,
+		       integrity, source, enriched_at, created_at, updated_at
+		FROM versions WHERE purl = ?
+	`, purl)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+// GetVersionsByPackagePURL returns all versions for a package.
+func (db *DB) GetVersionsByPackagePURL(packagePURL string) ([]Version, error) {
+	var versions []Version
+	err := db.db.Select(&versions, `
+		SELECT id, purl, package_purl, license, published_at,
+		       integrity, source, enriched_at, created_at, updated_at
+		FROM versions WHERE package_purl = ?
+		ORDER BY created_at DESC
+	`, packagePURL)
+	if err != nil {
+		return nil, err
+	}
+	return versions, nil
+}
+
+// UpsertVersion inserts or updates a version record.
+func (db *DB) UpsertVersion(v *Version) error {
+	now := time.Now()
+	_, err := db.db.Exec(`
+		INSERT INTO versions (purl, package_purl, license, published_at,
+		                      integrity, source, enriched_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(purl) DO UPDATE SET
+			license = excluded.license,
+			published_at = excluded.published_at,
+			integrity = excluded.integrity,
+			source = excluded.source,
+			enriched_at = excluded.enriched_at,
+			updated_at = excluded.updated_at
+	`, v.PURL, v.PackagePURL, v.License, v.PublishedAt,
+		v.Integrity, v.Source, v.EnrichedAt, now, now)
+	if err != nil {
+		return fmt.Errorf("upserting version: %w", err)
+	}
+	return nil
+}
+
+// Extension read queries below.
+
 // GetBranch returns information about a branch by name.
 func (db *DB) GetBranch(name string) (*BranchInfo, error) {
 	var info BranchInfo

--- a/database/queries.go
+++ b/database/queries.go
@@ -1,0 +1,1691 @@
+package database
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// GetBranch returns information about a branch by name.
+func (db *DB) GetBranch(name string) (*BranchInfo, error) {
+	var info BranchInfo
+	var lastSHA sql.NullString
+
+	err := db.db.QueryRow(
+		"SELECT id, name, last_analyzed_sha FROM branches WHERE name = ?",
+		name,
+	).Scan(&info.ID, &info.Name, &lastSHA)
+	if err != nil {
+		return nil, err
+	}
+
+	if lastSHA.Valid {
+		info.LastAnalyzedSHA = lastSHA.String
+	}
+
+	return &info, nil
+}
+
+// GetDefaultBranch returns the first branch (by ID), which is typically the default.
+func (db *DB) GetDefaultBranch() (*BranchInfo, error) {
+	var info BranchInfo
+	var lastSHA sql.NullString
+
+	err := db.db.QueryRow(
+		"SELECT id, name, last_analyzed_sha FROM branches ORDER BY id LIMIT 1",
+	).Scan(&info.ID, &info.Name, &lastSHA)
+	if err != nil {
+		return nil, err
+	}
+
+	if lastSHA.Valid {
+		info.LastAnalyzedSHA = lastSHA.String
+		info.LastSHA = lastSHA.String
+	}
+
+	return &info, nil
+}
+
+// GetBranches returns all branches with their commit counts.
+func (db *DB) GetBranches() ([]BranchInfo, error) {
+	rows, err := db.db.Query(`
+		SELECT b.id, b.name, b.last_analyzed_sha, COUNT(bc.id) as commit_count
+		FROM branches b
+		LEFT JOIN branch_commits bc ON bc.branch_id = b.id
+		GROUP BY b.id, b.name, b.last_analyzed_sha
+		ORDER BY b.name
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var branches []BranchInfo
+	for rows.Next() {
+		var info BranchInfo
+		var lastSHA sql.NullString
+
+		if err := rows.Scan(&info.ID, &info.Name, &lastSHA, &info.CommitCount); err != nil {
+			return nil, err
+		}
+
+		if lastSHA.Valid {
+			info.LastAnalyzedSHA = lastSHA.String
+			info.LastSHA = lastSHA.String
+		}
+
+		branches = append(branches, info)
+	}
+
+	return branches, rows.Err()
+}
+
+// HasSnapshotForCommit checks if snapshot data exists for a specific commit.
+func (db *DB) HasSnapshotForCommit(sha string) (bool, error) {
+	var count int
+	err := db.db.QueryRow(`
+		SELECT COUNT(*) FROM dependency_snapshots ds
+		JOIN commits c ON c.id = ds.commit_id
+		WHERE c.sha = ?
+	`, sha).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// GetDependenciesAtCommit returns dependencies at the most recent snapshot at or before the given commit.
+func (db *DB) GetDependenciesAtCommit(sha string) ([]Dependency, error) {
+	var commitID int64
+	err := db.db.QueryRow(`
+		SELECT ds.commit_id
+		FROM dependency_snapshots ds
+		JOIN branch_commits snap_bc ON snap_bc.commit_id = ds.commit_id
+		JOIN commits c ON c.sha = ?
+		JOIN branch_commits target_bc ON target_bc.commit_id = c.id
+			AND target_bc.branch_id = snap_bc.branch_id
+		WHERE snap_bc.position <= target_bc.position
+		ORDER BY snap_bc.position DESC
+		LIMIT 1
+	`, sha).Scan(&commitID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return db.getDependenciesForCommitID(commitID)
+}
+
+// GetDependenciesAtRef returns dependencies at a specific ref on a branch.
+func (db *DB) GetDependenciesAtRef(ref string, branchID int64) ([]Dependency, error) {
+	var commitID int64
+	err := db.db.QueryRow(`
+		SELECT c.id
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE c.sha = ? AND bc.branch_id = ?
+	`, ref, branchID).Scan(&commitID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshotCommitID int64
+	err = db.db.QueryRow(`
+		SELECT ds.commit_id
+		FROM dependency_snapshots ds
+		JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+		JOIN branch_commits target_bc ON target_bc.commit_id = ?
+		WHERE bc.branch_id = ? AND bc.position <= target_bc.position
+		GROUP BY ds.commit_id
+		ORDER BY bc.position DESC
+		LIMIT 1
+	`, commitID, branchID).Scan(&snapshotCommitID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return db.getDependenciesForCommitID(snapshotCommitID)
+}
+
+// GetLatestDependencies returns dependencies from the most recent snapshot on a branch.
+func (db *DB) GetLatestDependencies(branchID int64) ([]Dependency, error) {
+	var commitID int64
+	err := db.db.QueryRow(`
+		SELECT ds.commit_id
+		FROM dependency_snapshots ds
+		JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+		WHERE bc.branch_id = ?
+		ORDER BY bc.position DESC
+		LIMIT 1
+	`, branchID).Scan(&commitID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return db.getDependenciesForCommitID(commitID)
+}
+
+func (db *DB) getDependenciesForCommitID(commitID int64) ([]Dependency, error) {
+	rows, err := db.db.Query(`
+		SELECT ds.name, ds.ecosystem, ds.purl, ds.requirement, ds.dependency_type, ds.integrity, m.path, m.kind
+		FROM dependency_snapshots ds
+		JOIN manifests m ON m.id = ds.manifest_id
+		WHERE ds.commit_id = ? AND ds.name != '_EMPTY_MARKER_'
+		ORDER BY m.path, ds.name
+	`, commitID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var deps []Dependency
+	for rows.Next() {
+		var d Dependency
+		var ecosystem, purl, requirement, depType, integrity, kind sql.NullString
+
+		if err := rows.Scan(&d.Name, &ecosystem, &purl, &requirement, &depType, &integrity, &d.ManifestPath, &kind); err != nil {
+			return nil, err
+		}
+
+		if ecosystem.Valid {
+			d.Ecosystem = ecosystem.String
+		}
+		if purl.Valid {
+			d.PURL = purl.String
+		}
+		if requirement.Valid {
+			d.Requirement = requirement.String
+		}
+		if depType.Valid {
+			d.DependencyType = depType.String
+		}
+		if integrity.Valid {
+			d.Integrity = integrity.String
+		}
+		if kind.Valid {
+			d.ManifestKind = kind.String
+		}
+
+		deps = append(deps, d)
+	}
+
+	return deps, rows.Err()
+}
+
+// GetCommitsWithChanges returns commits that have dependency changes, with their changes eager-loaded.
+func (db *DB) GetCommitsWithChanges(opts LogOptions) ([]CommitWithChanges, error) {
+	query := `
+		SELECT DISTINCT c.sha, c.message, c.author_name, c.author_email, c.committed_at
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		JOIN dependency_changes dc ON dc.commit_id = c.id
+		WHERE bc.branch_id = ?
+	`
+	args := []any{opts.BranchID}
+
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Author != "" {
+		query += " AND (c.author_name LIKE ? OR c.author_email LIKE ?)"
+		pattern := "%" + opts.Author + "%"
+		args = append(args, pattern, pattern)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+
+	query += " ORDER BY bc.position DESC"
+
+	if opts.Limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var commits []CommitWithChanges
+	for rows.Next() {
+		var c CommitWithChanges
+		var message, authorName, authorEmail sql.NullString
+
+		if err := rows.Scan(&c.SHA, &message, &authorName, &authorEmail, &c.CommittedAt); err != nil {
+			return nil, err
+		}
+
+		if message.Valid {
+			c.Message = message.String
+		}
+		if authorName.Valid {
+			c.AuthorName = authorName.String
+		}
+		if authorEmail.Valid {
+			c.AuthorEmail = authorEmail.String
+		}
+
+		commits = append(commits, c)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	shas := make([]string, len(commits))
+	for i, c := range commits {
+		shas[i] = c.SHA
+	}
+
+	allChanges, err := db.GetChangesForCommits(shas)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range commits {
+		changes := allChanges[commits[i].SHA]
+
+		if opts.Ecosystem != "" {
+			var filtered []Change
+			for _, ch := range changes {
+				if ch.Ecosystem == opts.Ecosystem {
+					filtered = append(filtered, ch)
+				}
+			}
+			changes = filtered
+		}
+
+		commits[i].Changes = changes
+	}
+
+	return commits, nil
+}
+
+// GetChangesForCommit returns dependency changes for a single commit.
+func (db *DB) GetChangesForCommit(sha string) ([]Change, error) {
+	rows, err := db.db.Query(`
+		SELECT dc.name, dc.ecosystem, dc.purl, dc.change_type, dc.requirement, dc.previous_requirement, dc.dependency_type, m.path
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN manifests m ON m.id = dc.manifest_id
+		WHERE c.sha = ?
+		ORDER BY m.path, dc.name
+	`, sha)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var changes []Change
+	for rows.Next() {
+		var c Change
+		var ecosystem, purl, requirement, prevReq, depType sql.NullString
+
+		if err := rows.Scan(&c.Name, &ecosystem, &purl, &c.ChangeType, &requirement, &prevReq, &depType, &c.ManifestPath); err != nil {
+			return nil, err
+		}
+
+		if ecosystem.Valid {
+			c.Ecosystem = ecosystem.String
+		}
+		if purl.Valid {
+			c.PURL = purl.String
+		}
+		if requirement.Valid {
+			c.Requirement = requirement.String
+		}
+		if prevReq.Valid {
+			c.PreviousRequirement = prevReq.String
+		}
+		if depType.Valid {
+			c.DependencyType = depType.String
+		}
+
+		changes = append(changes, c)
+	}
+
+	return changes, rows.Err()
+}
+
+// GetChangesForCommits fetches changes for multiple commits in one query.
+func (db *DB) GetChangesForCommits(shas []string) (map[string][]Change, error) {
+	if len(shas) == 0 {
+		return make(map[string][]Change), nil
+	}
+
+	placeholders := make([]string, len(shas))
+	args := make([]any, len(shas))
+	for i, sha := range shas {
+		placeholders[i] = "?"
+		args[i] = sha
+	}
+
+	query := fmt.Sprintf(`
+		SELECT c.sha, dc.name, dc.ecosystem, dc.purl, dc.change_type, dc.requirement, dc.previous_requirement, dc.dependency_type, m.path
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN manifests m ON m.id = dc.manifest_id
+		WHERE c.sha IN (%s)
+		ORDER BY c.sha, m.path, dc.name
+	`, strings.Join(placeholders, ","))
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string][]Change)
+	for rows.Next() {
+		var sha string
+		var ch Change
+		var ecosystem, purl, requirement, prevReq, depType sql.NullString
+
+		if err := rows.Scan(&sha, &ch.Name, &ecosystem, &purl, &ch.ChangeType, &requirement, &prevReq, &depType, &ch.ManifestPath); err != nil {
+			return nil, err
+		}
+
+		if ecosystem.Valid {
+			ch.Ecosystem = ecosystem.String
+		}
+		if purl.Valid {
+			ch.PURL = purl.String
+		}
+		if requirement.Valid {
+			ch.Requirement = requirement.String
+		}
+		if prevReq.Valid {
+			ch.PreviousRequirement = prevReq.String
+		}
+		if depType.Valid {
+			ch.DependencyType = depType.String
+		}
+
+		result[sha] = append(result[sha], ch)
+	}
+
+	return result, rows.Err()
+}
+
+// GetPackageHistory returns the change history for a package.
+func (db *DB) GetPackageHistory(opts HistoryOptions) ([]HistoryEntry, error) {
+	query := `
+		SELECT c.sha, c.message, c.author_name, c.author_email, c.committed_at,
+		       dc.name, dc.ecosystem, dc.change_type, dc.requirement, dc.previous_requirement, m.path, m.kind
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		JOIN manifests m ON m.id = dc.manifest_id
+		WHERE bc.branch_id = ?
+	`
+	args := []any{opts.BranchID}
+
+	if opts.PackageName != "" {
+		query += " AND dc.name LIKE ?"
+		args = append(args, "%"+opts.PackageName+"%")
+	}
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Author != "" {
+		query += " AND (c.author_name LIKE ? OR c.author_email LIKE ?)"
+		pattern := "%" + opts.Author + "%"
+		args = append(args, pattern, pattern)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+
+	query += " ORDER BY bc.position ASC, dc.name"
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []HistoryEntry
+	for rows.Next() {
+		var e HistoryEntry
+		var message, authorName, authorEmail, ecosystem, requirement, prevReq, manifestKind sql.NullString
+
+		if err := rows.Scan(&e.SHA, &message, &authorName, &authorEmail, &e.CommittedAt,
+			&e.Name, &ecosystem, &e.ChangeType, &requirement, &prevReq, &e.ManifestPath, &manifestKind); err != nil {
+			return nil, err
+		}
+
+		if message.Valid {
+			e.Message = message.String
+		}
+		if authorName.Valid {
+			e.AuthorName = authorName.String
+		}
+		if authorEmail.Valid {
+			e.AuthorEmail = authorEmail.String
+		}
+		if ecosystem.Valid {
+			e.Ecosystem = ecosystem.String
+		}
+		if requirement.Valid {
+			e.Requirement = requirement.String
+		}
+		if prevReq.Valid {
+			e.PreviousRequirement = prevReq.String
+		}
+		if manifestKind.Valid {
+			e.ManifestKind = manifestKind.String
+		}
+
+		entries = append(entries, e)
+	}
+
+	return entries, rows.Err()
+}
+
+// GetStats returns aggregate statistics for a branch.
+func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
+	stats := &Stats{
+		DepsByEcosystem: make(map[string]int),
+		ChangesByType:   make(map[string]int),
+	}
+
+	var branchName sql.NullString
+	var latestCommitID sql.NullInt64
+	err := db.db.QueryRow(`
+		SELECT b.name, bc.commit_id
+		FROM branches b
+		LEFT JOIN branch_commits bc ON bc.branch_id = b.id
+		WHERE b.id = ?
+		ORDER BY bc.position DESC
+		LIMIT 1
+	`, opts.BranchID).Scan(&branchName, &latestCommitID)
+	if err != nil {
+		return nil, err
+	}
+	if branchName.Valid {
+		stats.Branch = branchName.String
+	}
+
+	err = db.db.QueryRow(`
+		SELECT COUNT(*) FROM branch_commits WHERE branch_id = ?
+	`, opts.BranchID).Scan(&stats.CommitsAnalyzed)
+	if err != nil {
+		return nil, err
+	}
+
+	query := `
+		SELECT COUNT(DISTINCT c.id)
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		JOIN dependency_changes dc ON dc.commit_id = c.id
+		WHERE bc.branch_id = ?
+	`
+	args := []any{opts.BranchID}
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+	err = db.db.QueryRow(query, args...).Scan(&stats.CommitsWithChanges)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshotCommitID sql.NullInt64
+	if latestCommitID.Valid {
+		_ = db.db.QueryRow(`
+			SELECT ds.commit_id
+			FROM dependency_snapshots ds
+			JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+			WHERE bc.branch_id = ?
+			ORDER BY bc.position DESC
+			LIMIT 1
+		`, opts.BranchID).Scan(&snapshotCommitID)
+	}
+	if snapshotCommitID.Valid {
+		err = db.db.QueryRow(`
+			SELECT COUNT(*) FROM dependency_snapshots WHERE commit_id = ?
+		`, snapshotCommitID.Int64).Scan(&stats.CurrentDeps)
+		if err != nil {
+			return nil, err
+		}
+
+		rows, err := db.db.Query(`
+			SELECT ecosystem, COUNT(*)
+			FROM dependency_snapshots
+			WHERE commit_id = ?
+			GROUP BY ecosystem
+		`, snapshotCommitID.Int64)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var eco sql.NullString
+			var count int
+			if err := rows.Scan(&eco, &count); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			if eco.Valid && eco.String != "" {
+				stats.DepsByEcosystem[eco.String] = count
+			}
+		}
+		_ = rows.Close()
+	}
+
+	query = `
+		SELECT dc.change_type, COUNT(*)
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE bc.branch_id = ?
+	`
+	args = []any{opts.BranchID}
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+	query += " GROUP BY dc.change_type"
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var changeType string
+		var count int
+		if err := rows.Scan(&changeType, &count); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		stats.ChangesByType[changeType] = count
+		stats.TotalChanges += count
+	}
+	_ = rows.Close()
+
+	limit := opts.Limit
+	if limit == 0 {
+		limit = 10
+	}
+
+	query = `
+		SELECT dc.name, COUNT(*) as cnt
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE bc.branch_id = ?
+	`
+	args = []any{opts.BranchID}
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+	query += " GROUP BY dc.name ORDER BY cnt DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err = db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var nc NameCount
+		if err := rows.Scan(&nc.Name, &nc.Count); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		stats.TopChanged = append(stats.TopChanged, nc)
+	}
+	_ = rows.Close()
+
+	query = `
+		SELECT c.author_name, COUNT(DISTINCT dc.id) as cnt
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE bc.branch_id = ?
+	`
+	args = []any{opts.BranchID}
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+	query += " GROUP BY c.author_name ORDER BY cnt DESC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err = db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var nc NameCount
+		var name sql.NullString
+		if err := rows.Scan(&name, &nc.Count); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if name.Valid {
+			nc.Name = name.String
+		}
+		stats.TopAuthors = append(stats.TopAuthors, nc)
+	}
+	_ = rows.Close()
+
+	return stats, nil
+}
+
+// GetAuthorStats returns per-author dependency change statistics.
+func (db *DB) GetAuthorStats(opts StatsOptions) ([]AuthorStats, error) {
+	query := `
+		SELECT c.author_name, c.author_email,
+		       COUNT(DISTINCT c.id) as commits,
+		       COUNT(dc.id) as changes,
+		       SUM(CASE WHEN dc.change_type = 'added' THEN 1 ELSE 0 END) as added,
+		       SUM(CASE WHEN dc.change_type = 'modified' THEN 1 ELSE 0 END) as modified,
+		       SUM(CASE WHEN dc.change_type = 'removed' THEN 1 ELSE 0 END) as removed
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		JOIN dependency_changes dc ON dc.commit_id = c.id
+	`
+	args := []any{opts.BranchID}
+	query += " WHERE bc.branch_id = ?"
+
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.Since != "" {
+		query += " AND c.committed_at >= ?"
+		args = append(args, opts.Since)
+	}
+	if opts.Until != "" {
+		query += " AND c.committed_at <= ?"
+		args = append(args, opts.Until)
+	}
+
+	query += " GROUP BY c.author_name, c.author_email ORDER BY changes DESC"
+	if opts.Limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []AuthorStats
+	for rows.Next() {
+		var as AuthorStats
+		var name, email sql.NullString
+		var added, modified, removed int
+		if err := rows.Scan(&name, &email, &as.Commits, &as.Changes, &added, &modified, &removed); err != nil {
+			return nil, err
+		}
+		if name.Valid {
+			as.Name = name.String
+		}
+		if email.Valid {
+			as.Email = email.String
+		}
+		as.ByType = map[string]int{
+			"added":    added,
+			"modified": modified,
+			"removed":  removed,
+		}
+		results = append(results, as)
+	}
+
+	return results, rows.Err()
+}
+
+// SearchDependencies searches current dependencies matching a pattern.
+func (db *DB) SearchDependencies(branchID int64, pattern, ecosystem string, directOnly bool) ([]SearchResult, error) {
+	query := `
+		WITH current_deps AS (
+			SELECT DISTINCT ds.name, ds.ecosystem, ds.requirement, m.kind
+			FROM dependency_snapshots ds
+			JOIN manifests m ON m.id = ds.manifest_id
+			JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+			WHERE bc.branch_id = ?
+			AND bc.position = (
+				SELECT MAX(bc2.position)
+				FROM branch_commits bc2
+				JOIN dependency_snapshots ds2 ON ds2.commit_id = bc2.commit_id
+				WHERE bc2.branch_id = ?
+			)
+			AND ds.name LIKE ?
+	`
+	args := []any{branchID, branchID, "%" + pattern + "%"}
+
+	if ecosystem != "" {
+		query += " AND ds.ecosystem = ?"
+		args = append(args, ecosystem)
+	}
+
+	if directOnly {
+		query += " AND m.kind = 'manifest'"
+	}
+
+	query += `
+		),
+		first_added AS (
+			SELECT dc.name, MIN(c.committed_at) as first_seen, MIN(c.sha) as added_in
+			FROM dependency_changes dc
+			JOIN commits c ON c.id = dc.commit_id
+			JOIN branch_commits bc ON bc.commit_id = c.id
+			WHERE bc.branch_id = ? AND dc.change_type = 'added'
+			GROUP BY dc.name
+		),
+		last_changed AS (
+			SELECT dc.name, MAX(c.committed_at) as last_changed
+			FROM dependency_changes dc
+			JOIN commits c ON c.id = dc.commit_id
+			JOIN branch_commits bc ON bc.commit_id = c.id
+			WHERE bc.branch_id = ?
+			GROUP BY dc.name
+		)
+		SELECT cd.name, cd.ecosystem, cd.requirement, cd.kind,
+		       COALESCE(fa.first_seen, ''), COALESCE(lc.last_changed, ''), COALESCE(fa.added_in, '')
+		FROM current_deps cd
+		LEFT JOIN first_added fa ON fa.name = cd.name
+		LEFT JOIN last_changed lc ON lc.name = cd.name
+		ORDER BY cd.name
+	`
+	args = append(args, branchID, branchID)
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		var eco, req, kind sql.NullString
+
+		if err := rows.Scan(&r.Name, &eco, &req, &kind, &r.FirstSeen, &r.LastChanged, &r.AddedIn); err != nil {
+			return nil, err
+		}
+
+		if eco.Valid {
+			r.Ecosystem = eco.String
+		}
+		if req.Valid {
+			r.Requirement = req.String
+		}
+		if kind.Valid {
+			r.ManifestKind = kind.String
+		}
+
+		results = append(results, r)
+	}
+
+	return results, rows.Err()
+}
+
+// GetWhy returns the commit that first added a package.
+func (db *DB) GetWhy(branchID int64, packageName, ecosystem string) (*WhyResult, error) {
+	query := `
+		SELECT dc.name, dc.ecosystem, m.path, c.sha, c.message, c.author_name, c.author_email, c.committed_at
+		FROM dependency_changes dc
+		JOIN commits c ON c.id = dc.commit_id
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		JOIN manifests m ON m.id = dc.manifest_id
+		WHERE bc.branch_id = ? AND dc.change_type = 'added' AND dc.name = ?
+	`
+	args := []any{branchID, packageName}
+
+	if ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, ecosystem)
+	}
+
+	query += " ORDER BY bc.position ASC LIMIT 1"
+
+	var r WhyResult
+	var eco, message, authorName, authorEmail sql.NullString
+
+	err := db.db.QueryRow(query, args...).Scan(
+		&r.Name, &eco, &r.ManifestPath, &r.SHA,
+		&message, &authorName, &authorEmail, &r.CommittedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if eco.Valid {
+		r.Ecosystem = eco.String
+	}
+	if message.Valid {
+		r.Message = message.String
+	}
+	if authorName.Valid {
+		r.AuthorName = authorName.String
+	}
+	if authorEmail.Valid {
+		r.AuthorEmail = authorEmail.String
+	}
+
+	return &r, nil
+}
+
+// GetBlame returns the commit that first added each current dependency.
+func (db *DB) GetBlame(branchID int64, ecosystem string) ([]BlameEntry, error) {
+	query := `
+		WITH current_deps AS (
+			SELECT DISTINCT ds.name, ds.ecosystem, ds.requirement, m.path as manifest_path
+			FROM dependency_snapshots ds
+			JOIN manifests m ON m.id = ds.manifest_id
+			JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+			WHERE bc.branch_id = ?
+			AND bc.position = (
+				SELECT MAX(bc2.position)
+				FROM branch_commits bc2
+				JOIN dependency_snapshots ds2 ON ds2.commit_id = bc2.commit_id
+				WHERE bc2.branch_id = ?
+			)
+		),
+		first_added AS (
+			SELECT dc.name, m.path as manifest_path, MIN(bc.position) as first_pos
+			FROM dependency_changes dc
+			JOIN commits c ON c.id = dc.commit_id
+			JOIN branch_commits bc ON bc.commit_id = c.id
+			JOIN manifests m ON m.id = dc.manifest_id
+			WHERE bc.branch_id = ? AND dc.change_type = 'added'
+			GROUP BY dc.name, m.path
+		)
+		SELECT cd.name, cd.ecosystem, cd.requirement, cd.manifest_path,
+		       c.sha, c.author_name, c.author_email, c.committed_at
+		FROM current_deps cd
+		JOIN first_added fa ON fa.name = cd.name AND fa.manifest_path = cd.manifest_path
+		JOIN commits c ON c.id = (
+			SELECT bc.commit_id FROM branch_commits bc
+			WHERE bc.branch_id = ? AND bc.position = fa.first_pos
+		)
+	`
+	args := []any{branchID, branchID, branchID, branchID}
+
+	if ecosystem != "" {
+		query += " WHERE cd.ecosystem = ?"
+		args = append(args, ecosystem)
+	}
+
+	query += " ORDER BY cd.manifest_path, cd.name"
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []BlameEntry
+	for rows.Next() {
+		var e BlameEntry
+		var eco, requirement, authorName, authorEmail sql.NullString
+
+		if err := rows.Scan(&e.Name, &eco, &requirement, &e.ManifestPath,
+			&e.SHA, &authorName, &authorEmail, &e.CommittedAt); err != nil {
+			return nil, err
+		}
+
+		if eco.Valid {
+			e.Ecosystem = eco.String
+		}
+		if requirement.Valid {
+			e.Requirement = requirement.String
+		}
+		if authorName.Valid {
+			e.AuthorName = authorName.String
+		}
+		if authorEmail.Valid {
+			e.AuthorEmail = authorEmail.String
+		}
+
+		entries = append(entries, e)
+	}
+
+	return entries, rows.Err()
+}
+
+// GetStaleDependencies returns dependencies that haven't been updated recently.
+func (db *DB) GetStaleDependencies(branchID int64, ecosystem string, days int) ([]StaleEntry, error) {
+	query := `
+		WITH current_deps AS (
+			SELECT DISTINCT ds.name, ds.ecosystem, ds.requirement, m.path, m.kind
+			FROM dependency_snapshots ds
+			JOIN manifests m ON m.id = ds.manifest_id
+			JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+			WHERE bc.branch_id = ?
+			AND bc.position = (SELECT MAX(position) FROM branch_commits WHERE branch_id = ?)
+			AND (m.kind = 'lockfile' OR (m.kind = 'manifest' AND m.ecosystem = 'golang'))
+		),
+		last_changed AS (
+			SELECT dc.name, m.path, MAX(c.committed_at) as last_changed
+			FROM dependency_changes dc
+			JOIN commits c ON c.id = dc.commit_id
+			JOIN branch_commits bc ON bc.commit_id = c.id
+			JOIN manifests m ON m.id = dc.manifest_id
+			WHERE bc.branch_id = ?
+			GROUP BY dc.name, m.path
+		)
+		SELECT cd.name, cd.ecosystem, cd.requirement, cd.path,
+		       COALESCE(lc.last_changed, '') as last_changed,
+		       CAST(julianday('now') - julianday(substr(COALESCE(lc.last_changed, '2000-01-01'), 1, 19)) AS INTEGER) as days_since
+		FROM current_deps cd
+		LEFT JOIN last_changed lc ON lc.name = cd.name AND lc.path = cd.path
+	`
+	args := []any{branchID, branchID, branchID}
+
+	if ecosystem != "" {
+		query += " WHERE cd.ecosystem = ?"
+		args = append(args, ecosystem)
+	}
+
+	if days > 0 {
+		if ecosystem != "" {
+			query += " AND"
+		} else {
+			query += " WHERE"
+		}
+		query += " CAST(julianday('now') - julianday(substr(COALESCE(lc.last_changed, '2000-01-01'), 1, 19)) AS INTEGER) >= ?"
+		args = append(args, days)
+	}
+
+	query += " ORDER BY days_since DESC, cd.name"
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []StaleEntry
+	for rows.Next() {
+		var e StaleEntry
+		var eco, req, lastChanged sql.NullString
+		var daysSince sql.NullInt64
+
+		if err := rows.Scan(&e.Name, &eco, &req, &e.ManifestPath, &lastChanged, &daysSince); err != nil {
+			return nil, err
+		}
+
+		if eco.Valid {
+			e.Ecosystem = eco.String
+		}
+		if req.Valid {
+			e.Requirement = req.String
+		}
+		if lastChanged.Valid {
+			e.LastChanged = lastChanged.String
+		}
+		if daysSince.Valid {
+			e.DaysSince = int(daysSince.Int64)
+		}
+
+		entries = append(entries, e)
+	}
+
+	return entries, rows.Err()
+}
+
+// GetDatabaseInfo returns metadata about the database.
+func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
+	info := &DatabaseInfo{
+		Path:      db.path,
+		RowCounts: make(map[string]int),
+	}
+
+	version, err := db.SchemaVersion()
+	if err != nil {
+		return nil, err
+	}
+	info.SchemaVersion = version
+
+	branchInfo, err := db.GetDefaultBranch()
+	if err == nil {
+		info.BranchName = branchInfo.Name
+		info.LastAnalyzedSHA = branchInfo.LastAnalyzedSHA
+	}
+
+	tables := []string{"branches", "commits", "branch_commits", "manifests", "dependency_changes", "dependency_snapshots", "packages", "versions"}
+	for _, table := range tables {
+		var count int
+		err := db.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
+		if err != nil {
+			continue
+		}
+		info.RowCounts[table] = count
+	}
+
+	rows, err := db.db.Query(`
+		SELECT ecosystem, COUNT(*) FROM dependency_snapshots
+		WHERE ecosystem IS NOT NULL AND ecosystem != ''
+		GROUP BY ecosystem
+		ORDER BY ecosystem
+	`)
+	if err == nil {
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var eco string
+			var count int
+			if rows.Scan(&eco, &count) == nil && eco != "" {
+				info.Ecosystems = append(info.Ecosystems, EcosystemCount{Name: eco, Count: count})
+			}
+		}
+	}
+
+	return info, nil
+}
+
+// GetVulnerabilitiesForPackage returns all vulnerabilities affecting a specific package.
+func (db *DB) GetVulnerabilitiesForPackage(ecosystem, packageName string) ([]Vulnerability, error) {
+	rows, err := db.db.Query(`
+		SELECT v.id, v.aliases, v.severity, v.cvss_score, v.cvss_vector, v.refs,
+		       v.summary, v.details, v.published_at, v.withdrawn_at, v.modified_at, v.fetched_at
+		FROM vulnerabilities v
+		JOIN vulnerability_packages vp ON vp.vulnerability_id = v.id
+		WHERE vp.ecosystem = ? AND vp.package_name = ?
+		ORDER BY v.cvss_score DESC, v.id
+	`, ecosystem, packageName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var vulns []Vulnerability
+	for rows.Next() {
+		var v Vulnerability
+		var aliases, refs sql.NullString
+		var severity, cvssVector, summary, details sql.NullString
+		var publishedAt, withdrawnAt, modifiedAt sql.NullString
+		var cvssScore sql.NullFloat64
+
+		if err := rows.Scan(&v.ID, &aliases, &severity, &cvssScore, &cvssVector, &refs,
+			&summary, &details, &publishedAt, &withdrawnAt, &modifiedAt, &v.FetchedAt); err != nil {
+			return nil, err
+		}
+
+		if aliases.Valid && aliases.String != "" {
+			v.Aliases = splitCommaList(aliases.String)
+		}
+		if refs.Valid && refs.String != "" {
+			v.References = splitCommaList(refs.String)
+		}
+		if severity.Valid {
+			v.Severity = severity.String
+		}
+		if cvssScore.Valid {
+			v.CVSSScore = cvssScore.Float64
+		}
+		if cvssVector.Valid {
+			v.CVSSVector = cvssVector.String
+		}
+		if summary.Valid {
+			v.Summary = summary.String
+		}
+		if details.Valid {
+			v.Details = details.String
+		}
+		if publishedAt.Valid {
+			v.PublishedAt = publishedAt.String
+		}
+		if withdrawnAt.Valid {
+			v.WithdrawnAt = withdrawnAt.String
+		}
+		if modifiedAt.Valid {
+			v.ModifiedAt = modifiedAt.String
+		}
+
+		vulns = append(vulns, v)
+	}
+
+	return vulns, rows.Err()
+}
+
+// GetVulnerabilityPackageInfo returns the affected package info for a vulnerability.
+func (db *DB) GetVulnerabilityPackageInfo(vulnID, ecosystem, packageName string) (*VulnerabilityPackage, error) {
+	var vp VulnerabilityPackage
+	var affectedVersions, fixedVersions sql.NullString
+
+	err := db.db.QueryRow(`
+		SELECT vulnerability_id, ecosystem, package_name, affected_versions, fixed_versions
+		FROM vulnerability_packages
+		WHERE vulnerability_id = ? AND ecosystem = ? AND package_name = ?
+	`, vulnID, ecosystem, packageName).Scan(&vp.VulnerabilityID, &vp.Ecosystem, &vp.PackageName,
+		&affectedVersions, &fixedVersions)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if affectedVersions.Valid {
+		vp.AffectedVersions = affectedVersions.String
+	}
+	if fixedVersions.Valid {
+		vp.FixedVersions = fixedVersions.String
+	}
+
+	return &vp, nil
+}
+
+// GetVulnSyncStatus returns packages that have vulnerability data.
+func (db *DB) GetVulnSyncStatus(branchID int64) ([]VulnSyncStatus, error) {
+	rows, err := db.db.Query(`
+		SELECT DISTINCT ds.ecosystem, ds.name
+		FROM dependency_snapshots ds
+		JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+		JOIN manifests m ON m.id = ds.manifest_id
+		WHERE bc.branch_id = ?
+		AND (m.kind = 'lockfile' OR (m.kind = 'manifest' AND m.ecosystem = 'golang'))
+		AND ds.ecosystem IS NOT NULL AND ds.ecosystem != ''
+		ORDER BY ds.ecosystem, ds.name
+	`, branchID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var statuses []VulnSyncStatus
+	for rows.Next() {
+		var s VulnSyncStatus
+		if err := rows.Scan(&s.Ecosystem, &s.PackageName); err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, s)
+	}
+
+	return statuses, rows.Err()
+}
+
+// GetStoredVulnCount returns the number of vulnerabilities stored for a package.
+func (db *DB) GetStoredVulnCount(ecosystem, packageName string) (int, error) {
+	var count int
+	err := db.db.QueryRow(`
+		SELECT COUNT(*)
+		FROM vulnerability_packages
+		WHERE ecosystem = ? AND package_name = ?
+	`, ecosystem, packageName).Scan(&count)
+	return count, err
+}
+
+// GetVulnerabilityStats returns vulnerability counts by severity for current dependencies.
+func (db *DB) GetVulnerabilityStats(branchID int64) (map[string]int, error) {
+	rows, err := db.db.Query(`
+		SELECT v.severity, COUNT(DISTINCT v.id)
+		FROM vulnerabilities v
+		JOIN vulnerability_packages vp ON vp.vulnerability_id = v.id
+		JOIN dependency_snapshots ds ON ds.ecosystem = vp.ecosystem AND ds.name = vp.package_name
+		JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+		JOIN manifests m ON m.id = ds.manifest_id
+		WHERE bc.branch_id = ?
+		AND bc.position = (SELECT MAX(position) FROM branch_commits WHERE branch_id = ?)
+		AND (m.kind = 'lockfile' OR (m.kind = 'manifest' AND m.ecosystem = 'golang'))
+		GROUP BY v.severity
+	`, branchID, branchID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	stats := make(map[string]int)
+	for rows.Next() {
+		var severity sql.NullString
+		var count int
+		if err := rows.Scan(&severity, &count); err != nil {
+			return nil, err
+		}
+		sev := "unknown"
+		if severity.Valid && severity.String != "" {
+			sev = severity.String
+		}
+		stats[sev] = count
+	}
+
+	return stats, rows.Err()
+}
+
+// GetVulnsSyncedAt returns when vulnerabilities were last synced for a package.
+func (db *DB) GetVulnsSyncedAt(purlStr string) (time.Time, error) {
+	var syncedAt sql.NullString
+	err := db.db.QueryRow(`
+		SELECT vulns_synced_at FROM packages
+		WHERE purl = ?
+		LIMIT 1
+	`, purlStr).Scan(&syncedAt)
+	if err == sql.ErrNoRows || !syncedAt.Valid {
+		return time.Time{}, nil
+	}
+	if err != nil {
+		return time.Time{}, err
+	}
+	t, _ := time.Parse(time.RFC3339, syncedAt.String)
+	return t, nil
+}
+
+// GetCachedPackages returns cached package data for the given PURLs that aren't stale.
+func (db *DB) GetCachedPackages(purls []string, staleDuration time.Duration) (map[string]*CachedPackage, error) {
+	if len(purls) == 0 {
+		return make(map[string]*CachedPackage), nil
+	}
+
+	staleThreshold := time.Now().Add(-staleDuration)
+	result := make(map[string]*CachedPackage)
+
+	const batchSize = 500
+	for i := 0; i < len(purls); i += batchSize {
+		end := i + batchSize
+		if end > len(purls) {
+			end = len(purls)
+		}
+		batch := purls[i:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch)+1)
+		args[0] = staleThreshold.Format(time.RFC3339)
+		for j, purl := range batch {
+			placeholders[j] = "?"
+			args[j+1] = purl
+		}
+
+		query := `SELECT purl, ecosystem, name, latest_version, license, enriched_at
+			FROM packages
+			WHERE enriched_at >= ? AND purl IN (` + strings.Join(placeholders, ",") + `)`
+
+		rows, err := db.db.Query(query, args...)
+		if err != nil {
+			return nil, err
+		}
+
+		for rows.Next() {
+			var cp CachedPackage
+			var latestVersion, license sql.NullString
+			var enrichedAt string
+			if err := rows.Scan(&cp.PURL, &cp.Ecosystem, &cp.Name, &latestVersion, &license, &enrichedAt); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			if latestVersion.Valid {
+				cp.LatestVersion = latestVersion.String
+			}
+			if license.Valid {
+				cp.License = license.String
+			}
+			cp.EnrichedAt, _ = time.Parse(time.RFC3339, enrichedAt)
+			result[cp.PURL] = &cp
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+
+	return result, nil
+}
+
+// GetCachedVersions returns cached version data for a package that isn't stale.
+func (db *DB) GetCachedVersions(packagePurl string, staleDuration time.Duration) ([]CachedVersion, error) {
+	staleThreshold := time.Now().Add(-staleDuration)
+
+	rows, err := db.db.Query(`
+		SELECT purl, package_purl, license, published_at
+		FROM versions
+		WHERE package_purl = ? AND enriched_at >= ?
+		ORDER BY published_at DESC`,
+		packagePurl, staleThreshold.Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []CachedVersion
+	for rows.Next() {
+		var cv CachedVersion
+		var license sql.NullString
+		var publishedAt string
+		if err := rows.Scan(&cv.PURL, &cv.PackagePURL, &license, &publishedAt); err != nil {
+			return nil, err
+		}
+		if license.Valid {
+			cv.License = license.String
+		}
+		cv.PublishedAt, _ = time.Parse(time.RFC3339, publishedAt)
+		result = append(result, cv)
+	}
+	return result, rows.Err()
+}
+
+// GetNote returns a note by PURL and namespace.
+func (db *DB) GetNote(purl, namespace string) (*Note, error) {
+	var n Note
+	var message, metadata sql.NullString
+	err := db.db.QueryRow(`
+		SELECT id, purl, namespace, origin, message, metadata, created_at, updated_at
+		FROM notes WHERE purl = ? AND namespace = ?
+	`, purl, namespace).Scan(&n.ID, &n.PURL, &n.Namespace, &n.Origin, &message, &metadata, &n.CreatedAt, &n.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if message.Valid {
+		n.Message = message.String
+	}
+	if metadata.Valid {
+		n.Metadata = decodeMetadata(metadata.String)
+	}
+	return &n, nil
+}
+
+// ListNotes returns notes filtered by namespace and/or PURL pattern.
+func (db *DB) ListNotes(namespace, purlFilter string) ([]Note, error) {
+	query := "SELECT id, purl, namespace, origin, message, metadata, created_at, updated_at FROM notes WHERE 1=1"
+	var args []any
+
+	if namespace != "" {
+		query += " AND namespace = ?"
+		args = append(args, namespace)
+	}
+	if purlFilter != "" {
+		query += " AND purl LIKE ?"
+		args = append(args, "%"+purlFilter+"%")
+	}
+
+	query += " ORDER BY purl, namespace"
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var notes []Note
+	for rows.Next() {
+		var n Note
+		var message, metadata sql.NullString
+		if err := rows.Scan(&n.ID, &n.PURL, &n.Namespace, &n.Origin, &message, &metadata, &n.CreatedAt, &n.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if message.Valid {
+			n.Message = message.String
+		}
+		if metadata.Valid {
+			n.Metadata = decodeMetadata(metadata.String)
+		}
+		notes = append(notes, n)
+	}
+	return notes, rows.Err()
+}
+
+// ListNoteNamespaces returns namespaces with their note counts.
+func (db *DB) ListNoteNamespaces(purlFilter string) ([]NamespaceCount, error) {
+	query := "SELECT namespace, COUNT(*) as count FROM notes"
+	var args []any
+	if purlFilter != "" {
+		query += " WHERE purl LIKE ?"
+		args = append(args, "%"+purlFilter+"%")
+	}
+	query += " GROUP BY namespace ORDER BY count DESC, namespace"
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []NamespaceCount
+	for rows.Next() {
+		var nc NamespaceCount
+		if err := rows.Scan(&nc.Namespace, &nc.Count); err != nil {
+			return nil, err
+		}
+		results = append(results, nc)
+	}
+	return results, rows.Err()
+}
+
+// GetMaxPosition returns the maximum position in branch_commits for a branch.
+func (db *DB) GetMaxPosition(branchID int64) (int, error) {
+	var position sql.NullInt64
+	err := db.db.QueryRow(
+		"SELECT MAX(position) FROM branch_commits WHERE branch_id = ?",
+		branchID,
+	).Scan(&position)
+	if err != nil {
+		return 0, err
+	}
+	if position.Valid {
+		return int(position.Int64), nil
+	}
+	return 0, nil
+}
+
+// GetCommitID returns the internal ID for a commit by SHA.
+func (db *DB) GetCommitID(sha string) (int64, error) {
+	var id int64
+	err := db.db.QueryRow("SELECT id FROM commits WHERE sha = ?", sha).Scan(&id)
+	return id, err
+}
+
+// GetCommitPosition returns the position of a commit in a branch.
+func (db *DB) GetCommitPosition(sha string, branchID int64) (int, error) {
+	var pos int
+	err := db.db.QueryRow(`
+		SELECT bc.position
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE c.sha = ? AND bc.branch_id = ?
+	`, sha, branchID).Scan(&pos)
+	return pos, err
+}
+
+// GetCommitAtPosition returns the SHA of the commit at a given position.
+func (db *DB) GetCommitAtPosition(position int, branchID int64) (string, error) {
+	var sha string
+	err := db.db.QueryRow(`
+		SELECT c.sha
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE bc.position = ? AND bc.branch_id = ?
+	`, position, branchID).Scan(&sha)
+	return sha, err
+}
+
+// GetLastSnapshot returns the most recent snapshot data for a branch.
+func (db *DB) GetLastSnapshot(branchID int64) (map[string]Dependency, error) {
+	var commitID int64
+	err := db.db.QueryRow(`
+		SELECT ds.commit_id
+		FROM dependency_snapshots ds
+		JOIN branch_commits bc ON bc.commit_id = ds.commit_id
+		WHERE bc.branch_id = ?
+		ORDER BY bc.position DESC
+		LIMIT 1
+	`, branchID).Scan(&commitID)
+	if err == sql.ErrNoRows {
+		return make(map[string]Dependency), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.db.Query(`
+		SELECT m.path, ds.name, ds.ecosystem, ds.purl, ds.requirement, ds.dependency_type, ds.integrity
+		FROM dependency_snapshots ds
+		JOIN manifests m ON m.id = ds.manifest_id
+		WHERE ds.commit_id = ?
+	`, commitID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string]Dependency)
+	for rows.Next() {
+		var path, name string
+		var d Dependency
+		var ecosystem, purl, requirement, depType, integrity sql.NullString
+
+		if err := rows.Scan(&path, &name, &ecosystem, &purl, &requirement, &depType, &integrity); err != nil {
+			return nil, err
+		}
+
+		d.ManifestPath = path
+		d.Name = name
+		if ecosystem.Valid {
+			d.Ecosystem = ecosystem.String
+		}
+		if purl.Valid {
+			d.PURL = purl.String
+		}
+		if requirement.Valid {
+			d.Requirement = requirement.String
+		}
+		if depType.Valid {
+			d.DependencyType = depType.String
+		}
+		if integrity.Valid {
+			d.Integrity = integrity.String
+		}
+
+		key := path + ":" + name + ":" + d.Requirement
+		result[key] = d
+	}
+
+	return result, rows.Err()
+}
+
+// GetBisectCandidates returns commits with dependency changes between two commits.
+func (db *DB) GetBisectCandidates(opts BisectOptions) ([]BisectCandidate, error) {
+	var startPos, endPos int
+	err := db.db.QueryRow(`
+		SELECT bc.position
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE c.sha = ? AND bc.branch_id = ?
+	`, opts.StartSHA, opts.BranchID).Scan(&startPos)
+	if err != nil {
+		return nil, fmt.Errorf("finding start commit position: %w", err)
+	}
+
+	err = db.db.QueryRow(`
+		SELECT bc.position
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		WHERE c.sha = ? AND bc.branch_id = ?
+	`, opts.EndSHA, opts.BranchID).Scan(&endPos)
+	if err != nil {
+		return nil, fmt.Errorf("finding end commit position: %w", err)
+	}
+
+	query := `
+		SELECT DISTINCT c.sha, c.message, bc.position
+		FROM commits c
+		JOIN branch_commits bc ON bc.commit_id = c.id
+		JOIN dependency_changes dc ON dc.commit_id = c.id
+		JOIN manifests m ON m.id = dc.manifest_id
+		WHERE bc.branch_id = ?
+		AND bc.position > ?
+		AND bc.position <= ?
+	`
+	args := []any{opts.BranchID, startPos, endPos}
+
+	if opts.Ecosystem != "" {
+		query += " AND dc.ecosystem = ?"
+		args = append(args, opts.Ecosystem)
+	}
+	if opts.PackageName != "" {
+		query += " AND dc.name = ?"
+		args = append(args, opts.PackageName)
+	}
+	if opts.ManifestPath != "" {
+		query += " AND m.path = ?"
+		args = append(args, opts.ManifestPath)
+	}
+
+	query += " ORDER BY bc.position ASC"
+
+	rows, err := db.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var candidates []BisectCandidate
+	for rows.Next() {
+		var c BisectCandidate
+		var message sql.NullString
+		if err := rows.Scan(&c.SHA, &message, &c.Position); err != nil {
+			return nil, err
+		}
+		if message.Valid {
+			c.Message = message.String
+		}
+		candidates = append(candidates, c)
+	}
+
+	return candidates, rows.Err()
+}

--- a/database/queries_test.go
+++ b/database/queries_test.go
@@ -173,6 +173,145 @@ func populatedDB(t *testing.T) (string, int64) {
 	return dbPath, branchID
 }
 
+func TestUpsertAndGetPackage(t *testing.T) {
+	dbPath := createTestDB(t)
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pkg := &database.Package{
+		PURL:      "pkg:npm/lodash",
+		Ecosystem: "npm",
+		Name:      "lodash",
+	}
+	pkg.LatestVersion.String = "4.17.21"
+	pkg.LatestVersion.Valid = true
+	pkg.License.String = "MIT"
+	pkg.License.Valid = true
+
+	err = db.UpsertPackage(pkg)
+	if err != nil {
+		t.Fatalf("upserting package: %v", err)
+	}
+
+	// Get by PURL
+	got, err := db.GetPackageByPURL("pkg:npm/lodash")
+	if err != nil {
+		t.Fatalf("getting package by purl: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected package, got nil")
+	}
+	if got.Name != "lodash" {
+		t.Errorf("name = %q, want %q", got.Name, "lodash")
+	}
+	if got.LatestVersion.String != "4.17.21" {
+		t.Errorf("latest_version = %q, want %q", got.LatestVersion.String, "4.17.21")
+	}
+
+	// Get by ecosystem/name
+	got, err = db.GetPackageByEcosystemName("npm", "lodash")
+	if err != nil {
+		t.Fatalf("getting package by ecosystem/name: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected package, got nil")
+	}
+	if got.PURL != "pkg:npm/lodash" {
+		t.Errorf("purl = %q, want %q", got.PURL, "pkg:npm/lodash")
+	}
+
+	// Upsert updates existing
+	pkg.LatestVersion.String = "4.18.0"
+	err = db.UpsertPackage(pkg)
+	if err != nil {
+		t.Fatalf("upserting package: %v", err)
+	}
+
+	got, err = db.GetPackageByPURL("pkg:npm/lodash")
+	if err != nil {
+		t.Fatalf("getting package: %v", err)
+	}
+	if got.LatestVersion.String != "4.18.0" {
+		t.Errorf("latest_version after upsert = %q, want %q", got.LatestVersion.String, "4.18.0")
+	}
+
+	// Non-existent returns nil
+	got, err = db.GetPackageByPURL("pkg:npm/nonexistent")
+	if err != nil {
+		t.Fatalf("getting nonexistent: %v", err)
+	}
+	if got != nil {
+		t.Error("expected nil for nonexistent package")
+	}
+}
+
+func TestUpsertAndGetVersion(t *testing.T) {
+	dbPath := createTestDB(t)
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// Insert parent package first
+	pkg := &database.Package{
+		PURL:      "pkg:npm/lodash",
+		Ecosystem: "npm",
+		Name:      "lodash",
+	}
+	if err := db.UpsertPackage(pkg); err != nil {
+		t.Fatalf("upserting package: %v", err)
+	}
+
+	v := &database.Version{
+		PURL:        "pkg:npm/lodash@4.17.21",
+		PackagePURL: "pkg:npm/lodash",
+	}
+	v.License.String = "MIT"
+	v.License.Valid = true
+
+	err = db.UpsertVersion(v)
+	if err != nil {
+		t.Fatalf("upserting version: %v", err)
+	}
+
+	// Get by PURL
+	got, err := db.GetVersionByPURL("pkg:npm/lodash@4.17.21")
+	if err != nil {
+		t.Fatalf("getting version: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected version, got nil")
+	}
+	if got.PackagePURL != "pkg:npm/lodash" {
+		t.Errorf("package_purl = %q, want %q", got.PackagePURL, "pkg:npm/lodash")
+	}
+	if got.VersionString() != "4.17.21" {
+		t.Errorf("VersionString() = %q, want %q", got.VersionString(), "4.17.21")
+	}
+
+	// Add another version
+	v2 := &database.Version{
+		PURL:        "pkg:npm/lodash@4.18.0",
+		PackagePURL: "pkg:npm/lodash",
+	}
+	if err := db.UpsertVersion(v2); err != nil {
+		t.Fatalf("upserting version: %v", err)
+	}
+
+	// Get all versions for package
+	versions, err := db.GetVersionsByPackagePURL("pkg:npm/lodash")
+	if err != nil {
+		t.Fatalf("getting versions: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("got %d versions, want 2", len(versions))
+	}
+}
+
 func TestGetBranch(t *testing.T) {
 	dbPath, _ := populatedDB(t)
 	db, err := database.OpenReadOnly(dbPath)

--- a/database/queries_test.go
+++ b/database/queries_test.go
@@ -34,7 +34,9 @@ func populatedDB(t *testing.T) (string, int64) {
 		t.Fatalf("getting branch: %v", err)
 	}
 	branchID := branch.ID
-	w.UseBranch(branchID)
+	if err := w.UseBranch(branchID); err != nil {
+		t.Fatalf("using branch: %v", err)
+	}
 
 	// Commit 1: adds two dependencies
 	commit1 := idb.CommitInfo{
@@ -130,7 +132,9 @@ func populatedDB(t *testing.T) (string, int64) {
 		t.Fatalf("updating branch: %v", err)
 	}
 
-	w.Close()
+	if err := w.Close(); err != nil {
+		t.Fatalf("closing writer: %v", err)
+	}
 
 	// Add a note
 	err = db.InsertNote(idb.Note{

--- a/database/queries_test.go
+++ b/database/queries_test.go
@@ -1,0 +1,755 @@
+package database_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/git-pkgs/git-pkgs/database"
+	idb "github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+// populatedDB creates a database with sample data for query testing.
+// Returns the path and the branch ID.
+func populatedDB(t *testing.T) (string, int64) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := idb.Create(dbPath)
+	if err != nil {
+		t.Fatalf("creating database: %v", err)
+	}
+
+	w, err := idb.NewWriter(db)
+	if err != nil {
+		t.Fatalf("creating writer: %v", err)
+	}
+
+	err = w.CreateBranch("main")
+	if err != nil {
+		t.Fatalf("creating branch: %v", err)
+	}
+
+	branch, err := db.GetBranch("main")
+	if err != nil {
+		t.Fatalf("getting branch: %v", err)
+	}
+	branchID := branch.ID
+	w.UseBranch(branchID)
+
+	// Commit 1: adds two dependencies
+	commit1 := idb.CommitInfo{
+		SHA:         "aaa111",
+		Message:     "Initial deps",
+		AuthorName:  "Alice",
+		AuthorEmail: "alice@example.com",
+		CommittedAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	commitID1, _, err := w.InsertCommit(commit1, true)
+	if err != nil {
+		t.Fatalf("inserting commit 1: %v", err)
+	}
+
+	manifest := idb.ManifestInfo{Path: "go.mod", Ecosystem: "golang", Kind: "manifest"}
+
+	err = w.InsertChange(commitID1, manifest, idb.ChangeInfo{
+		Name: "github.com/foo/bar", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/foo/bar", ChangeType: "added",
+		Requirement: "v1.0.0", DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting change: %v", err)
+	}
+	err = w.InsertChange(commitID1, manifest, idb.ChangeInfo{
+		Name: "github.com/baz/qux", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/baz/qux", ChangeType: "added",
+		Requirement: "v2.0.0", DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting change: %v", err)
+	}
+
+	err = w.InsertSnapshot(commitID1, manifest, idb.SnapshotInfo{
+		Name: "github.com/foo/bar", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/foo/bar", Requirement: "v1.0.0",
+		DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting snapshot: %v", err)
+	}
+	err = w.InsertSnapshot(commitID1, manifest, idb.SnapshotInfo{
+		Name: "github.com/baz/qux", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/baz/qux", Requirement: "v2.0.0",
+		DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting snapshot: %v", err)
+	}
+
+	// Commit 2: modifies one dependency
+	commit2 := idb.CommitInfo{
+		SHA:         "bbb222",
+		Message:     "Bump foo/bar",
+		AuthorName:  "Bob",
+		AuthorEmail: "bob@example.com",
+		CommittedAt: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	commitID2, _, err := w.InsertCommit(commit2, true)
+	if err != nil {
+		t.Fatalf("inserting commit 2: %v", err)
+	}
+
+	err = w.InsertChange(commitID2, manifest, idb.ChangeInfo{
+		Name: "github.com/foo/bar", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/foo/bar", ChangeType: "modified",
+		Requirement: "v1.1.0", PreviousRequirement: "v1.0.0",
+		DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting change: %v", err)
+	}
+
+	err = w.InsertSnapshot(commitID2, manifest, idb.SnapshotInfo{
+		Name: "github.com/foo/bar", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/foo/bar", Requirement: "v1.1.0",
+		DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting snapshot: %v", err)
+	}
+	err = w.InsertSnapshot(commitID2, manifest, idb.SnapshotInfo{
+		Name: "github.com/baz/qux", Ecosystem: "golang",
+		PURL: "pkg:golang/github.com/baz/qux", Requirement: "v2.0.0",
+		DependencyType: "runtime",
+	})
+	if err != nil {
+		t.Fatalf("inserting snapshot: %v", err)
+	}
+
+	err = w.UpdateBranchLastSHA("bbb222")
+	if err != nil {
+		t.Fatalf("updating branch: %v", err)
+	}
+
+	w.Close()
+
+	// Add a note
+	err = db.InsertNote(idb.Note{
+		PURL:      "pkg:golang/github.com/foo/bar",
+		Namespace: "license",
+		Origin:    "test",
+		Message:   "MIT license",
+		Metadata:  map[string]string{"source": "manual"},
+	})
+	if err != nil {
+		t.Fatalf("inserting note: %v", err)
+	}
+
+	// Add a vulnerability
+	err = db.InsertVulnerability(idb.Vulnerability{
+		ID:          "GHSA-1234",
+		Severity:    "high",
+		CVSSScore:   8.5,
+		Summary:     "Test vulnerability",
+		PublishedAt: "2025-01-15",
+		ModifiedAt:  "2025-01-15",
+		FetchedAt:   "2025-01-20",
+	})
+	if err != nil {
+		t.Fatalf("inserting vulnerability: %v", err)
+	}
+
+	err = db.InsertVulnerabilityPackage(idb.VulnerabilityPackage{
+		VulnerabilityID:  "GHSA-1234",
+		Ecosystem:        "golang",
+		PackageName:      "github.com/foo/bar",
+		AffectedVersions: "vers:golang/<1.2.0",
+		FixedVersions:    "1.2.0",
+	})
+	if err != nil {
+		t.Fatalf("inserting vuln package: %v", err)
+	}
+
+	_ = db.Close()
+	return dbPath, branchID
+}
+
+func TestGetBranch(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	branch, err := db.GetBranch("main")
+	if err != nil {
+		t.Fatalf("getting branch: %v", err)
+	}
+	if branch.Name != "main" {
+		t.Errorf("got branch name %q, want %q", branch.Name, "main")
+	}
+	if branch.LastAnalyzedSHA != "bbb222" {
+		t.Errorf("got last SHA %q, want %q", branch.LastAnalyzedSHA, "bbb222")
+	}
+}
+
+func TestGetDefaultBranch(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	branch, err := db.GetDefaultBranch()
+	if err != nil {
+		t.Fatalf("getting default branch: %v", err)
+	}
+	if branch.Name != "main" {
+		t.Errorf("got branch name %q, want %q", branch.Name, "main")
+	}
+}
+
+func TestGetBranches(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	branches, err := db.GetBranches()
+	if err != nil {
+		t.Fatalf("getting branches: %v", err)
+	}
+	if len(branches) != 1 {
+		t.Fatalf("got %d branches, want 1", len(branches))
+	}
+	if branches[0].CommitCount != 2 {
+		t.Errorf("got commit count %d, want 2", branches[0].CommitCount)
+	}
+}
+
+func TestGetLatestDependencies(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	deps, err := db.GetLatestDependencies(branchID)
+	if err != nil {
+		t.Fatalf("getting dependencies: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("got %d dependencies, want 2", len(deps))
+	}
+
+	// foo/bar should have been bumped to v1.1.0
+	for _, d := range deps {
+		if d.Name == "github.com/foo/bar" && d.Requirement != "v1.1.0" {
+			t.Errorf("foo/bar requirement = %q, want %q", d.Requirement, "v1.1.0")
+		}
+		if d.Name == "github.com/baz/qux" && d.Requirement != "v2.0.0" {
+			t.Errorf("baz/qux requirement = %q, want %q", d.Requirement, "v2.0.0")
+		}
+	}
+}
+
+func TestGetDependenciesAtCommit(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	deps, err := db.GetDependenciesAtCommit("aaa111")
+	if err != nil {
+		t.Fatalf("getting dependencies: %v", err)
+	}
+	if len(deps) != 2 {
+		t.Fatalf("got %d dependencies, want 2", len(deps))
+	}
+
+	for _, d := range deps {
+		if d.Name == "github.com/foo/bar" && d.Requirement != "v1.0.0" {
+			t.Errorf("foo/bar at commit 1 requirement = %q, want %q", d.Requirement, "v1.0.0")
+		}
+	}
+}
+
+func TestHasSnapshotForCommit(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	has, err := db.HasSnapshotForCommit("aaa111")
+	if err != nil {
+		t.Fatalf("checking snapshot: %v", err)
+	}
+	if !has {
+		t.Error("expected snapshot to exist for aaa111")
+	}
+
+	has, err = db.HasSnapshotForCommit("nonexistent")
+	if err != nil {
+		t.Fatalf("checking snapshot: %v", err)
+	}
+	if has {
+		t.Error("expected no snapshot for nonexistent commit")
+	}
+}
+
+func TestGetCommitsWithChanges(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	commits, err := db.GetCommitsWithChanges(database.LogOptions{BranchID: branchID})
+	if err != nil {
+		t.Fatalf("getting commits: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("got %d commits, want 2", len(commits))
+	}
+	// Most recent first
+	if commits[0].SHA != "bbb222" {
+		t.Errorf("first commit SHA = %q, want %q", commits[0].SHA, "bbb222")
+	}
+	if len(commits[0].Changes) != 1 {
+		t.Errorf("first commit has %d changes, want 1", len(commits[0].Changes))
+	}
+	if len(commits[1].Changes) != 2 {
+		t.Errorf("second commit has %d changes, want 2", len(commits[1].Changes))
+	}
+}
+
+func TestGetChangesForCommit(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	changes, err := db.GetChangesForCommit("bbb222")
+	if err != nil {
+		t.Fatalf("getting changes: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("got %d changes, want 1", len(changes))
+	}
+	if changes[0].ChangeType != "modified" {
+		t.Errorf("change type = %q, want %q", changes[0].ChangeType, "modified")
+	}
+	if changes[0].PreviousRequirement != "v1.0.0" {
+		t.Errorf("previous requirement = %q, want %q", changes[0].PreviousRequirement, "v1.0.0")
+	}
+}
+
+func TestGetPackageHistory(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	entries, err := db.GetPackageHistory(database.HistoryOptions{
+		BranchID:    branchID,
+		PackageName: "foo/bar",
+	})
+	if err != nil {
+		t.Fatalf("getting history: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	// Oldest first
+	if entries[0].ChangeType != "added" {
+		t.Errorf("first entry change type = %q, want %q", entries[0].ChangeType, "added")
+	}
+	if entries[1].ChangeType != "modified" {
+		t.Errorf("second entry change type = %q, want %q", entries[1].ChangeType, "modified")
+	}
+}
+
+func TestGetStats(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stats, err := db.GetStats(database.StatsOptions{BranchID: branchID})
+	if err != nil {
+		t.Fatalf("getting stats: %v", err)
+	}
+	if stats.Branch != "main" {
+		t.Errorf("branch = %q, want %q", stats.Branch, "main")
+	}
+	if stats.CommitsAnalyzed != 2 {
+		t.Errorf("commits analyzed = %d, want 2", stats.CommitsAnalyzed)
+	}
+	if stats.CommitsWithChanges != 2 {
+		t.Errorf("commits with changes = %d, want 2", stats.CommitsWithChanges)
+	}
+	if stats.TotalChanges != 3 {
+		t.Errorf("total changes = %d, want 3", stats.TotalChanges)
+	}
+}
+
+func TestGetAuthorStats(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stats, err := db.GetAuthorStats(database.StatsOptions{BranchID: branchID})
+	if err != nil {
+		t.Fatalf("getting author stats: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("got %d authors, want 2", len(stats))
+	}
+}
+
+func TestSearchDependencies(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	results, err := db.SearchDependencies(branchID, "foo", "", false)
+	if err != nil {
+		t.Fatalf("searching dependencies: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Name != "github.com/foo/bar" {
+		t.Errorf("result name = %q, want %q", results[0].Name, "github.com/foo/bar")
+	}
+}
+
+func TestGetWhy(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	result, err := db.GetWhy(branchID, "github.com/foo/bar", "golang")
+	if err != nil {
+		t.Fatalf("getting why: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if result.SHA != "aaa111" {
+		t.Errorf("SHA = %q, want %q", result.SHA, "aaa111")
+	}
+	if result.AuthorName != "Alice" {
+		t.Errorf("author = %q, want %q", result.AuthorName, "Alice")
+	}
+}
+
+func TestGetBlame(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	entries, err := db.GetBlame(branchID, "")
+	if err != nil {
+		t.Fatalf("getting blame: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestGetDatabaseInfo(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	info, err := db.GetDatabaseInfo()
+	if err != nil {
+		t.Fatalf("getting database info: %v", err)
+	}
+	if info.SchemaVersion != database.SchemaVersion {
+		t.Errorf("schema version = %d, want %d", info.SchemaVersion, database.SchemaVersion)
+	}
+	if info.BranchName != "main" {
+		t.Errorf("branch = %q, want %q", info.BranchName, "main")
+	}
+	if info.RowCounts["commits"] != 2 {
+		t.Errorf("commits row count = %d, want 2", info.RowCounts["commits"])
+	}
+}
+
+func TestGetNote(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	note, err := db.GetNote("pkg:golang/github.com/foo/bar", "license")
+	if err != nil {
+		t.Fatalf("getting note: %v", err)
+	}
+	if note == nil {
+		t.Fatal("expected note, got nil")
+	}
+	if note.Message != "MIT license" {
+		t.Errorf("message = %q, want %q", note.Message, "MIT license")
+	}
+	if note.Metadata["source"] != "manual" {
+		t.Errorf("metadata source = %q, want %q", note.Metadata["source"], "manual")
+	}
+}
+
+func TestListNotes(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	notes, err := db.ListNotes("license", "")
+	if err != nil {
+		t.Fatalf("listing notes: %v", err)
+	}
+	if len(notes) != 1 {
+		t.Fatalf("got %d notes, want 1", len(notes))
+	}
+}
+
+func TestListNoteNamespaces(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	namespaces, err := db.ListNoteNamespaces("")
+	if err != nil {
+		t.Fatalf("listing namespaces: %v", err)
+	}
+	if len(namespaces) != 1 {
+		t.Fatalf("got %d namespaces, want 1", len(namespaces))
+	}
+	if namespaces[0].Namespace != "license" {
+		t.Errorf("namespace = %q, want %q", namespaces[0].Namespace, "license")
+	}
+}
+
+func TestGetVulnerabilitiesForPackage(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	vulns, err := db.GetVulnerabilitiesForPackage("golang", "github.com/foo/bar")
+	if err != nil {
+		t.Fatalf("getting vulnerabilities: %v", err)
+	}
+	if len(vulns) != 1 {
+		t.Fatalf("got %d vulns, want 1", len(vulns))
+	}
+	if vulns[0].ID != "GHSA-1234" {
+		t.Errorf("vuln ID = %q, want %q", vulns[0].ID, "GHSA-1234")
+	}
+	if vulns[0].Severity != "high" {
+		t.Errorf("severity = %q, want %q", vulns[0].Severity, "high")
+	}
+}
+
+func TestGetVulnerabilityPackageInfo(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	vp, err := db.GetVulnerabilityPackageInfo("GHSA-1234", "golang", "github.com/foo/bar")
+	if err != nil {
+		t.Fatalf("getting vuln package info: %v", err)
+	}
+	if vp == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if vp.AffectedVersions != "vers:golang/<1.2.0" {
+		t.Errorf("affected versions = %q, want %q", vp.AffectedVersions, "vers:golang/<1.2.0")
+	}
+}
+
+func TestGetStoredVulnCount(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	count, err := db.GetStoredVulnCount("golang", "github.com/foo/bar")
+	if err != nil {
+		t.Fatalf("getting vuln count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+}
+
+func TestGetVulnerabilityStats(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	stats, err := db.GetVulnerabilityStats(branchID)
+	if err != nil {
+		t.Fatalf("getting vuln stats: %v", err)
+	}
+	if stats["high"] != 1 {
+		t.Errorf("high severity count = %d, want 1", stats["high"])
+	}
+}
+
+func TestGetMaxPosition(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pos, err := db.GetMaxPosition(branchID)
+	if err != nil {
+		t.Fatalf("getting max position: %v", err)
+	}
+	if pos != 2 {
+		t.Errorf("max position = %d, want 2", pos)
+	}
+}
+
+func TestGetCommitID(t *testing.T) {
+	dbPath, _ := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	id, err := db.GetCommitID("aaa111")
+	if err != nil {
+		t.Fatalf("getting commit ID: %v", err)
+	}
+	if id == 0 {
+		t.Error("expected non-zero commit ID")
+	}
+}
+
+func TestGetCommitPosition(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	pos, err := db.GetCommitPosition("aaa111", branchID)
+	if err != nil {
+		t.Fatalf("getting position: %v", err)
+	}
+	if pos != 1 {
+		t.Errorf("position = %d, want 1", pos)
+	}
+}
+
+func TestGetCommitAtPosition(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sha, err := db.GetCommitAtPosition(2, branchID)
+	if err != nil {
+		t.Fatalf("getting commit at position: %v", err)
+	}
+	if sha != "bbb222" {
+		t.Errorf("SHA = %q, want %q", sha, "bbb222")
+	}
+}
+
+func TestGetBisectCandidates(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	candidates, err := db.GetBisectCandidates(database.BisectOptions{
+		BranchID: branchID,
+		StartSHA: "aaa111",
+		EndSHA:   "bbb222",
+	})
+	if err != nil {
+		t.Fatalf("getting bisect candidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(candidates))
+	}
+	if candidates[0].SHA != "bbb222" {
+		t.Errorf("candidate SHA = %q, want %q", candidates[0].SHA, "bbb222")
+	}
+}
+
+func TestGetLastSnapshot(t *testing.T) {
+	dbPath, branchID := populatedDB(t)
+	db, err := database.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	snapshot, err := db.GetLastSnapshot(branchID)
+	if err != nil {
+		t.Fatalf("getting last snapshot: %v", err)
+	}
+	if len(snapshot) != 2 {
+		t.Fatalf("got %d snapshot entries, want 2", len(snapshot))
+	}
+}

--- a/database/types.go
+++ b/database/types.go
@@ -37,6 +37,7 @@ type Version struct {
 	License     sql.NullString `db:"license" json:"license,omitzero"`
 	PublishedAt sql.NullTime   `db:"published_at" json:"published_at,omitzero"`
 	Integrity   sql.NullString `db:"integrity" json:"integrity,omitzero"`
+	Yanked      bool           `db:"yanked" json:"yanked"`
 	Source      sql.NullString `db:"source" json:"source,omitzero"`
 	EnrichedAt  sql.NullTime   `db:"enriched_at" json:"enriched_at,omitzero"`
 	CreatedAt   time.Time      `db:"created_at" json:"created_at"`

--- a/database/types.go
+++ b/database/types.go
@@ -1,0 +1,251 @@
+package database
+
+import "time"
+
+type BranchInfo struct {
+	ID              int64  `json:"id"`
+	Name            string `json:"name"`
+	LastAnalyzedSHA string `json:"last_analyzed_sha"`
+	LastSHA         string `json:"last_sha,omitempty"`
+	CommitCount     int    `json:"commit_count"`
+}
+
+type Dependency struct {
+	Name           string `json:"name"`
+	Ecosystem      string `json:"ecosystem"`
+	PURL           string `json:"purl"`
+	Requirement    string `json:"requirement"`
+	DependencyType string `json:"dependency_type"`
+	Integrity      string `json:"integrity,omitempty"`
+	ManifestPath   string `json:"manifest_path"`
+	ManifestKind   string `json:"manifest_kind"`
+}
+
+type Change struct {
+	Name                string `json:"name"`
+	Ecosystem           string `json:"ecosystem"`
+	PURL                string `json:"purl"`
+	ChangeType          string `json:"change_type"`
+	Requirement         string `json:"requirement"`
+	PreviousRequirement string `json:"previous_requirement,omitempty"`
+	DependencyType      string `json:"dependency_type"`
+	ManifestPath        string `json:"manifest_path"`
+}
+
+type CommitWithChanges struct {
+	SHA         string   `json:"sha"`
+	Message     string   `json:"message"`
+	AuthorName  string   `json:"author_name"`
+	AuthorEmail string   `json:"author_email"`
+	CommittedAt string   `json:"committed_at"`
+	Changes     []Change `json:"changes"`
+}
+
+type LogOptions struct {
+	BranchID  int64
+	Ecosystem string
+	Author    string
+	Since     string
+	Until     string
+	Limit     int
+}
+
+type HistoryEntry struct {
+	SHA                 string `json:"sha"`
+	Message             string `json:"message"`
+	AuthorName          string `json:"author_name"`
+	AuthorEmail         string `json:"author_email"`
+	CommittedAt         string `json:"committed_at"`
+	Name                string `json:"name"`
+	Ecosystem           string `json:"ecosystem"`
+	ChangeType          string `json:"change_type"`
+	Requirement         string `json:"requirement"`
+	PreviousRequirement string `json:"previous_requirement,omitempty"`
+	ManifestPath        string `json:"manifest_path"`
+	ManifestKind        string `json:"manifest_kind"`
+}
+
+type HistoryOptions struct {
+	BranchID    int64
+	PackageName string
+	Ecosystem   string
+	Author      string
+	Since       string
+	Until       string
+}
+
+type BlameEntry struct {
+	Name         string `json:"name"`
+	Ecosystem    string `json:"ecosystem"`
+	Requirement  string `json:"requirement"`
+	ManifestPath string `json:"manifest_path"`
+	SHA          string `json:"sha"`
+	AuthorName   string `json:"author_name"`
+	AuthorEmail  string `json:"author_email"`
+	CommittedAt  string `json:"committed_at"`
+}
+
+type WhyResult struct {
+	Name         string `json:"name"`
+	Ecosystem    string `json:"ecosystem"`
+	ManifestPath string `json:"manifest_path"`
+	SHA          string `json:"sha"`
+	Message      string `json:"message"`
+	AuthorName   string `json:"author_name"`
+	AuthorEmail  string `json:"author_email"`
+	CommittedAt  string `json:"committed_at"`
+}
+
+type SearchResult struct {
+	Name         string `json:"name"`
+	Ecosystem    string `json:"ecosystem"`
+	Requirement  string `json:"requirement"`
+	FirstSeen    string `json:"first_seen"`
+	LastChanged  string `json:"last_changed"`
+	AddedIn      string `json:"added_in"`
+	ManifestKind string `json:"manifest_kind"`
+}
+
+type StaleEntry struct {
+	Name         string `json:"name"`
+	Ecosystem    string `json:"ecosystem"`
+	Requirement  string `json:"requirement"`
+	ManifestPath string `json:"manifest_path"`
+	LastChanged  string `json:"last_changed"`
+	DaysSince    int    `json:"days_since"`
+}
+
+type Stats struct {
+	Branch             string         `json:"branch"`
+	CommitsAnalyzed    int            `json:"commits_analyzed"`
+	CommitsWithChanges int            `json:"commits_with_changes"`
+	CurrentDeps        int            `json:"current_deps"`
+	DepsByEcosystem    map[string]int `json:"deps_by_ecosystem"`
+	TotalChanges       int            `json:"total_changes"`
+	ChangesByType      map[string]int `json:"changes_by_type"`
+	TopChanged         []NameCount    `json:"top_changed"`
+	TopAuthors         []NameCount    `json:"top_authors"`
+}
+
+type NameCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type AuthorStats struct {
+	Name    string         `json:"name"`
+	Email   string         `json:"email"`
+	Commits int            `json:"commits"`
+	Changes int            `json:"changes"`
+	ByType  map[string]int `json:"by_type"`
+}
+
+type StatsOptions struct {
+	BranchID  int64
+	Ecosystem string
+	Since     string
+	Until     string
+	Limit     int
+}
+
+type EcosystemCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type DatabaseInfo struct {
+	Path            string           `json:"path"`
+	SizeBytes       int64            `json:"size_bytes"`
+	SchemaVersion   int              `json:"schema_version"`
+	BranchName      string           `json:"branch_name"`
+	LastAnalyzedSHA string           `json:"last_analyzed_sha"`
+	RowCounts       map[string]int   `json:"row_counts"`
+	Ecosystems      []EcosystemCount `json:"ecosystems"`
+}
+
+type Vulnerability struct {
+	ID          string   `json:"id"`
+	Aliases     []string `json:"aliases,omitempty"`
+	Severity    string   `json:"severity"`
+	CVSSScore   float64  `json:"cvss_score"`
+	CVSSVector  string   `json:"cvss_vector,omitempty"`
+	References  []string `json:"references,omitempty"`
+	Summary     string   `json:"summary"`
+	Details     string   `json:"details,omitempty"`
+	PublishedAt string   `json:"published_at"`
+	WithdrawnAt string   `json:"withdrawn_at,omitempty"`
+	ModifiedAt  string   `json:"modified_at"`
+	FetchedAt   string   `json:"fetched_at"`
+}
+
+type VulnerabilityPackage struct {
+	VulnerabilityID  string `json:"vulnerability_id"`
+	Ecosystem        string `json:"ecosystem"`
+	PackageName      string `json:"package_name"`
+	AffectedVersions string `json:"affected_versions"`
+	FixedVersions    string `json:"fixed_versions"`
+}
+
+type VulnSyncStatus struct {
+	Ecosystem   string `json:"ecosystem"`
+	PackageName string `json:"package_name"`
+	SyncedAt    string `json:"synced_at"`
+	VulnCount   int    `json:"vuln_count"`
+}
+
+type CachedPackage struct {
+	PURL          string    `json:"purl"`
+	Ecosystem     string    `json:"ecosystem"`
+	Name          string    `json:"name"`
+	LatestVersion string    `json:"latest_version"`
+	License       string    `json:"license"`
+	EnrichedAt    time.Time `json:"enriched_at"`
+}
+
+type CachedVersion struct {
+	PURL        string    `json:"purl"`
+	PackagePURL string    `json:"package_purl"`
+	License     string    `json:"license"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+type PackageEnrichmentData struct {
+	PURL          string
+	Ecosystem     string
+	Name          string
+	LatestVersion string
+	License       string
+	RegistryURL   string
+	Source        string
+}
+
+type Note struct {
+	ID        int64             `json:"id"`
+	PURL      string            `json:"purl"`
+	Namespace string            `json:"namespace"`
+	Origin    string            `json:"origin"`
+	Message   string            `json:"message,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	CreatedAt string            `json:"created_at"`
+	UpdatedAt string            `json:"updated_at"`
+}
+
+type NamespaceCount struct {
+	Namespace string `json:"namespace"`
+	Count     int    `json:"count"`
+}
+
+type BisectCandidate struct {
+	SHA      string `json:"sha"`
+	Message  string `json:"message"`
+	Position int    `json:"position"`
+}
+
+type BisectOptions struct {
+	BranchID     int64
+	StartSHA     string
+	EndSHA       string
+	Ecosystem    string
+	PackageName  string
+	ManifestPath string
+}

--- a/database/types.go
+++ b/database/types.go
@@ -1,6 +1,58 @@
 package database
 
-import "time"
+import (
+	"database/sql"
+	"strings"
+	"time"
+)
+
+// Package represents a row in the packages table.
+// This type is shared between git-pkgs and the proxy.
+type Package struct {
+	ID            int64          `db:"id" json:"id"`
+	PURL          string         `db:"purl" json:"purl"`
+	Ecosystem     string         `db:"ecosystem" json:"ecosystem"`
+	Name          string         `db:"name" json:"name"`
+	LatestVersion sql.NullString `db:"latest_version" json:"latest_version,omitzero"`
+	License       sql.NullString `db:"license" json:"license,omitzero"`
+	Description   sql.NullString `db:"description" json:"description,omitzero"`
+	Homepage      sql.NullString `db:"homepage" json:"homepage,omitzero"`
+	RepositoryURL sql.NullString `db:"repository_url" json:"repository_url,omitzero"`
+	RegistryURL   sql.NullString `db:"registry_url" json:"registry_url,omitzero"`
+	SupplierName  sql.NullString `db:"supplier_name" json:"supplier_name,omitzero"`
+	SupplierType  sql.NullString `db:"supplier_type" json:"supplier_type,omitzero"`
+	Source        sql.NullString `db:"source" json:"source,omitzero"`
+	EnrichedAt    sql.NullTime   `db:"enriched_at" json:"enriched_at,omitzero"`
+	VulnsSyncedAt sql.NullTime   `db:"vulns_synced_at" json:"vulns_synced_at,omitzero"`
+	CreatedAt     time.Time      `db:"created_at" json:"created_at"`
+	UpdatedAt     time.Time      `db:"updated_at" json:"updated_at"`
+}
+
+// Version represents a row in the versions table.
+// This type is shared between git-pkgs and the proxy.
+type Version struct {
+	ID          int64          `db:"id" json:"id"`
+	PURL        string         `db:"purl" json:"purl"`
+	PackagePURL string         `db:"package_purl" json:"package_purl"`
+	License     sql.NullString `db:"license" json:"license,omitzero"`
+	PublishedAt sql.NullTime   `db:"published_at" json:"published_at,omitzero"`
+	Integrity   sql.NullString `db:"integrity" json:"integrity,omitzero"`
+	Source      sql.NullString `db:"source" json:"source,omitzero"`
+	EnrichedAt  sql.NullTime   `db:"enriched_at" json:"enriched_at,omitzero"`
+	CreatedAt   time.Time      `db:"created_at" json:"created_at"`
+	UpdatedAt   time.Time      `db:"updated_at" json:"updated_at"`
+}
+
+// VersionString extracts the version string from the PURL.
+// e.g., "pkg:npm/lodash@4.17.21" -> "4.17.21"
+func (v *Version) VersionString() string {
+	if idx := strings.LastIndex(v.PURL, "@"); idx >= 0 {
+		return v.PURL[idx+1:]
+	}
+	return ""
+}
+
+// Extension and query result types below.
 
 type BranchInfo struct {
 	ID              int64  `json:"id"`

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/git-pkgs/vers v0.2.3
 	github.com/git-pkgs/vulns v0.1.3
 	github.com/go-git/go-git/v5 v5.17.0
+	github.com/jmoiron/sqlx v1.4.0
 	github.com/mattn/go-isatty v0.0.20
 	github.com/spf13/cobra v1.10.2
 	modernc.org/sqlite v1.46.1

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ dev.gaijin.team/go/exhaustruct/v4 v4.0.0/go.mod h1:aZ/k2o4Y05aMJtiux15x8iXaumE88
 dev.gaijin.team/go/golib v0.6.0 h1:v6nnznFTs4bppib/NyU1PQxobwDHwCXXl15P7DV5Zgo=
 dev.gaijin.team/go/golib v0.6.0/go.mod h1:uY1mShx8Z/aNHWDyAkZTkX+uCi5PdX7KsG1eDQa2AVE=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/4meepo/tagalign v1.4.3 h1:Bnu7jGWwbfpAie2vyl63Zup5KuRv21olsPIha53BJr8=
 github.com/4meepo/tagalign v1.4.3/go.mod h1:00WwRjiuSbrRJnSVeGWPLp2epS5Q/l4UEy0apLLS37c=
 github.com/Abirdcfly/dupword v0.1.7 h1:2j8sInznrje4I0CMisSL6ipEBkeJUJAmK1/lfoNGWrQ=
@@ -264,6 +266,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
 github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
@@ -422,6 +426,8 @@ github.com/jingyugao/rowserrcheck v1.1.1 h1:zibz55j/MJtLsjP1OF4bSdgXxwL1b+Vn7Tjz
 github.com/jingyugao/rowserrcheck v1.1.1/go.mod h1:4yvlZSDb3IyDTUZJUmpZfm2Hwok+Dtp+nu2qOq+er9c=
 github.com/jjti/go-spancheck v0.6.5 h1:lmi7pKxa37oKYIMScialXUK6hP3iY5F1gu+mLBPgYB8=
 github.com/jjti/go-spancheck v0.6.5/go.mod h1:aEogkeatBrbYsyW6y5TgDfihCulDYciL1B7rG2vSsrU=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -475,6 +481,9 @@ github.com/ldez/usetesting v0.5.0 h1:3/QtzZObBKLy1F4F8jLuKJiKBjjVFi1IavpoWbmqLwc
 github.com/ldez/usetesting v0.5.0/go.mod h1:Spnb4Qppf8JTuRgblLrEWb7IE6rDmUpGvxY3iRrzvDQ=
 github.com/leonklingele/grouper v1.1.2 h1:o1ARBDLOmmasUaNDesWqWCIFH3u7hoFlM84YrjT3mIY=
 github.com/leonklingele/grouper v1.1.2/go.mod h1:6D0M/HVkhs2yRKRFZUoGjeDy7EZTfFBE9gl4kjmIGkA=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.11.1 h1:wuChtj2hfsGmmx3nf1m7xC2XpK6OtelS2shMY+bGMtI=
+github.com/lib/pq v1.11.1/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
@@ -499,6 +508,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgechev/revive v1.14.0 h1:CC2Ulb3kV7JFYt+izwORoS3VT/+Plb8BvslI/l1yZsc=

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -119,6 +119,7 @@ func (db *DB) CreateSchema() error {
 		license TEXT,
 		published_at DATETIME,
 		integrity TEXT,
+		yanked INTEGER DEFAULT 0,
 		source TEXT,
 		enriched_at DATETIME,
 		created_at DATETIME,


### PR DESCRIPTION
Adds `github.com/git-pkgs/git-pkgs/database` with typed, read-only query access to the dependency database. Extensions and external tools can import this instead of shelling out to CLI commands or opening raw SQLite connections.

- `OpenReadOnly` opens with `?mode=ro` and validates schema version on open
- `Open` skips validation for tools that manage their own write paths (e.g. proxy)
- `DB` struct wraps `*sql.DB` with a private field to prevent arbitrary SQL
- All read query methods duplicated from `internal/database` (branches, dependencies, changes, history, stats, search, blame, vulns, cache, notes, positions, bisect)
- Tests use `internal/database` to populate data, then read through the public package

Closes #116