### PR TITLE
Read refs and objects from linked worktrees

### DIFF
--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/go-git/go-git/v5/storage/filesystem/dotgit"
 )
 
 const DatabaseFile = "pkgs.sqlite3"
@@ -27,8 +28,7 @@ type Repository struct {
 
 func OpenRepository(path string) (*Repository, error) {
 	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: true,
+		DetectDotGit: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("opening repository: %w", err)
@@ -52,13 +52,17 @@ func OpenRepository(path string) (*Repository, error) {
 		gitDir = filepath.Join(workDir, gitDir)
 	}
 
-	// PlainOpen chroots its billy filesystem to .git, which stops alternates
-	// that point outside the repo from being read. Reopen with an AlternatesFS
-	// rooted at the volume root so borrowed objects are visible.
+	// PlainOpen roots its billy filesystem at the per-repo .git, so it can't
+	// follow alternates that point outside the repo, and in a linked worktree
+	// it can't see refs/objects in the common dir. PlainOpenOptions doesn't
+	// expose AlternatesFS, and EnableDotGitCommonDir leaks an fd in v5, so
+	// rebuild the storage here with both wired up. gitDir above is already
+	// the common dir from `git rev-parse --git-common-dir`.
 	if fsStorer, ok := repo.Storer.(*filesystem.Storage); ok {
+		dotFs := dotgit.NewRepositoryFilesystem(fsStorer.Filesystem(), osfs.New(gitDir))
 		root := filepath.VolumeName(gitDir) + string(filepath.Separator)
 		s := filesystem.NewStorageWithOptions(
-			fsStorer.Filesystem(),
+			dotFs,
 			cache.NewObjectLRUDefault(),
 			filesystem.Options{AlternatesFS: osfs.New(root)},
 		)

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -27,7 +27,8 @@ type Repository struct {
 
 func OpenRepository(path string) (*Repository, error) {
 	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("opening repository: %w", err)

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -92,7 +92,7 @@ func TestOpenRepository(t *testing.T) {
 	t.Run("opens from worktree", func(t *testing.T) {
 		repoDir := createTestRepo(t)
 		addFile(t, repoDir, "README.md", "# Test")
-		commit(t, repoDir, "Initial commit")
+		sha := commit(t, repoDir, "Initial commit")
 
 		worktreeDir := filepath.Join(t.TempDir(), "wt")
 		gitRun(t, repoDir, "worktree", "add", worktreeDir, "-b", "wt-branch")
@@ -121,6 +121,32 @@ func TestOpenRepository(t *testing.T) {
 		expectedDBPath := filepath.Join(resolvedRepoDir, ".git", git.DatabaseFile)
 		if repo.DatabasePath() != expectedDBPath {
 			t.Errorf("expected database path %s, got %s", expectedDBPath, repo.DatabasePath())
+		}
+
+		// Refs and objects live in the main repo's .git, reached via commondir.
+		// Without EnableDotGitCommonDir these fail with "reference not found".
+		hash, err := repo.ResolveRevision("HEAD")
+		if err != nil {
+			t.Fatalf("failed to resolve HEAD from worktree: %v", err)
+		}
+		if hash.String() != sha {
+			t.Errorf("expected %s, got %s", sha, hash.String())
+		}
+
+		c, err := repo.CommitObject(*hash)
+		if err != nil {
+			t.Fatalf("failed to read commit object from worktree: %v", err)
+		}
+		if !strings.Contains(c.Message, "Initial commit") {
+			t.Errorf("expected message 'Initial commit', got %q", c.Message)
+		}
+
+		branch, err := repo.CurrentBranch()
+		if err != nil {
+			t.Fatalf("failed to get current branch from worktree: %v", err)
+		}
+		if branch != "wt-branch" {
+			t.Errorf("expected branch wt-branch, got %s", branch)
 		}
 	})
 

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -124,7 +124,6 @@ func TestOpenRepository(t *testing.T) {
 		}
 
 		// Refs and objects live in the main repo's .git, reached via commondir.
-		// Without EnableDotGitCommonDir these fail with "reference not found".
 		hash, err := repo.ResolveRevision("HEAD")
 		if err != nil {
 			t.Fatalf("failed to resolve HEAD from worktree: %v", err)


### PR DESCRIPTION
In a linked worktree `.git` is a file pointing at `<main>/.git/worktrees/<name>`, and that directory has a `commondir` file pointing back to the main `.git` where refs and objects actually live. go-git's `PlainOpen` roots its storer at the per-worktree dir, which has no `objects/` and no `refs/heads/`, so even resolving `HEAD` fails with `reference not found`.

go-git has `PlainOpenOptions.EnableDotGitCommonDir` for this, but in v5 it opens `commondir` without closing it, which on Windows blocks `t.TempDir()` cleanup and would leak an fd per open in any long-running caller. The fix is on go-git's main but not in any v5 tag including v5.19.0.

We already shell out to `git rev-parse --git-common-dir` for `DatabasePath()`, and #194 already rebuilds the storage to set `AlternatesFS`, so this wraps the dotgit fs in `dotgit.NewRepositoryFilesystem` with the common dir during that same rebuild. go-git never opens `commondir` itself.

This is separate from #194. That one is about `objects/info/alternates` (`git clone --shared` / `--reference`), which is a different mechanism with the same error message. The two compose: a worktree of a `--shared` clone needs both, and the `RepositoryFilesystem` wrapper routes `objects/info/alternates` to the common dir where it lives.

Extended the existing worktree test to actually read refs and objects rather than just checking path resolution.

Fixes #195