### PR TITLE
sbom: emit via github.com/git-pkgs/sbom

### DIFF
--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"time"
 
@@ -11,6 +9,7 @@ import (
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/sbom"
 	"github.com/spf13/cobra"
 )
 
@@ -34,90 +33,6 @@ The SBOM includes all dependencies and optionally enriched license information.`
 	parent.AddCommand(sbomCmd)
 }
 
-// CycloneDX BOM structure
-type CycloneDXBOM struct {
-	XMLName      xml.Name              `xml:"bom" json:"-"`
-	XMLNS        string                `xml:"xmlns,attr" json:"-"`
-	Version      int                   `xml:"version,attr" json:"version"`
-	BOMFormat    string                `xml:"-" json:"bomFormat"`
-	SpecVersion  string                `xml:"-" json:"specVersion"`
-	SerialNumber string                `xml:"serialNumber,attr,omitempty" json:"serialNumber,omitempty"`
-	Metadata     *CycloneDXMetadata    `xml:"metadata,omitempty" json:"metadata,omitempty"`
-	Components   []CycloneDXComponent  `xml:"components>component" json:"components"`
-	Dependencies []CycloneDXDependency `xml:"dependencies>dependency,omitempty" json:"dependencies,omitempty"`
-}
-
-type CycloneDXMetadata struct {
-	Timestamp string              `xml:"timestamp" json:"timestamp"`
-	Tools     []CycloneDXTool     `xml:"tools>tool,omitempty" json:"tools,omitempty"`
-	Component *CycloneDXComponent `xml:"component,omitempty" json:"component,omitempty"`
-}
-
-type CycloneDXTool struct {
-	Vendor  string `xml:"vendor" json:"vendor"`
-	Name    string `xml:"name" json:"name"`
-	Version string `xml:"version" json:"version"`
-}
-
-type CycloneDXComponent struct {
-	Type        string             `xml:"type,attr" json:"type"`
-	BOMRef      string             `xml:"bom-ref,attr,omitempty" json:"bom-ref,omitempty"`
-	Name        string             `xml:"name" json:"name"`
-	Version     string             `xml:"version,omitempty" json:"version,omitempty"`
-	PURL        string             `xml:"purl,omitempty" json:"purl,omitempty"`
-	Licenses    []CycloneDXLicense `xml:"licenses>license,omitempty" json:"licenses,omitempty"`
-	Description string             `xml:"description,omitempty" json:"description,omitempty"`
-}
-
-type CycloneDXLicense struct {
-	ID   string `xml:"id,omitempty" json:"id,omitempty"`
-	Name string `xml:"name,omitempty" json:"name,omitempty"`
-}
-
-type CycloneDXDependency struct {
-	Ref       string   `xml:"ref,attr" json:"ref"`
-	DependsOn []string `xml:"dependency,omitempty" json:"dependsOn,omitempty"`
-}
-
-// SPDX structure
-type SPDXSBOM struct {
-	SPDXVersion       string             `json:"spdxVersion"`
-	DataLicense       string             `json:"dataLicense"`
-	SPDXID            string             `json:"SPDXID"`
-	Name              string             `json:"name"`
-	DocumentNamespace string             `json:"documentNamespace"`
-	CreationInfo      SPDXCreationInfo   `json:"creationInfo"`
-	Packages          []SPDXPackage      `json:"packages"`
-	Relationships     []SPDXRelationship `json:"relationships,omitempty"`
-}
-
-type SPDXCreationInfo struct {
-	Created  string   `json:"created"`
-	Creators []string `json:"creators"`
-}
-
-type SPDXPackage struct {
-	SPDXID           string            `json:"SPDXID"`
-	Name             string            `json:"name"`
-	VersionInfo      string            `json:"versionInfo,omitempty"`
-	DownloadLocation string            `json:"downloadLocation"`
-	LicenseConcluded string            `json:"licenseConcluded,omitempty"`
-	LicenseDeclared  string            `json:"licenseDeclared,omitempty"`
-	ExternalRefs     []SPDXExternalRef `json:"externalRefs,omitempty"`
-}
-
-type SPDXExternalRef struct {
-	ReferenceCategory string `json:"referenceCategory"`
-	ReferenceType     string `json:"referenceType"`
-	ReferenceLocator  string `json:"referenceLocator"`
-}
-
-type SPDXRelationship struct {
-	SPDXElementID      string `json:"spdxElementId"`
-	RelationshipType   string `json:"relationshipType"`
-	RelatedSPDXElement string `json:"relatedSpdxElement"`
-}
-
 func runSBOM(cmd *cobra.Command, args []string) error {
 	sbomType, _ := cmd.Flags().GetString("type")
 	format, _ := cmd.Flags().GetString("format")
@@ -127,6 +42,11 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 	projectName, _ := cmd.Flags().GetString("name")
 	projectVersion, _ := cmd.Flags().GetString("version")
 	skipEnrichment, _ := cmd.Flags().GetBool("skip-enrichment")
+
+	out, err := sbomFormat(sbomType, format)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {
@@ -143,42 +63,82 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 
 	deps = filterByEcosystem(deps, ecosystem)
 
-	// Get licenses from cache or ecosyste.ms if not skipped
-	licenseMap := make(map[string][]string)
+	licenseMap := map[string]string{}
 	if !skipEnrichment {
-		purls := make([]string, 0, len(deps))
-		purlToDep := make(map[string]database.Dependency)
-		for _, d := range deps {
-			// Use versionless PURL for cache lookup
-			purlStr := purl.MakePURLString(d.Ecosystem, d.Name, "")
-			if purlStr != "" {
-				purls = append(purls, purlStr)
-				purlToDep[purlStr] = d
-			}
-		}
-
-		if len(purls) > 0 {
-			data, err := getSBOMLicenseData(db, purls, purlToDep)
-			if err == nil {
-				for purl, license := range data {
-					if license != "" {
-						licenseMap[purl] = []string{license}
-					}
-				}
-			}
-		}
+		licenseMap = enrichLicenses(db, deps)
 	}
 
 	if projectName == "" {
 		projectName = "project"
 	}
 
-	switch sbomType {
-	case "spdx":
-		return generateSPDX(cmd, deps, licenseMap, projectName, projectVersion, format)
+	doc := buildSBOM(deps, licenseMap, projectName, projectVersion)
+	return sbom.Encode(cmd.OutOrStdout(), doc, out)
+}
+
+func sbomFormat(sbomType, format string) (sbom.Format, error) {
+	switch {
+	case sbomType == "spdx" && format == "json":
+		return sbom.FormatSPDXJSON, nil
+	case sbomType == "spdx":
+		return 0, fmt.Errorf("SPDX %s format not supported, use json", format)
+	case format == "xml":
+		return sbom.FormatCycloneDXXML, nil
 	default:
-		return generateCycloneDX(cmd, deps, licenseMap, projectName, projectVersion, format)
+		return sbom.FormatCycloneDXJSON, nil
 	}
+}
+
+func buildSBOM(deps []database.Dependency, licenses map[string]string, name, ver string) *sbom.SBOM {
+	s := sbom.New(sbom.TypeCycloneDX)
+	s.Document = sbom.Document{
+		Name:      name,
+		Namespace: "https://git-pkgs.example.com/" + name,
+		Component: sbom.Component{Type: "application", Name: name, Version: ver},
+		Creators:  []sbom.Creator{{Type: "Tool", Name: "git-pkgs-" + version}},
+	}
+	for _, d := range deps {
+		purlStr := d.PURL
+		if purlStr == "" {
+			purlStr = purl.MakePURLString(d.Ecosystem, d.Name, d.Requirement)
+		}
+		p := sbom.Package{
+			Name:    d.Name,
+			Version: d.Requirement,
+		}
+		if purlStr != "" {
+			p.ExternalRefs = []sbom.ExternalRef{{
+				Category: "PACKAGE_MANAGER", Type: "purl", Locator: purlStr,
+			}}
+		}
+		licKey := purl.MakePURLString(d.Ecosystem, d.Name, "")
+		if lic := licenses[licKey]; lic != "" {
+			p.LicenseConcluded = lic
+			p.LicenseDeclared = lic
+		}
+		s.AddPackage(p)
+	}
+	return s
+}
+
+func enrichLicenses(db *database.DB, deps []database.Dependency) map[string]string {
+	purls := make([]string, 0, len(deps))
+	purlToDep := make(map[string]database.Dependency)
+	for _, d := range deps {
+		purlStr := purl.MakePURLString(d.Ecosystem, d.Name, "")
+		if purlStr != "" {
+			purls = append(purls, purlStr)
+			purlToDep[purlStr] = d
+		}
+	}
+	if len(purls) == 0 {
+		return nil
+	}
+	data, err := getSBOMLicenseData(db, purls, purlToDep)
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 func getSBOMLicenseData(db *database.DB, purls []string, purlToDep map[string]database.Dependency) (map[string]string, error) {
@@ -236,139 +196,4 @@ func getSBOMLicenseData(db *database.DB, purls []string, purlToDep map[string]da
 	}
 
 	return result, nil
-}
-
-func generateCycloneDX(cmd *cobra.Command, deps []database.Dependency, licenseMap map[string][]string, name, version, format string) error {
-	bom := CycloneDXBOM{
-		XMLNS:       "http://cyclonedx.org/schema/bom/1.5",
-		Version:     1,
-		BOMFormat:   "CycloneDX",
-		SpecVersion: "1.5",
-		Metadata: &CycloneDXMetadata{
-			Timestamp: time.Now().UTC().Format(time.RFC3339),
-			Tools: []CycloneDXTool{
-				{Vendor: "git-pkgs", Name: "git-pkgs", Version: "1.0.0"},
-			},
-		},
-	}
-
-	if name != "" {
-		bom.Metadata.Component = &CycloneDXComponent{
-			Type:    "application",
-			Name:    name,
-			Version: version,
-		}
-	}
-
-	for _, dep := range deps {
-		// Full PURL with version for the component
-		purlStr := dep.PURL
-		if purlStr == "" {
-			purlStr = purl.MakePURLString(dep.Ecosystem, dep.Name, dep.Requirement)
-		}
-		// Versionless PURL for license lookup (matches cache key)
-		licensePurl := purl.MakePURLString(dep.Ecosystem, dep.Name, "")
-
-		comp := CycloneDXComponent{
-			Type:    "library",
-			BOMRef:  purlStr,
-			Name:    dep.Name,
-			Version: dep.Requirement,
-			PURL:    purlStr,
-		}
-
-		if licenses, ok := licenseMap[licensePurl]; ok {
-			for _, lic := range licenses {
-				comp.Licenses = append(comp.Licenses, CycloneDXLicense{ID: lic})
-			}
-		}
-
-		bom.Components = append(bom.Components, comp)
-	}
-
-	if format == "xml" {
-		enc := xml.NewEncoder(cmd.OutOrStdout())
-		enc.Indent("", "  ")
-		_, _ = fmt.Fprint(cmd.OutOrStdout(), xml.Header)
-		return enc.Encode(bom)
-	}
-
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(bom)
-}
-
-func generateSPDX(cmd *cobra.Command, deps []database.Dependency, licenseMap map[string][]string, name, version, format string) error {
-	sbom := SPDXSBOM{
-		SPDXVersion:       "SPDX-2.3",
-		DataLicense:       "CC0-1.0",
-		SPDXID:            "SPDXRef-DOCUMENT",
-		Name:              name,
-		DocumentNamespace: fmt.Sprintf("https://git-pkgs.example.com/%s", name),
-		CreationInfo: SPDXCreationInfo{
-			Created:  time.Now().UTC().Format(time.RFC3339),
-			Creators: []string{"Tool: git-pkgs-1.0.0"},
-		},
-	}
-
-	// Add root package
-	rootPkg := SPDXPackage{
-		SPDXID:           "SPDXRef-Package-root",
-		Name:             name,
-		VersionInfo:      version,
-		DownloadLocation: "NOASSERTION",
-	}
-	sbom.Packages = append(sbom.Packages, rootPkg)
-
-	for i, dep := range deps {
-		// Full PURL with version for the package reference
-		purlStr := dep.PURL
-		if purlStr == "" {
-			purlStr = purl.MakePURLString(dep.Ecosystem, dep.Name, dep.Requirement)
-		}
-		// Versionless PURL for license lookup (matches cache key)
-		licensePurl := purl.MakePURLString(dep.Ecosystem, dep.Name, "")
-
-		pkg := SPDXPackage{
-			SPDXID:           fmt.Sprintf("SPDXRef-Package-%d", i),
-			Name:             dep.Name,
-			VersionInfo:      dep.Requirement,
-			DownloadLocation: "NOASSERTION",
-		}
-
-		if licenses, ok := licenseMap[licensePurl]; ok && len(licenses) > 0 {
-			pkg.LicenseConcluded = licenses[0]
-			pkg.LicenseDeclared = licenses[0]
-		} else {
-			pkg.LicenseConcluded = "NOASSERTION"
-			pkg.LicenseDeclared = "NOASSERTION"
-		}
-
-		if purlStr != "" {
-			pkg.ExternalRefs = []SPDXExternalRef{
-				{
-					ReferenceCategory: "PACKAGE-MANAGER",
-					ReferenceType:     "purl",
-					ReferenceLocator:  purlStr,
-				},
-			}
-		}
-
-		sbom.Packages = append(sbom.Packages, pkg)
-
-		// Add dependency relationship
-		sbom.Relationships = append(sbom.Relationships, SPDXRelationship{
-			SPDXElementID:      "SPDXRef-Package-root",
-			RelationshipType:   "DEPENDS_ON",
-			RelatedSPDXElement: pkg.SPDXID,
-		})
-	}
-
-	if format == "xml" {
-		return fmt.Errorf("SPDX XML format not supported, use json")
-	}
-
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(sbom)
 }

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/sbom"
+)
+
+func TestBuildSBOM(t *testing.T) {
+	deps := []database.Dependency{
+		{Ecosystem: "npm", Name: "lodash", Requirement: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"},
+		{Ecosystem: "npm", Name: "react", Requirement: "18.2.0"},
+	}
+	licenses := map[string]string{"pkg:npm/lodash": "MIT"}
+
+	doc := buildSBOM(deps, licenses, "demo", "1.0.0")
+
+	if len(doc.Packages) != 2 {
+		t.Fatalf("Packages = %d, want 2", len(doc.Packages))
+	}
+	if doc.Document.Component.Name != "demo" || doc.Document.Component.Version != "1.0.0" {
+		t.Errorf("component = %+v", doc.Document.Component)
+	}
+	lodash := doc.Packages[0]
+	if lodash.PURL() != "pkg:npm/lodash@4.17.21" {
+		t.Errorf("lodash purl = %q", lodash.PURL())
+	}
+	if lodash.LicenseDeclared != licenses["pkg:npm/lodash"] {
+		t.Errorf("lodash license = %q", lodash.LicenseDeclared)
+	}
+	react := doc.Packages[1]
+	if react.PURL() == "" {
+		t.Errorf("react purl should be synthesised from ecosystem/name/version")
+	}
+
+	// Round-trip through the encoder so output remains parseable.
+	for _, f := range []sbom.Format{sbom.FormatCycloneDXJSON, sbom.FormatSPDXJSON} {
+		var buf bytes.Buffer
+		if err := sbom.Encode(&buf, doc, f); err != nil {
+			t.Fatalf("Encode(%d): %v", f, err)
+		}
+		if _, err := sbom.Parse(buf.Bytes()); err != nil {
+			t.Fatalf("Parse(%d): %v\n%s", f, err, buf.String())
+		}
+		if !strings.Contains(buf.String(), "pkg:npm/lodash@4.17.21") {
+			t.Errorf("encoded output missing purl:\n%s", buf.String())
+		}
+	}
+}
+
+func TestSBOMFormat(t *testing.T) {
+	tests := []struct {
+		typ, fmt string
+		want     sbom.Format
+		wantErr  bool
+	}{
+		{"cyclonedx", "json", sbom.FormatCycloneDXJSON, false},
+		{"cyclonedx", "xml", sbom.FormatCycloneDXXML, false},
+		{"spdx", "json", sbom.FormatSPDXJSON, false},
+		{"spdx", "xml", 0, true},
+		{"", "", sbom.FormatCycloneDXJSON, false},
+	}
+	for _, tt := range tests {
+		got, err := sbomFormat(tt.typ, tt.fmt)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("sbomFormat(%s,%s) err = %v", tt.typ, tt.fmt, err)
+		}
+		if !tt.wantErr && got != tt.want {
+			t.Errorf("sbomFormat(%s,%s) = %d, want %d", tt.typ, tt.fmt, got, tt.want)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/git-pkgs/purl v0.1.10
 	github.com/git-pkgs/registries v0.4.1
 	github.com/git-pkgs/resolve v0.1.2
+	github.com/git-pkgs/sbom v0.1.0
 	github.com/git-pkgs/spdx v0.1.2
 	github.com/git-pkgs/vers v0.2.4
 	github.com/git-pkgs/vulns v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/git-pkgs/registries v0.4.1 h1:4qlKVNhC/6x6Bt87t3wrGJtF3EFrUpHQt9/zKsa
 github.com/git-pkgs/registries v0.4.1/go.mod h1:49UCPFWQmwNV7rBEr9TrTDWKR7vYxFcxp3VfdkeFbdE=
 github.com/git-pkgs/resolve v0.1.2 h1:4hEopaxv4Zh+z4vez1cmgt1xwA3a0S3cTqd/78CM2Z8=
 github.com/git-pkgs/resolve v0.1.2/go.mod h1:2jXGrrX3o3WNi4Vp5FnSgBR2a2zou34QLEyL1MVE2JY=
+github.com/git-pkgs/sbom v0.1.0 h1:rMNqpHl8qb2MPHF3g0dlL0RU5r0lfcpI3uXmJR9bd+U=
+github.com/git-pkgs/sbom v0.1.0/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/spdx v0.1.2 h1:wHSK+CqFsO5N7yDTPvxDmer5LgNEa7vAsiZhi5Aci0A=
 github.com/git-pkgs/spdx v0.1.2/go.mod h1:V98MgZapNgYw54/pdGR82d7RU93qzJoybahbpZqTfw8=
 github.com/git-pkgs/vers v0.2.4 h1:Zr3jR/Xf1i/6cvBaJKPxhCwjzqz7uvYHE0Fhid/GPBk=


### PR DESCRIPTION
Moves the CycloneDX/SPDX struct definitions and serialisation out of `cmd/sbom.go` into the new `github.com/git-pkgs/sbom` module (v0.1.0), which is a Go port of the Ruby `andrew/sbom` gem and now also handles parsing.

`cmd/sbom.go` keeps the flag handling, dependency loading, and ecosyste.ms license enrichment; it now builds an `*sbom.SBOM` and calls `sbom.Encode`. Same flags, same output formats (`--type cyclonedx|spdx`, `--format json|xml`).

Adds `cmd/sbom_test.go` covering `buildSBOM` and round-tripping both JSON formats through `sbom.Parse`.

Net -97 lines.