### PR TITLE
Fall back to git rev-parse when go-git cannot resolve a revision

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -83,7 +83,22 @@ func (r *Repository) CurrentBranch() (string, error) {
 }
 
 func (r *Repository) ResolveRevision(rev string) (*plumbing.Hash, error) {
-	return r.repo.ResolveRevision(plumbing.Revision(rev))
+	hash, err := r.repo.ResolveRevision(plumbing.Revision(rev))
+	if err == nil {
+		return hash, nil
+	}
+
+	// go-git's ResolveRevision does not implement the full gitrevisions(7)
+	// grammar (reflog @{n}, :/regex, dates) and can fail on hashes in some
+	// storage layouts. Fall back to the git CLI which we already require.
+	cmd := exec.Command("git", "rev-parse", "--verify", "--end-of-options", rev)
+	cmd.Dir = r.workDir
+	out, gitErr := cmd.Output()
+	if gitErr != nil {
+		return nil, err
+	}
+	h := plumbing.NewHash(strings.TrimSpace(string(out)))
+	return &h, nil
 }
 
 func (r *Repository) CommitObject(hash plumbing.Hash) (*object.Commit, error) {

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -198,6 +198,43 @@ func TestResolveRevision(t *testing.T) {
 			t.Errorf("expected %s, got %s", sha, hash.String())
 		}
 	})
+
+	t.Run("resolves abbreviated sha", func(t *testing.T) {
+		hash, err := repo.ResolveRevision(sha[:7])
+		if err != nil {
+			t.Fatalf("failed to resolve short sha: %v", err)
+		}
+		if hash.String() != sha {
+			t.Errorf("expected %s, got %s", sha, hash.String())
+		}
+	})
+
+	t.Run("resolves reflog syntax via git fallback", func(t *testing.T) {
+		hash, err := repo.ResolveRevision("@{0}")
+		if err != nil {
+			t.Fatalf("failed to resolve @{0}: %v", err)
+		}
+		if hash.String() != sha {
+			t.Errorf("expected %s, got %s", sha, hash.String())
+		}
+	})
+
+	t.Run("resolves :/message syntax via git fallback", func(t *testing.T) {
+		hash, err := repo.ResolveRevision(":/Initial")
+		if err != nil {
+			t.Fatalf("failed to resolve :/Initial: %v", err)
+		}
+		if hash.String() != sha {
+			t.Errorf("expected %s, got %s", sha, hash.String())
+		}
+	})
+
+	t.Run("returns error for unknown revision", func(t *testing.T) {
+		_, err := repo.ResolveRevision("does-not-exist")
+		if err == nil {
+			t.Error("expected error for unknown revision")
+		}
+	})
 }
 
 func TestCommitObject(t *testing.T) {


### PR DESCRIPTION
go-git's `ResolveRevision` does not implement the full `gitrevisions(7)` grammar. Reflog refs (`HEAD@{1}`, `@{-1}`), message search (`:/text`), and date refs (`main@{yesterday}`) all fail with `reference not found`, and there's a report in #166 of full and abbreviated SHAs failing too in some repos.

When go-git fails, shell out to `git rev-parse --verify --end-of-options <rev>` and use that. We already require the git CLI for `--git-common-dir` and config reads so this adds no new dependency. `--end-of-options` stops a user-supplied rev from being read as a flag.

This affects `show`, `tree`, `bisect`, and `branch`, which all go through `Repository.ResolveRevision`.

If the #166 report turns out to be go-git failing to read the object store entirely (rather than just resolution), `CommitObject` will still fail one line later in `show` and we'll need a deeper fix, but this at least gets every standard rev spelling through the front door.