### PR TITLE
Read alternate object stores when opening a repository

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/git-pkgs/spdx v0.1.3
 	github.com/git-pkgs/vers v0.2.5
 	github.com/git-pkgs/vulns v0.1.5
+	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
@@ -98,7 +99,6 @@ require (
 	github.com/github/go-spdx/v2 v2.6.0 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
-	github.com/go-git/go-billy/v5 v5.8.0 // indirect
 	github.com/go-toolsmith/astcast v1.1.0 // indirect
 	github.com/go-toolsmith/astcopy v1.1.0 // indirect
 	github.com/go-toolsmith/astequal v1.2.0 // indirect

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -8,9 +8,12 @@ import (
 	"strings"
 
 	"github.com/git-pkgs/git-pkgs/internal/mailmap"
+	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/filesystem"
 )
 
 const DatabaseFile = "pkgs.sqlite3"
@@ -46,6 +49,21 @@ func OpenRepository(path string) (*Repository, error) {
 	gitDir := filepath.FromSlash(strings.TrimSpace(string(out)))
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(workDir, gitDir)
+	}
+
+	// PlainOpen chroots its billy filesystem to .git, which stops alternates
+	// that point outside the repo from being read. Reopen with an AlternatesFS
+	// rooted at the volume root so borrowed objects are visible.
+	if fsStorer, ok := repo.Storer.(*filesystem.Storage); ok {
+		root := filepath.VolumeName(gitDir) + string(filepath.Separator)
+		s := filesystem.NewStorageWithOptions(
+			fsStorer.Filesystem(),
+			cache.NewObjectLRUDefault(),
+			filesystem.Options{AlternatesFS: osfs.New(root)},
+		)
+		if reopened, rerr := git.Open(s, wt.Filesystem); rerr == nil {
+			repo = reopened
+		}
 	}
 
 	return &Repository{

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -131,6 +131,43 @@ func TestOpenRepository(t *testing.T) {
 			t.Error("expected error for non-repository")
 		}
 	})
+
+	t.Run("reads objects borrowed via alternates", func(t *testing.T) {
+		srcDir := createTestRepo(t)
+		addFile(t, srcDir, "README.md", "# Test")
+		olderSha := commit(t, srcDir, "First commit")
+		addFile(t, srcDir, "f.txt", "content")
+		commit(t, srcDir, "Second commit")
+
+		cloneDir := filepath.Join(t.TempDir(), "clone")
+		gitRun(t, srcDir, "clone", "--shared", srcDir, cloneDir)
+		gitRun(t, cloneDir, "config", "user.email", "test@example.com")
+		gitRun(t, cloneDir, "config", "user.name", "Test User")
+		gitRun(t, cloneDir, "config", "commit.gpgsign", "false")
+		addFile(t, cloneDir, "local.txt", "local")
+		commit(t, cloneDir, "Local commit")
+
+		repo, err := git.OpenRepository(cloneDir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		hash, err := repo.ResolveRevision(olderSha)
+		if err != nil {
+			t.Fatalf("failed to resolve borrowed sha: %v", err)
+		}
+		if hash.String() != olderSha {
+			t.Errorf("expected %s, got %s", olderSha, hash.String())
+		}
+
+		c, err := repo.CommitObject(*hash)
+		if err != nil {
+			t.Fatalf("failed to read borrowed commit object: %v", err)
+		}
+		if !strings.Contains(c.Message, "First commit") {
+			t.Errorf("expected message 'First commit', got %q", c.Message)
+		}
+	})
 }
 
 func TestDatabasePath(t *testing.T) {


### PR DESCRIPTION
go-git's `PlainOpen` chroots its billy filesystem to `.git`, so absolute paths in `objects/info/alternates` can't be followed and borrowed objects are invisible. In a repo created with `git clone --shared` or `--reference`, any SHA in the borrowed history fails with `reference not found` while HEAD (a local object) works. That matches the report in #166.

`PlainOpenOptions` doesn't expose `AlternatesFS`, so after discovery we rebuild the storage with `filesystem.Options{AlternatesFS: osfs.New(<volume root>)}` and reopen. If the storer isn't a `*filesystem.Storage` or the reopen fails we keep the original repo, so this is strictly additive.

Abbreviated SHAs that live only in the alternate still fail because go-git's `resolveHashPrefix` doesn't traverse alternates; #193 covers that via the `git rev-parse` fallback. The two together handle everything in the #166 report.

The repro matrix that pinned this down is at `/tmp/repro-resolve` locally if anyone wants it; not committing it since it's a throwaway.