### PR TITLE
fix(list): emit [] instead of null for empty JSON list results

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -85,6 +85,9 @@ func filterDependencies(deps []database.Dependency, ecosystem, manifest, depType
 }
 
 func outputListJSON(cmd *cobra.Command, deps []database.Dependency) error {
+	if deps == nil {
+		deps = []database.Dependency{}
+	}
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(deps)

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestOutputListJSON(t *testing.T) {
+	t.Run("nil slice produces []", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := NewRootCmd()
+		cmd.SetOut(&buf)
+
+		var deps []database.Dependency // nil
+		err := outputListJSON(cmd, deps)
+		if err != nil {
+			t.Fatalf("outputListJSON returned error: %v", err)
+		}
+
+		var result []database.Dependency
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\nRaw: %q", err, buf.String())
+		}
+		if result == nil {
+			t.Error("decoded result is nil, expected empty slice []")
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty array, got %d elements", len(result))
+		}
+	})
+
+	t.Run("empty slice produces []", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := NewRootCmd()
+		cmd.SetOut(&buf)
+
+		err := outputListJSON(cmd, []database.Dependency{})
+		if err != nil {
+			t.Fatalf("outputListJSON returned error: %v", err)
+		}
+
+		var result []database.Dependency
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\nRaw: %q", err, buf.String())
+		}
+		if result == nil {
+			t.Error("decoded result is nil, expected empty slice []")
+		}
+	})
+
+	t.Run("non-empty slice serializes correctly", func(t *testing.T) {
+		var buf bytes.Buffer
+		cmd := NewRootCmd()
+		cmd.SetOut(&buf)
+
+		deps := []database.Dependency{
+			{Name: "lodash", Ecosystem: "npm"},
+			{Name: "express", Ecosystem: "npm"},
+		}
+
+		err := outputListJSON(cmd, deps)
+		if err != nil {
+			t.Fatalf("outputListJSON returned error: %v", err)
+		}
+
+		var result []database.Dependency
+		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+			t.Fatalf("output is not valid JSON: %v\nRaw: %q", err, buf.String())
+		}
+		if len(result) != 2 {
+			t.Errorf("expected 2 elements, got %d", len(result))
+		}
+		if result[0].Name != "lodash" {
+			t.Errorf("first element name = %q, want %q", result[0].Name, "lodash")
+		}
+	})
+}


### PR DESCRIPTION
## Description

When `GetDependenciesWithDB` returns a nil slice (no manifests found), Go's `json.Encode` emits `null` rather than `[]`.

Downstream consumers that wrap the output (e.g. `printf '{"dependencies": '; git-pkgs list --format json; printf '}'`) end up with `{"dependencies": null}`, which fails schema validation against `"type": "array"`.

## Fix

Add a nil check before encoding — coalesce to an empty slice so `json.Encode` produces `[]`.

Fixes #207