### PR TITLE
Prevent where command from following symlinks out of repo

### DIFF
--- a/cmd/where.go
+++ b/cmd/where.go
@@ -74,6 +74,14 @@ func runWhere(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Scope all file reads to the repo directory so that symlinks
+	// pointing outside the repository are rejected by the kernel.
+	osRoot, err := os.OpenRoot(workDir)
+	if err != nil {
+		return fmt.Errorf("opening root %q: %w", workDir, err)
+	}
+	defer func() { _ = osRoot.Close() }()
+
 	var matches []WhereMatch
 
 	// Walk the working directory looking for manifest files
@@ -83,9 +91,9 @@ func runWhere(cmd *cobra.Command, args []string) error {
 		}
 
 		// Get relative path for manifest identification
-		relPath, _ := filepath.Rel(workDir, path)
+		osRel, _ := filepath.Rel(workDir, path)
 		// Normalize to forward slashes for cross-platform consistency
-		relPath = filepath.ToSlash(relPath)
+		relPath := filepath.ToSlash(osRel)
 
 		if info.IsDir() {
 			// Always skip .git
@@ -125,7 +133,7 @@ func runWhere(cmd *cobra.Command, args []string) error {
 		if ecosystem != "" && !strings.EqualFold(eco, ecosystem) {
 			return nil
 		}
-		fileMatches, err := searchFileForPackage(path, relPath, packageName, eco, context)
+		fileMatches, err := searchFileForPackage(osRoot, osRel, relPath, packageName, eco, context)
 		if err != nil {
 			return nil // Skip files we can't read
 		}
@@ -150,8 +158,8 @@ func runWhere(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func searchFileForPackage(path, relPath, packageName, ecosystem string, contextLines int) ([]WhereMatch, error) {
-	file, err := os.Open(path)
+func searchFileForPackage(root *os.Root, osRel, relPath, packageName, ecosystem string, contextLines int) ([]WhereMatch, error) {
+	file, err := root.Open(osRel)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/where_test.go
+++ b/cmd/where_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -65,7 +66,13 @@ func TestSearchFileForPackage(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			matches, err := searchFileForPackage(path, "package-lock.json", tt.packageName, "npm", 0)
+			root, err := os.OpenRoot(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = root.Close() }()
+
+			matches, err := searchFileForPackage(root, "package-lock.json", "package-lock.json", tt.packageName, "npm", 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -80,5 +87,52 @@ func TestSearchFileForPackage(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSearchFileForPackageRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevation on windows")
+	}
+
+	repoDir := t.TempDir()
+
+	// Place a real manifest inside the repo
+	if err := os.WriteFile(filepath.Join(repoDir, "package.json"), []byte(`{"dependencies":{"lodash":"^4.17.21"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a manifest outside the repo
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.json")
+	if err := os.WriteFile(secret, []byte(`{"dependencies":{"escaped-marker":"1.0.0"}}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink inside the repo pointing to the outside manifest
+	link := filepath.Join(repoDir, "requirements.txt")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	root, err := os.OpenRoot(repoDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+
+	// Opening the symlink through os.Root should fail because it escapes the root
+	_, err = searchFileForPackage(root, "requirements.txt", "requirements.txt", "escaped-marker", "pip", 0)
+	if err == nil {
+		t.Fatal("expected error opening symlink that escapes repo root, got nil")
+	}
+
+	// The real file inside the repo should still work
+	matches, err := searchFileForPackage(root, "package.json", "package.json", "lodash", "npm", 0)
+	if err != nil {
+		t.Fatalf("unexpected error reading real file: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for lodash, got %d", len(matches))
 	}
 }


### PR DESCRIPTION
\`searchFileForPackage\` used \`os.Open\` with an absolute path, which follows symlinks. A symlink named like a manifest file (e.g. \`package-lock.json\`) could point outside the repository and leak matching lines.

Uses \`os.Root\` scoped to the working directory so the kernel rejects any path that resolves outside the repo boundary. Same approach as PR #174.