### PR TITLE
Sign release checksums with cosign keyless

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -17,6 +18,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - uses: sigstore/cosign-installer@d7543c93d881b35a8faa02e8e3605f69b7a1ce62 # v3.10.0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,18 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+signs:
+  - cmd: cosign
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: checksum
+    output: true
+
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
 


### PR DESCRIPTION
Adds cosign keyless signing to releases. The workflow gets an OIDC token from GitHub, exchanges it with Fulcio for a short-lived cert bound to this repo/workflow/commit, and signs `checksums.txt`. Signature and cert get uploaded alongside the release assets, entry goes to Rekor.

No keys to manage. Users verify with:

```
cosign verify-blob \
  --certificate checksums.txt.pem \
  --signature checksums.txt.sig \
  --certificate-identity-regexp '^https://github.com/git-pkgs/git-pkgs/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  checksums.txt
```

Only signs the checksum file since it chains trust to all the archives.