### PR TITLE
Scope working-dir manifest reads with os.Root

### DIFF
--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -675,8 +676,25 @@ func (a *Analyzer) parseSupplementsInDir(tree *object.Tree, dir string) map[supp
 	return hashes
 }
 
+func readFileInRoot(r *os.Root, name string) ([]byte, error) {
+	f, err := r.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return io.ReadAll(f)
+}
+
 func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool) ([]Change, error) {
 	var deps []Change
+
+	// Scope all file reads to the repo directory. Manifest paths are
+	// repo-controlled; a symlink named like a manifest could point anywhere.
+	osRoot, err := os.OpenRoot(root)
+	if err != nil {
+		return nil, fmt.Errorf("opening root %q: %w", root, err)
+	}
+	defer func() { _ = osRoot.Close() }()
 
 	// Load gitignore patterns and submodule paths
 	matcher := gitignore.New(root)
@@ -697,17 +715,17 @@ func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool)
 		}
 	}
 
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}
 
-		relPath, err := filepath.Rel(root, path)
+		osRel, err := filepath.Rel(root, path)
 		if err != nil {
 			return nil
 		}
 		// Normalize to forward slashes for cross-platform consistency with git paths
-		relPath = filepath.ToSlash(relPath)
+		relPath := filepath.ToSlash(osRel)
 
 		if info.IsDir() {
 			// Always skip .git
@@ -746,7 +764,7 @@ func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool)
 			return nil
 		}
 
-		content, err := os.ReadFile(path)
+		content, err := readFileInRoot(osRoot, osRel)
 		if err != nil {
 			return nil
 		}
@@ -757,7 +775,7 @@ func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool)
 		}
 
 		// Look for supplement files in the same directory
-		supHashes := a.parseSupplementsInWorkingDir(filepath.Dir(path), filepath.Dir(relPath))
+		supHashes := a.parseSupplementsInWorkingDir(osRoot, filepath.Dir(osRel), filepath.Dir(relPath))
 
 		for _, dep := range result.Dependencies {
 			integrity := dep.Integrity
@@ -784,10 +802,15 @@ func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool)
 	return deps, err
 }
 
-func (a *Analyzer) parseSupplementsInWorkingDir(absDir, relDir string) map[supplementKey]string {
+func (a *Analyzer) parseSupplementsInWorkingDir(osRoot *os.Root, osDir, relDir string) map[supplementKey]string {
 	hashes := make(map[supplementKey]string)
 
-	entries, err := os.ReadDir(absDir)
+	d, err := osRoot.Open(osDir)
+	if err != nil {
+		return hashes
+	}
+	entries, err := d.ReadDir(-1)
+	_ = d.Close()
 	if err != nil {
 		return hashes
 	}
@@ -801,7 +824,7 @@ func (a *Analyzer) parseSupplementsInWorkingDir(absDir, relDir string) map[suppl
 			continue
 		}
 
-		content, err := os.ReadFile(filepath.Join(absDir, entry.Name()))
+		content, err := readFileInRoot(osRoot, filepath.Join(osDir, entry.Name()))
 		if err != nil {
 			continue
 		}

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -679,6 +680,57 @@ jobs:
 	}
 	if names["puma"] {
 		t.Error("expected puma from vendor/Gemfile to be ignored")
+	}
+}
+
+func TestDependenciesInWorkingDirRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevation on windows")
+	}
+
+	repoDir := createTestRepo(t)
+	addFile(t, repoDir, "README.md", "# Test")
+	commit(t, repoDir, "Initial commit")
+
+	// Real manifest in a subdir to confirm the analyzer still works
+	addFile(t, repoDir, "app/package.json", samplePackageJSON(map[string]string{
+		"lodash": "^4.17.21",
+	}))
+
+	// Valid manifest content sitting outside the repo
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.json")
+	if err := os.WriteFile(secret, []byte(samplePackageJSON(map[string]string{
+		"escaped-symlink-marker": "1.0.0",
+	})), 0644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	// Symlink at the repo root named like a manifest, pointing outside
+	if err := os.Symlink(secret, filepath.Join(repoDir, "package.json")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	a := analyzer.New()
+	deps, err := a.DependenciesInWorkingDir(repoDir, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, d := range deps {
+		if d.Name == "escaped-symlink-marker" {
+			t.Fatalf("symlink escaped repo root, read %s", secret)
+		}
+	}
+
+	var found bool
+	for _, d := range deps {
+		if d.Name == "lodash" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected lodash from app/package.json, got %+v", deps)
 	}
 }
 


### PR DESCRIPTION
`DependenciesInWorkingDir` walks the repo and reads anything that looks like a manifest. A repo can contain a symlink named `package.json` pointing at `~/.aws/credentials` or anything else, and `os.ReadFile` follows it. The content goes through the manifest parser and fragments may end up in the sqlite index.

Switched both read sites to go through `os.Root` so anything resolving outside the repo dir gets `ErrInvalid` and is skipped like any other unreadable file.

Test creates a valid manifest outside the repo with a marker dependency, symlinks to it from inside, and asserts the marker never shows up in results. Fails on `main`.