### PR TITLE
Reindex all tracked branches when no -b flag is given

### DIFF
--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -449,8 +449,8 @@ func TestReindexCommand(t *testing.T) {
 			t.Fatalf("reindex failed: %v", err)
 		}
 
-		if !strings.Contains(stdout, "Already up to date") {
-			t.Errorf("expected 'Already up to date' message, got: %s", stdout)
+		if !strings.Contains(stdout, "up to date") {
+			t.Errorf("expected 'up to date' message, got: %s", stdout)
 		}
 	})
 

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -14,11 +14,13 @@ func addReindexCmd(parent *cobra.Command) {
 		Use:   "reindex",
 		Short: "Update database with new commits",
 		Long: `Incrementally update the git-pkgs database with commits since
-the last analysis. Use this after pulling new changes.`,
+the last analysis. Use this after pulling new changes.
+
+When no branch is specified, all tracked branches are updated.`,
 		RunE: runReindex,
 	}
 
-	reindexCmd.Flags().StringP("branch", "b", "", "Branch to reindex (default: tracked branch)")
+	reindexCmd.Flags().StringP("branch", "b", "", "Branch to reindex (default: all tracked branches)")
 	parent.AddCommand(reindexCmd)
 }
 
@@ -42,15 +44,30 @@ func runReindex(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = db.Close() }()
 
-	// If no branch specified, use the default tracked branch
-	if branch == "" {
-		branchInfo, err := db.GetDefaultBranch()
-		if err != nil {
-			return fmt.Errorf("no tracked branch found. Run 'git pkgs init' first")
-		}
-		branch = branchInfo.Name
+	if branch != "" {
+		return reindexBranch(cmd, repo, db, branch, quiet)
 	}
 
+	// No branch specified: reindex all tracked branches
+	branches, err := db.GetBranches()
+	if err != nil {
+		return fmt.Errorf("getting tracked branches: %w", err)
+	}
+
+	if len(branches) == 0 {
+		return fmt.Errorf("no tracked branches found. Run 'git pkgs init' first")
+	}
+
+	for _, b := range branches {
+		if err := reindexBranch(cmd, repo, db, b.Name, quiet); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func reindexBranch(cmd *cobra.Command, repo *git.Repository, db *database.DB, branch string, quiet bool) error {
 	_, branchErr := db.GetBranch(branch)
 	incremental := branchErr == nil
 
@@ -63,7 +80,7 @@ func runReindex(cmd *cobra.Command, args []string) error {
 
 	result, err := idx.Run()
 	if err != nil {
-		return fmt.Errorf("updating: %w", err)
+		return fmt.Errorf("updating %s: %w", branch, err)
 	}
 
 	if !quiet {
@@ -71,10 +88,10 @@ func runReindex(cmd *cobra.Command, args []string) error {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Added branch %q: %d commits, %d with dependency changes\n",
 				branch, result.CommitsAnalyzed, result.CommitsWithChanges)
 		} else if result.CommitsAnalyzed == 0 {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Already up to date.")
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: up to date\n", branch)
 		} else {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nDone! Analyzed %d new commits, found %d with dependency changes (%d total changes)\n",
-				result.CommitsAnalyzed, result.CommitsWithChanges, result.TotalChanges)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s: %d new commits, %d with dependency changes\n",
+				branch, result.CommitsAnalyzed, result.CommitsWithChanges)
 		}
 	}
 

--- a/cmd/reindex_test.go
+++ b/cmd/reindex_test.go
@@ -27,8 +27,115 @@ func TestReindex(t *testing.T) {
 			t.Fatalf("reindex failed: %v", err)
 		}
 
-		if !strings.Contains(stdout, "Analyzed") && !strings.Contains(stdout, "Already up to date") {
+		if !strings.Contains(stdout, "new commits") && !strings.Contains(stdout, "up to date") {
 			t.Errorf("unexpected output: %s", stdout)
+		}
+	})
+
+	t.Run("reindexes all tracked branches", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.21\n", "Initial commit")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		// Create a feature branch and add a commit with dependency changes
+		gitCmd := exec.Command("git", "checkout", "-b", "feature")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatalf("failed to create branch: %v", err)
+		}
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.22\n\nrequire golang.org/x/text v0.3.0\n", "Add dependency on feature")
+
+		// Track the feature branch
+		_, _, err = runCmd(t, "branch", "add", "feature")
+		if err != nil {
+			t.Fatalf("branch add failed: %v", err)
+		}
+
+		// Go back to main and add a commit
+		gitCmd = exec.Command("git", "checkout", "main")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatalf("failed to checkout main: %v", err)
+		}
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.22\n", "Bump go on main")
+
+		// Add another commit on feature
+		gitCmd = exec.Command("git", "checkout", "feature")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatalf("failed to checkout feature: %v", err)
+		}
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.22\n\nrequire golang.org/x/text v0.4.0\n", "Update dependency on feature")
+
+		// Reindex without -b should update both branches
+		stdout, _, err := runCmd(t, "reindex")
+		if err != nil {
+			t.Fatalf("reindex failed: %v", err)
+		}
+
+		if !strings.Contains(stdout, "feature") {
+			t.Errorf("expected output to mention feature branch, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "main") {
+			t.Errorf("expected output to mention main branch, got: %s", stdout)
+		}
+	})
+
+	t.Run("reindexes single branch with -b flag", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.21\n", "Initial commit")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		// Create feature branch and track it
+		gitCmd := exec.Command("git", "checkout", "-b", "feature")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatalf("failed to create branch: %v", err)
+		}
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.22\n", "Change on feature")
+
+		_, _, err = runCmd(t, "branch", "add", "feature")
+		if err != nil {
+			t.Fatalf("branch add failed: %v", err)
+		}
+
+		// Add another commit on feature
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.23\n", "Another change on feature")
+
+		// Add a commit on main too
+		gitCmd = exec.Command("git", "checkout", "main")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatalf("failed to checkout main: %v", err)
+		}
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.22\n", "Change on main")
+
+		// Reindex only feature branch
+		stdout, _, err := runCmd(t, "reindex", "-b", "feature")
+		if err != nil {
+			t.Fatalf("reindex -b feature failed: %v", err)
+		}
+
+		if !strings.Contains(stdout, "feature") {
+			t.Errorf("expected output to mention feature, got: %s", stdout)
+		}
+		// main should not have been updated
+		if strings.Contains(stdout, "main") {
+			t.Errorf("expected output to NOT mention main, got: %s", stdout)
 		}
 	})
 


### PR DESCRIPTION
Previously reindex only updated the default branch, so new commits on feature branches were silently ignored until the user ran `reindex -b` explicitly. Now it iterates over all tracked branches, matching how developers actually work with multiple branches.

Related to #164