### PR TITLE
Strip control characters from externally sourced strings before TTY output

### DIFF
--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -100,7 +100,7 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 		if !ok {
 			return fmt.Errorf("no changelog entries found between %s and %s", fromVersion, toVersion)
 		}
-		_, _ = fmt.Fprint(cmd.OutOrStdout(), between)
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), Sanitize(between))
 		if !strings.HasSuffix(between, "\n") {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		}
@@ -119,9 +119,9 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 		if !ok {
 			continue
 		}
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "## %s\n", v)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "## %s\n", Sanitize(v))
 		if entry.Content != "" {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), entry.Content)
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), Sanitize(entry.Content))
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout())
 	}

--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -214,7 +214,7 @@ func convertLockfile(cmd *cobra.Command, filePath string) error {
 		if dep.Version != "" {
 			line += " " + dep.Version
 		}
-		_, _ = fmt.Fprintln(w, line)
+		_, _ = fmt.Fprintln(w, Sanitize(line))
 	}
 	return w.Flush()
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -230,8 +230,8 @@ func outputHistoryText(cmd *cobra.Command, entries []database.HistoryEntry, pack
 		}
 		message = strings.TrimSpace(message)
 
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Commit: %s %s\n", Yellow(shortSHA(g.SHA)), message)
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Author: %s %s\n", g.AuthorName, Dim("<"+g.AuthorEmail+">"))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Commit: %s %s\n", Yellow(shortSHA(g.SHA)), Sanitize(message))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  Author: %s %s\n", Sanitize(g.AuthorName), Dim("<"+Sanitize(g.AuthorEmail)+">"))
 		_, _ = fmt.Fprintln(cmd.OutOrStdout())
 	}
 }

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 )
@@ -81,6 +83,22 @@ func IsColorEnabled() bool {
 	}
 
 	return true
+}
+
+// Sanitize strips control characters (other than tab and newline) from
+// externally sourced strings before they reach a TTY, so registry
+// changelogs, OSV records, manifest entries, and commit metadata can't
+// inject ANSI/OSC escape sequences into the operator's terminal.
+func Sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
 }
 
 // Colorize wraps text with color codes if color is enabled

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import "testing"
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain text", "plain text"},
+		{"keep\ttab\nnewline", "keep\ttab\nnewline"},
+		{"\x1b[31mred\x1b[0m", "[31mred[0m"},
+		{"\x1b]0;title\x07", "]0;title"},
+		{"ab\x00cd", "abcd"},
+		{"carriage\rreturn", "carriagereturn"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := Sanitize(tt.in)
+		if got != tt.want {
+			t.Errorf("Sanitize(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -858,11 +858,11 @@ func runVulnsShow(cmd *cobra.Command, args []string) error {
 	_, _ = fmt.Fprintln(cmd.OutOrStdout())
 
 	if vuln.Summary != "" {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Summary:\n  %s\n\n", vuln.Summary)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Summary:\n  %s\n\n", Sanitize(vuln.Summary))
 	}
 
 	if vuln.Details != "" {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Details:\n  %s\n\n", vuln.Details)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Details:\n  %s\n\n", Sanitize(vuln.Details))
 	}
 
 	if len(vuln.Affected) > 0 {

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -228,11 +228,11 @@ func outputWhereText(cmd *cobra.Command, matches []WhereMatch, showContext bool)
 				if lineNum == m.LineNumber {
 					marker = ">"
 				}
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %4d: %s\n", marker, lineNum, line)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %4d: %s\n", marker, lineNum, Sanitize(line))
 			}
 			_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		} else {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:%d:%s\n", m.FilePath, m.LineNumber, m.Content)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:%d:%s\n", m.FilePath, m.LineNumber, Sanitize(m.Content))
 		}
 	}
 


### PR DESCRIPTION
Changelog text fetched from upstream repositories, OSV \`summary\`/\`details\` fields, dependency names parsed from lockfiles, file content from \`where\`, and git commit author/message all reach the terminal with C0 control bytes intact. A hostile package author or commit author can embed ANSI/OSC escape sequences to clear the screen, move the cursor over earlier output, set the terminal title, inject OSC 8 hyperlinks, or write the clipboard on terminals that honour OSC 52.

Adds \`Sanitize\` in \`cmd/output.go\` which strips control characters other than \`\t\`/\`\n\` via \`strings.Map\` + \`unicode.IsControl\`, and applies it at the output sites in \`changelog.go\`, \`vulns.go\`, \`diff_driver.go\`, \`where.go\`, and \`history.go\`.