### PR TITLE
Include dependency type in diff driver and show output

### DIFF
--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -214,6 +214,9 @@ func convertLockfile(cmd *cobra.Command, filePath string) error {
 		if dep.Version != "" {
 			line += " " + dep.Version
 		}
+		if dep.Scope != "" {
+			line += " (" + string(dep.Scope) + ")"
+		}
 		_, _ = fmt.Fprintln(w, Sanitize(line))
 	}
 	return w.Flush()

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -111,14 +111,15 @@ func getChangesForCommit(repo *git.Repository, commitRef string) ([]database.Cha
 	var changes []database.Change
 	for _, c := range result.Changes {
 		changes = append(changes, database.Change{
-			Name:                c.Name,
-			Ecosystem:           c.Ecosystem,
-			PURL:                c.PURL,
-			ChangeType:          c.ChangeType,
-			Requirement:         c.Requirement,
-			PreviousRequirement: c.PreviousRequirement,
-			DependencyType:      c.DependencyType,
-			ManifestPath:        c.ManifestPath,
+			Name:                   c.Name,
+			Ecosystem:              c.Ecosystem,
+			PURL:                   c.PURL,
+			ChangeType:             c.ChangeType,
+			Requirement:            c.Requirement,
+			PreviousRequirement:    c.PreviousRequirement,
+			DependencyType:         c.DependencyType,
+			PreviousDependencyType: c.PreviousDependencyType,
+			ManifestPath:           c.ManifestPath,
 		})
 	}
 
@@ -163,9 +164,12 @@ func outputShowText(cmd *cobra.Command, changes []database.Change) error {
 				line = fmt.Sprintf("    %s", c.Name)
 			}
 
-			if c.ChangeType == changeTypeModified && c.PreviousRequirement != "" {
+			switch {
+			case c.ChangeType == changeTypeModified && c.PreviousRequirement != "":
 				line += fmt.Sprintf(" %s -> %s", Dim(c.PreviousRequirement), c.Requirement)
-			} else if c.Requirement != "" {
+			case c.ChangeType == changeTypeModified && c.PreviousDependencyType != "":
+				line += fmt.Sprintf(" %s (%s -> %s)", c.Requirement, Dim(c.PreviousDependencyType), c.DependencyType)
+			case c.Requirement != "":
 				line += fmt.Sprintf(" %s", c.Requirement)
 			}
 

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -24,16 +24,17 @@ func isSupplementFile(path string) bool {
 }
 
 type Change struct {
-	ManifestPath        string
-	Ecosystem           string
-	Kind                string
-	Name                string
-	PURL                string
-	ChangeType          string // "added", "modified", "removed"
-	Requirement         string
-	PreviousRequirement string
-	DependencyType      string
-	Integrity           string
+	ManifestPath           string
+	Ecosystem              string
+	Kind                   string
+	Name                   string
+	PURL                   string
+	ChangeType             string // "added", "modified", "removed"
+	Requirement            string
+	PreviousRequirement    string
+	DependencyType         string
+	PreviousDependencyType string
+	Integrity              string
 }
 
 type SnapshotEntry struct {
@@ -398,16 +399,16 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				for _, before := range beforeVersions[dep.Name] {
 					if before.Version == dep.Version && before.Scope != dep.Scope {
 						result.Changes = append(result.Changes, Change{
-							ManifestPath:        path,
-							Ecosystem:           afterDeps.Ecosystem,
-							Kind:                string(afterDeps.Kind),
-							Name:                dep.Name,
-							PURL:                dep.PURL,
-							ChangeType:          "modified",
-							Requirement:         dep.Version,
-							PreviousRequirement: before.Version,
-							DependencyType:      string(dep.Scope),
-							Integrity:           integrity,
+							ManifestPath:           path,
+							Ecosystem:              afterDeps.Ecosystem,
+							Kind:                   string(afterDeps.Kind),
+							Name:                   dep.Name,
+							PURL:                   dep.PURL,
+							ChangeType:             "modified",
+							Requirement:            dep.Version,
+							DependencyType:         string(dep.Scope),
+							PreviousDependencyType: string(before.Scope),
+							Integrity:              integrity,
 						})
 						break
 					}

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -959,6 +959,99 @@ func TestMultipleVersionsSamePackage(t *testing.T) {
 	}
 }
 
+func TestScopeChangeTracksType(t *testing.T) {
+	// When npm restructures the dependency tree (e.g. after updating one package),
+	// dev/optional flags can change on many packages without their versions changing.
+	// These should be reported as modified with PreviousDependencyType set so the
+	// display can show what actually changed (e.g. "dev -> runtime").
+	//
+	// Scenario: express 4.18.0 -> 4.19.0 (version change)
+	//           debug, ms, accepts lose "dev": true (scope change, no version change)
+	repoDir := createTestRepo(t)
+	addFile(t, repoDir, "README.md", "# Test")
+	commit(t, repoDir, "Initial commit")
+
+	before, err := os.ReadFile("testdata/scope-change-before.json")
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+	addFile(t, repoDir, "package-lock.json", string(before))
+	firstSha := commit(t, repoDir, "Add lockfile")
+
+	after, err := os.ReadFile("testdata/scope-change-after.json")
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+	addFile(t, repoDir, "package-lock.json", string(after))
+	secondSha := commit(t, repoDir, "Update express")
+
+	repo := openRepo(t, repoDir)
+	a := analyzer.New()
+
+	firstHash := getCommit(t, firstSha)
+	firstCommit, _ := repo.CommitObject(*firstHash)
+	firstResult, err := a.AnalyzeCommit(firstCommit, nil)
+	if err != nil {
+		t.Fatalf("analyzing first commit: %v", err)
+	}
+
+	secondHash := getCommit(t, secondSha)
+	secondCommit, _ := repo.CommitObject(*secondHash)
+	result, err := a.AnalyzeCommit(secondCommit, firstResult.Snapshot)
+	if err != nil {
+		t.Fatalf("analyzing second commit: %v", err)
+	}
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Should have 4 modified changes: 1 version change + 3 scope changes
+	var modifiedChanges []analyzer.Change
+	for _, ch := range result.Changes {
+		if ch.ChangeType == "modified" {
+			modifiedChanges = append(modifiedChanges, ch)
+		}
+	}
+
+	if len(modifiedChanges) != 4 {
+		t.Fatalf("expected 4 modified changes, got %d: %+v", len(modifiedChanges), result.Changes)
+	}
+
+	// Check the version change (express)
+	var versionChanges, scopeChanges []analyzer.Change
+	for _, ch := range modifiedChanges {
+		if ch.PreviousRequirement != "" {
+			versionChanges = append(versionChanges, ch)
+		} else if ch.PreviousDependencyType != "" {
+			scopeChanges = append(scopeChanges, ch)
+		}
+	}
+
+	if len(versionChanges) != 1 {
+		t.Fatalf("expected 1 version change, got %d", len(versionChanges))
+	}
+	if versionChanges[0].Name != "express" {
+		t.Errorf("expected express version change, got %q", versionChanges[0].Name)
+	}
+	if versionChanges[0].PreviousRequirement != "4.18.0" || versionChanges[0].Requirement != "4.19.0" {
+		t.Errorf("expected 4.18.0 -> 4.19.0, got %s -> %s", versionChanges[0].PreviousRequirement, versionChanges[0].Requirement)
+	}
+
+	// Check scope changes have PreviousDependencyType set
+	if len(scopeChanges) != 3 {
+		t.Fatalf("expected 3 scope changes, got %d", len(scopeChanges))
+	}
+	for _, ch := range scopeChanges {
+		if ch.PreviousDependencyType != "development" {
+			t.Errorf("%s: expected PreviousDependencyType 'development', got %q", ch.Name, ch.PreviousDependencyType)
+		}
+		if ch.DependencyType != "runtime" {
+			t.Errorf("%s: expected DependencyType 'runtime', got %q", ch.Name, ch.DependencyType)
+		}
+	}
+}
+
 func TestDiffCacheEvictedAfterConsume(t *testing.T) {
 	repoDir := createTestRepo(t)
 	addFile(t, repoDir, "README.md", "# Test")

--- a/internal/analyzer/testdata/scope-change-after.json
+++ b/internal/analyzer/testdata/scope-change-after.json
@@ -1,0 +1,44 @@
+{
+  "name": "test-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-app",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.19.0"
+      },
+      "devDependencies": {
+        "mocha": "^10.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.0.tgz",
+      "integrity": "sha512-xyz999"
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-def456"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-ghi789"
+    },
+    "node_modules/mocha": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-jkl012",
+      "dev": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-mno345"
+    }
+  }
+}

--- a/internal/analyzer/testdata/scope-change-before.json
+++ b/internal/analyzer/testdata/scope-change-before.json
@@ -1,0 +1,47 @@
+{
+  "name": "test-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-app",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.0"
+      },
+      "devDependencies": {
+        "mocha": "^10.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.0.tgz",
+      "integrity": "sha512-abc123"
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-def456",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-ghi789",
+      "dev": true
+    },
+    "node_modules/mocha": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.0.0.tgz",
+      "integrity": "sha512-jkl012",
+      "dev": true
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-mno345",
+      "dev": true
+    }
+  }
+}

--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -28,14 +28,15 @@ type ManifestInfo struct {
 }
 
 type ChangeInfo struct {
-	ManifestPath        string
-	Name                string
-	Ecosystem           string
-	PURL                string
-	ChangeType          string
-	Requirement         string
-	PreviousRequirement string
-	DependencyType      string
+	ManifestPath           string
+	Name                   string
+	Ecosystem              string
+	PURL                   string
+	ChangeType             string
+	Requirement            string
+	PreviousRequirement    string
+	DependencyType         string
+	PreviousDependencyType string
 }
 
 type SnapshotInfo struct {
@@ -492,8 +493,8 @@ func (w *BatchWriter) insertChanges(tx *sql.Tx, commitIDs map[string]int64, now 
 		return nil
 	}
 
-	// Changes have 11 columns, so max rows per batch = MaxSQLVariables / 11
-	const columnsPerRow = 11
+	// Changes have 12 columns, so max rows per batch = MaxSQLVariables / 12
+	const columnsPerRow = 12
 	maxRowsPerBatch := MaxSQLVariables / columnsPerRow
 
 	for start := 0; start < len(pending); start += maxRowsPerBatch {
@@ -504,14 +505,14 @@ func (w *BatchWriter) insertChanges(tx *sql.Tx, commitIDs map[string]int64, now 
 		batch := pending[start:end]
 
 		var sb strings.Builder
-		sb.WriteString("INSERT INTO dependency_changes (commit_id, manifest_id, name, ecosystem, purl, change_type, requirement, previous_requirement, dependency_type, created_at, updated_at) VALUES ")
+		sb.WriteString("INSERT INTO dependency_changes (commit_id, manifest_id, name, ecosystem, purl, change_type, requirement, previous_requirement, dependency_type, previous_dependency_type, created_at, updated_at) VALUES ")
 
 		args := make([]any, 0, len(batch)*columnsPerRow)
 		for i, pc := range batch {
 			if i > 0 {
 				sb.WriteString(",")
 			}
-			sb.WriteString("(?,?,?,?,?,?,?,?,?,?,?)")
+			sb.WriteString("(?,?,?,?,?,?,?,?,?,?,?,?)")
 			args = append(args,
 				commitIDs[pc.sha],
 				w.manifestCache[pc.manifest.Path],
@@ -522,6 +523,7 @@ func (w *BatchWriter) insertChanges(tx *sql.Tx, commitIDs map[string]int64, now 
 				pc.change.Requirement,
 				pc.change.PreviousRequirement,
 				pc.change.DependencyType,
+				pc.change.PreviousDependencyType,
 				now,
 				now,
 			)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 8
+const SchemaVersion = 9
 
 type DB struct {
 	*sql.DB

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -368,14 +368,15 @@ func (db *DB) getDependenciesForCommitID(commitID int64) ([]Dependency, error) {
 }
 
 type Change struct {
-	Name                string `json:"name"`
-	Ecosystem           string `json:"ecosystem"`
-	PURL                string `json:"purl"`
-	ChangeType          string `json:"change_type"`
-	Requirement         string `json:"requirement"`
-	PreviousRequirement string `json:"previous_requirement,omitempty"`
-	DependencyType      string `json:"dependency_type"`
-	ManifestPath        string `json:"manifest_path"`
+	Name                   string `json:"name"`
+	Ecosystem              string `json:"ecosystem"`
+	PURL                   string `json:"purl"`
+	ChangeType             string `json:"change_type"`
+	Requirement            string `json:"requirement"`
+	PreviousRequirement    string `json:"previous_requirement,omitempty"`
+	DependencyType         string `json:"dependency_type"`
+	PreviousDependencyType string `json:"previous_dependency_type,omitempty"`
+	ManifestPath           string `json:"manifest_path"`
 }
 
 type CommitWithChanges struct {
@@ -1329,7 +1330,7 @@ func (db *DB) GetPackageHistory(opts HistoryOptions) ([]HistoryEntry, error) {
 
 func (db *DB) GetChangesForCommit(sha string) ([]Change, error) {
 	rows, err := db.Query(`
-		SELECT dc.name, dc.ecosystem, dc.purl, dc.change_type, dc.requirement, dc.previous_requirement, dc.dependency_type, m.path
+		SELECT dc.name, dc.ecosystem, dc.purl, dc.change_type, dc.requirement, dc.previous_requirement, dc.dependency_type, dc.previous_dependency_type, m.path
 		FROM dependency_changes dc
 		JOIN commits c ON c.id = dc.commit_id
 		JOIN manifests m ON m.id = dc.manifest_id
@@ -1344,9 +1345,9 @@ func (db *DB) GetChangesForCommit(sha string) ([]Change, error) {
 	var changes []Change
 	for rows.Next() {
 		var c Change
-		var ecosystem, purl, requirement, prevReq, depType sql.NullString
+		var ecosystem, purl, requirement, prevReq, depType, prevDepType sql.NullString
 
-		if err := rows.Scan(&c.Name, &ecosystem, &purl, &c.ChangeType, &requirement, &prevReq, &depType, &c.ManifestPath); err != nil {
+		if err := rows.Scan(&c.Name, &ecosystem, &purl, &c.ChangeType, &requirement, &prevReq, &depType, &prevDepType, &c.ManifestPath); err != nil {
 			return nil, err
 		}
 
@@ -1364,6 +1365,9 @@ func (db *DB) GetChangesForCommit(sha string) ([]Change, error) {
 		}
 		if depType.Valid {
 			c.DependencyType = depType.String
+		}
+		if prevDepType.Valid {
+			c.PreviousDependencyType = prevDepType.String
 		}
 
 		changes = append(changes, c)
@@ -1386,7 +1390,7 @@ func (db *DB) GetChangesForCommits(shas []string) (map[string][]Change, error) {
 	}
 
 	query := fmt.Sprintf(`
-		SELECT c.sha, dc.name, dc.ecosystem, dc.purl, dc.change_type, dc.requirement, dc.previous_requirement, dc.dependency_type, m.path
+		SELECT c.sha, dc.name, dc.ecosystem, dc.purl, dc.change_type, dc.requirement, dc.previous_requirement, dc.dependency_type, dc.previous_dependency_type, m.path
 		FROM dependency_changes dc
 		JOIN commits c ON c.id = dc.commit_id
 		JOIN manifests m ON m.id = dc.manifest_id
@@ -1404,9 +1408,9 @@ func (db *DB) GetChangesForCommits(shas []string) (map[string][]Change, error) {
 	for rows.Next() {
 		var sha string
 		var ch Change
-		var ecosystem, purl, requirement, prevReq, depType sql.NullString
+		var ecosystem, purl, requirement, prevReq, depType, prevDepType sql.NullString
 
-		if err := rows.Scan(&sha, &ch.Name, &ecosystem, &purl, &ch.ChangeType, &requirement, &prevReq, &depType, &ch.ManifestPath); err != nil {
+		if err := rows.Scan(&sha, &ch.Name, &ecosystem, &purl, &ch.ChangeType, &requirement, &prevReq, &depType, &prevDepType, &ch.ManifestPath); err != nil {
 			return nil, err
 		}
 
@@ -1424,6 +1428,9 @@ func (db *DB) GetChangesForCommits(shas []string) (map[string][]Change, error) {
 		}
 		if depType.Valid {
 			ch.DependencyType = depType.String
+		}
+		if prevDepType.Valid {
+			ch.PreviousDependencyType = prevDepType.String
 		}
 
 		result[sha] = append(result[sha], ch)

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -64,6 +64,7 @@ func (db *DB) CreateSchema() error {
 		requirement TEXT,
 		previous_requirement TEXT,
 		dependency_type TEXT,
+		previous_dependency_type TEXT,
 		created_at DATETIME,
 		updated_at DATETIME
 	);

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -203,14 +203,15 @@ func (idx *Indexer) Run() (*Result, error) {
 						Kind:      change.Kind,
 					}
 					changeInfo := database.ChangeInfo{
-						ManifestPath:        change.ManifestPath,
-						Name:                change.Name,
-						Ecosystem:           change.Ecosystem,
-						PURL:                change.PURL,
-						ChangeType:          change.ChangeType,
-						Requirement:         change.Requirement,
-						PreviousRequirement: change.PreviousRequirement,
-						DependencyType:      change.DependencyType,
+						ManifestPath:           change.ManifestPath,
+						Name:                   change.Name,
+						Ecosystem:              change.Ecosystem,
+						PURL:                   change.PURL,
+						ChangeType:             change.ChangeType,
+						Requirement:            change.Requirement,
+						PreviousRequirement:    change.PreviousRequirement,
+						DependencyType:         change.DependencyType,
+						PreviousDependencyType: change.PreviousDependencyType,
 					}
 					writer.AddChange(sha, manifest, changeInfo)
 				}


### PR DESCRIPTION
The diff driver and the analyzer were not aligned on what constitutes a change. The diff driver output `name version` without scope, making scope changes invisible in git diffs. Meanwhile the analyzer reported scope-only changes as modified with identical before/after versions (`package 1.0.0 -> 1.0.0`), which was confusing.

Now both include dependency type. The diff driver outputs `name version (scope)` so scope changes appear in diffs. The show command displays scope-only changes as `package 1.0.0 (dev -> runtime)`.

Bumps schema to v9 with a `previous_dependency_type` column on `dependency_changes`.

Related to #164