### PR TITLE
Add dependency freshness metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ git pkgs diff main..feature   # compare branches
 git pkgs vulns          # scan for known CVEs
 git pkgs vulns blame    # who introduced each vulnerability
 git pkgs outdated       # find packages with newer versions
+git pkgs freshness      # release-age freshness metrics
 git pkgs changelog lodash -e npm --from 4.17.20 --to 4.17.21  # view changelog
 git pkgs update         # update all dependencies
 git pkgs add lodash     # add a package
@@ -244,6 +245,16 @@ git pkgs stale --ecosystem=npm  # filter by ecosystem
 ```
 
 Shows dependencies sorted by how long since they were last changed in your repo. Useful for finding packages that may have been forgotten or need review.
+
+### Check freshness metrics
+
+```bash
+git pkgs freshness                  # average days behind latest releases
+git pkgs freshness --limit=20       # show more lagging dependencies
+git pkgs freshness --ecosystem=npm  # filter by ecosystem
+```
+
+Compares installed versions with registry release dates to report average days behind latest and the dependencies with the largest release-date lag.
 
 ### Find outdated dependencies
 

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -98,6 +98,9 @@ func runFreshness(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(resolved) == 0 {
+		if format == formatJSON {
+			return outputFreshnessJSON(cmd, emptyFreshnessResult())
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
 		return nil
 	}
@@ -119,7 +122,7 @@ func runFreshness(cmd *cobra.Command, args []string) error {
 }
 
 func computeFreshness(db *database.DB, deps []database.Dependency) (*FreshnessResult, error) {
-	result := &FreshnessResult{}
+	result := emptyFreshnessResult()
 	result.Summary.TotalDependencies = len(deps)
 
 	purlVersions, err := loadFreshnessVersions(db, deps)
@@ -202,13 +205,12 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 		return nil, err
 	}
 
-	const freshnessTimeout = 60 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), freshnessTimeout)
-	defer cancel()
-
+	const freshnessLookupTimeout = 60 * time.Second
 	var fetchErrors []error
 	for _, purlStr := range missing {
+		ctx, cancel := context.WithTimeout(context.Background(), freshnessLookupTimeout)
 		versions, err := fetchFreshnessVersions(ctx, client, purlStr)
+		cancel()
 		if err != nil {
 			fetchErrors = append(fetchErrors, fmt.Errorf("%s: %w", purlStr, err))
 			continue
@@ -227,6 +229,12 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 	}
 
 	return result, nil
+}
+
+func emptyFreshnessResult() *FreshnessResult {
+	return &FreshnessResult{
+		Dependencies: []FreshnessEntry{},
+	}
 }
 
 func cachedFreshnessVersions(db *database.DB, purlStr string) ([]freshnessVersion, error) {

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -1,0 +1,379 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/vers"
+	"github.com/spf13/cobra"
+)
+
+const defaultFreshnessLimit = 10
+
+func addFreshnessCmd(parent *cobra.Command) {
+	freshnessCmd := &cobra.Command{
+		Use:   "freshness",
+		Short: "Show release freshness metrics",
+		Long: `Compare installed dependency versions with the latest published versions.
+Reports how many days dependencies lag behind latest releases and lists the
+packages with the largest release-date lag.`,
+		RunE: runFreshness,
+	}
+
+	freshnessCmd.Flags().StringP("commit", "c", "", "Check dependencies at specific commit (default: HEAD)")
+	freshnessCmd.Flags().StringP("branch", "b", "", "Branch to query (default: current branch)")
+	freshnessCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
+	freshnessCmd.Flags().IntP("limit", "n", defaultFreshnessLimit, "Number of lagging dependencies to show")
+	freshnessCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	parent.AddCommand(freshnessCmd)
+}
+
+type FreshnessSummary struct {
+	TotalDependencies          int `json:"total_dependencies"`
+	MeasuredDependencies       int `json:"measured_dependencies"`
+	LaggingDependencies        int `json:"lagging_dependencies"`
+	AverageDaysBehindLatest    int `json:"average_days_behind_latest"`
+	MaximumDaysBehindLatest    int `json:"maximum_days_behind_latest"`
+	UnmeasuredDependencies     int `json:"unmeasured_dependencies"`
+	UniquePackagesWithMetadata int `json:"unique_packages_with_metadata"`
+}
+
+type FreshnessEntry struct {
+	Name               string `json:"name"`
+	Ecosystem          string `json:"ecosystem"`
+	CurrentVersion     string `json:"current_version"`
+	LatestVersion      string `json:"latest_version"`
+	DaysBehindLatest   int    `json:"days_behind_latest"`
+	CurrentPublishedAt string `json:"current_published_at"`
+	LatestPublishedAt  string `json:"latest_published_at"`
+	ManifestPath       string `json:"manifest_path"`
+	PURL               string `json:"purl,omitempty"`
+}
+
+type FreshnessResult struct {
+	Summary      FreshnessSummary `json:"summary"`
+	Dependencies []FreshnessEntry `json:"dependencies"`
+}
+
+type freshnessVersion struct {
+	Number      string
+	PublishedAt time.Time
+}
+
+func runFreshness(cmd *cobra.Command, args []string) error {
+	commit, _ := cmd.Flags().GetString("commit")
+	branchName, _ := cmd.Flags().GetString("branch")
+	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	limit, _ := cmd.Flags().GetInt("limit")
+	format, _ := cmd.Flags().GetString("format")
+
+	repo, err := git.OpenRepository(".")
+	if err != nil {
+		return fmt.Errorf("not in a git repository: %w", err)
+	}
+
+	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	if db != nil {
+		defer func() { _ = db.Close() }()
+	}
+	if err != nil {
+		return fmt.Errorf("loading dependencies: %w", err)
+	}
+
+	deps = filterByEcosystem(deps, ecosystem)
+
+	var resolved []database.Dependency
+	for _, d := range deps {
+		if isResolvedDependency(d) {
+			resolved = append(resolved, d)
+		}
+	}
+
+	if len(resolved) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
+		return nil
+	}
+
+	result, err := computeFreshness(db, resolved)
+	if err != nil {
+		return err
+	}
+
+	if limit >= 0 && len(result.Dependencies) > limit {
+		result.Dependencies = result.Dependencies[:limit]
+	}
+
+	if format == formatJSON {
+		return outputFreshnessJSON(cmd, result)
+	}
+	outputFreshnessText(cmd, result)
+	return nil
+}
+
+func computeFreshness(db *database.DB, deps []database.Dependency) (*FreshnessResult, error) {
+	result := &FreshnessResult{}
+	result.Summary.TotalDependencies = len(deps)
+
+	purlVersions, err := loadFreshnessVersions(db, deps)
+	if err != nil {
+		return nil, err
+	}
+	result.Summary.UniquePackagesWithMetadata = len(purlVersions)
+
+	for _, dep := range deps {
+		purlStr := purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+		if purlStr == "" {
+			result.Summary.UnmeasuredDependencies++
+			continue
+		}
+
+		versions := purlVersions[purlStr]
+		entry, ok := freshnessEntryForDependency(dep, purlStr, versions)
+		if !ok {
+			result.Summary.UnmeasuredDependencies++
+			continue
+		}
+
+		result.Summary.MeasuredDependencies++
+		result.Summary.AverageDaysBehindLatest += entry.DaysBehindLatest
+		if entry.DaysBehindLatest > result.Summary.MaximumDaysBehindLatest {
+			result.Summary.MaximumDaysBehindLatest = entry.DaysBehindLatest
+		}
+		if entry.DaysBehindLatest > 0 {
+			result.Summary.LaggingDependencies++
+			result.Dependencies = append(result.Dependencies, entry)
+		}
+	}
+
+	if result.Summary.MeasuredDependencies > 0 {
+		result.Summary.AverageDaysBehindLatest /= result.Summary.MeasuredDependencies
+	}
+
+	sort.Slice(result.Dependencies, func(i, j int) bool {
+		if result.Dependencies[i].DaysBehindLatest != result.Dependencies[j].DaysBehindLatest {
+			return result.Dependencies[i].DaysBehindLatest > result.Dependencies[j].DaysBehindLatest
+		}
+		return result.Dependencies[i].Name < result.Dependencies[j].Name
+	})
+
+	return result, nil
+}
+
+func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[string][]freshnessVersion, error) {
+	purls := make([]string, 0, len(deps))
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		purlStr := purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+		if purlStr == "" || seen[purlStr] {
+			continue
+		}
+		seen[purlStr] = true
+		purls = append(purls, purlStr)
+	}
+
+	result := make(map[string][]freshnessVersion, len(purls))
+	var missing []string
+	for _, purlStr := range purls {
+		versions, err := cachedFreshnessVersions(db, purlStr)
+		if err != nil {
+			return nil, err
+		}
+		if len(versions) == 0 {
+			missing = append(missing, purlStr)
+			continue
+		}
+		result[purlStr] = versions
+	}
+
+	if len(missing) == 0 {
+		return result, nil
+	}
+
+	client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	if err != nil {
+		return nil, err
+	}
+
+	const freshnessTimeout = 60 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), freshnessTimeout)
+	defer cancel()
+
+	for _, purlStr := range missing {
+		versions, err := fetchFreshnessVersions(ctx, client, purlStr)
+		if err != nil {
+			continue
+		}
+		if len(versions) == 0 {
+			continue
+		}
+		result[purlStr] = versions
+		if db != nil {
+			_ = db.SaveVersions(cachedVersionsFromFreshness(purlStr, versions))
+		}
+	}
+
+	return result, nil
+}
+
+func cachedFreshnessVersions(db *database.DB, purlStr string) ([]freshnessVersion, error) {
+	if db == nil {
+		return nil, nil
+	}
+
+	cached, err := db.GetCachedVersions(purlStr, enrichmentCacheTTL)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := make([]freshnessVersion, 0, len(cached))
+	for _, v := range cached {
+		if v.PublishedAt.IsZero() {
+			continue
+		}
+		number := versionFromPURL(v.PURL)
+		if number == "" {
+			continue
+		}
+		versions = append(versions, freshnessVersion{
+			Number:      number,
+			PublishedAt: v.PublishedAt,
+		})
+	}
+	return versions, nil
+}
+
+func fetchFreshnessVersions(ctx context.Context, client enrichment.Client, purlStr string) ([]freshnessVersion, error) {
+	apiVersions, err := client.GetVersions(ctx, purlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	versions := make([]freshnessVersion, 0, len(apiVersions))
+	for _, v := range apiVersions {
+		if v.Number == "" || v.PublishedAt.IsZero() {
+			continue
+		}
+		versions = append(versions, freshnessVersion{
+			Number:      v.Number,
+			PublishedAt: v.PublishedAt,
+		})
+	}
+	return versions, nil
+}
+
+func cachedVersionsFromFreshness(packagePURL string, versions []freshnessVersion) []database.CachedVersion {
+	cached := make([]database.CachedVersion, 0, len(versions))
+	for _, v := range versions {
+		cached = append(cached, database.CachedVersion{
+			PURL:        packagePURL + "@" + v.Number,
+			PackagePURL: packagePURL,
+			PublishedAt: v.PublishedAt,
+		})
+	}
+	return cached
+}
+
+func freshnessEntryForDependency(dep database.Dependency, purlStr string, versions []freshnessVersion) (FreshnessEntry, bool) {
+	current, latest, ok := currentAndLatestVersions(dep.Requirement, versions)
+	if !ok {
+		return FreshnessEntry{}, false
+	}
+
+	daysBehind := int(latest.PublishedAt.Sub(current.PublishedAt).Hours() / 24)
+	if daysBehind < 0 {
+		daysBehind = 0
+	}
+
+	return FreshnessEntry{
+		Name:               dep.Name,
+		Ecosystem:          dep.Ecosystem,
+		CurrentVersion:     current.Number,
+		LatestVersion:      latest.Number,
+		DaysBehindLatest:   daysBehind,
+		CurrentPublishedAt: current.PublishedAt.Format(time.RFC3339),
+		LatestPublishedAt:  latest.PublishedAt.Format(time.RFC3339),
+		ManifestPath:       dep.ManifestPath,
+		PURL:               purlStr,
+	}, true
+}
+
+func currentAndLatestVersions(currentVersion string, versions []freshnessVersion) (freshnessVersion, freshnessVersion, bool) {
+	var current freshnessVersion
+	var latest freshnessVersion
+	for _, v := range versions {
+		if v.Number == currentVersion {
+			current = v
+		}
+		if latest.Number == "" || isVersionNewer(v, latest) {
+			latest = v
+		}
+	}
+	if current.Number == "" || latest.Number == "" {
+		return freshnessVersion{}, freshnessVersion{}, false
+	}
+	return current, latest, true
+}
+
+func isVersionNewer(candidate, current freshnessVersion) bool {
+	if cmp := vers.Compare(candidate.Number, current.Number); cmp != 0 {
+		return cmp > 0
+	}
+	return candidate.PublishedAt.After(current.PublishedAt)
+}
+
+func versionFromPURL(purlStr string) string {
+	parsed, err := purl.Parse(purlStr)
+	if err != nil {
+		return ""
+	}
+	return parsed.Version
+}
+
+func outputFreshnessJSON(cmd *cobra.Command, result *FreshnessResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func outputFreshnessText(cmd *cobra.Command, result *FreshnessResult) {
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Freshness Summary")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "=================")
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Measured dependencies: %d/%d\n",
+		result.Summary.MeasuredDependencies, result.Summary.TotalDependencies)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Lagging dependencies: %d\n", result.Summary.LaggingDependencies)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Average days behind latest: %d\n", result.Summary.AverageDaysBehindLatest)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Maximum days behind latest: %d\n", result.Summary.MaximumDaysBehindLatest)
+	if result.Summary.UnmeasuredDependencies > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Unmeasured dependencies: %d\n", result.Summary.UnmeasuredDependencies)
+	}
+
+	if len(result.Dependencies) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nAll measured dependencies are fresh.")
+		return
+	}
+
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "\nMost Lagging Dependencies")
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "-------------------------")
+	maxNameLen := 0
+	for _, e := range result.Dependencies {
+		if len(e.Name) > maxNameLen {
+			maxNameLen = len(e.Name)
+		}
+	}
+	for _, e := range result.Dependencies {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-*s  %s -> %s  (%d days)  %s\n",
+			maxNameLen,
+			e.Name,
+			e.CurrentVersion,
+			e.LatestVersion,
+			e.DaysBehindLatest,
+			e.ManifestPath)
+	}
+}

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -196,7 +197,7 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 		return result, nil
 	}
 
-	client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	client, err := NewEnrichmentClient(enrichment.WithUserAgent("git-pkgs/" + version))
 	if err != nil {
 		return nil, err
 	}
@@ -205,9 +206,11 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 	ctx, cancel := context.WithTimeout(context.Background(), freshnessTimeout)
 	defer cancel()
 
+	var fetchErrors []error
 	for _, purlStr := range missing {
 		versions, err := fetchFreshnessVersions(ctx, client, purlStr)
 		if err != nil {
+			fetchErrors = append(fetchErrors, fmt.Errorf("%s: %w", purlStr, err))
 			continue
 		}
 		if len(versions) == 0 {
@@ -217,6 +220,10 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 		if db != nil {
 			_ = db.SaveVersions(cachedVersionsFromFreshness(purlStr, versions))
 		}
+	}
+	if len(fetchErrors) == len(missing) {
+		return nil, fmt.Errorf("fetching freshness metadata failed for all %d uncached packages: %w",
+			len(missing), errors.Join(fetchErrors...))
 	}
 
 	return result, nil

--- a/cmd/freshness_test.go
+++ b/cmd/freshness_test.go
@@ -2,12 +2,15 @@ package cmd_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/cmd"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 )
@@ -83,6 +86,52 @@ func TestFreshnessCommand(t *testing.T) {
 			t.Fatalf("jest days behind latest = %d, want 91", result.Dependencies[0].DaysBehindLatest)
 		}
 	})
+}
+
+type failingFreshnessClient struct{}
+
+func (f failingFreshnessClient) BulkLookup(_ context.Context, _ []string) (map[string]*enrichment.PackageInfo, error) {
+	return nil, errors.New("metadata unavailable")
+}
+
+func (f failingFreshnessClient) GetVersions(_ context.Context, _ string) ([]enrichment.VersionInfo, error) {
+	return nil, errors.New("metadata unavailable")
+}
+
+func (f failingFreshnessClient) GetVersion(_ context.Context, _ string) (*enrichment.VersionInfo, error) {
+	return nil, errors.New("metadata unavailable")
+}
+
+func TestFreshnessCommandFailsWhenAllMetadataFetchesFail(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add lockfile")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"init"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	orig := cmd.NewEnrichmentClient
+	cmd.NewEnrichmentClient = func(opts ...enrichment.Option) (enrichment.Client, error) {
+		return failingFreshnessClient{}, nil
+	}
+	defer func() { cmd.NewEnrichmentClient = orig }()
+
+	rootCmd = cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"freshness"})
+	rootCmd.SetOut(&bytes.Buffer{})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected freshness to fail when all metadata fetches fail")
+	}
+	if !strings.Contains(err.Error(), "fetching freshness metadata failed for all") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func seedFreshnessVersions(t *testing.T, repoDir string) {

--- a/cmd/freshness_test.go
+++ b/cmd/freshness_test.go
@@ -88,6 +88,43 @@ func TestFreshnessCommand(t *testing.T) {
 	})
 }
 
+func TestFreshnessJSONNoResolvedDependencies(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add manifest")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"init"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	rootCmd = cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"freshness", "--format", "json"})
+	rootCmd.SetOut(&stdout)
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("freshness json failed: %v", err)
+	}
+
+	var result cmd.FreshnessResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("failed to parse JSON: %v; output: %s", err, stdout.String())
+	}
+	if result.Summary.TotalDependencies != 0 {
+		t.Fatalf("total dependencies = %d, want 0", result.Summary.TotalDependencies)
+	}
+	if result.Dependencies == nil {
+		t.Fatal("dependencies = nil, want empty array")
+	}
+	if len(result.Dependencies) != 0 {
+		t.Fatalf("dependencies length = %d, want 0", len(result.Dependencies))
+	}
+}
+
 type failingFreshnessClient struct{}
 
 func (f failingFreshnessClient) BulkLookup(_ context.Context, _ []string) (map[string]*enrichment.PackageInfo, error) {

--- a/cmd/freshness_test.go
+++ b/cmd/freshness_test.go
@@ -1,0 +1,116 @@
+package cmd_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/git-pkgs/git-pkgs/cmd"
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestFreshnessCommand(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add lockfile")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"init"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	seedFreshnessVersions(t, repoDir)
+
+	t.Run("shows freshness summary", func(t *testing.T) {
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"freshness"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("freshness failed: %v", err)
+		}
+
+		output := stdout.String()
+		if !strings.Contains(output, "Average days behind latest: 40") {
+			t.Errorf("expected average freshness metric, got: %s", output)
+		}
+		if !strings.Contains(output, "Maximum days behind latest: 91") {
+			t.Errorf("expected max freshness metric, got: %s", output)
+		}
+		if !strings.Contains(output, "jest") || !strings.Contains(output, "express") {
+			t.Errorf("expected lagging dependencies in output, got: %s", output)
+		}
+	})
+
+	t.Run("outputs json with limit", func(t *testing.T) {
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"freshness", "--format", "json", "--limit", "1"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("freshness json failed: %v", err)
+		}
+
+		var result cmd.FreshnessResult
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+
+		if result.Summary.MeasuredDependencies != 3 {
+			t.Fatalf("measured dependencies = %d, want 3", result.Summary.MeasuredDependencies)
+		}
+		if result.Summary.LaggingDependencies != 2 {
+			t.Fatalf("lagging dependencies = %d, want 2", result.Summary.LaggingDependencies)
+		}
+		if result.Summary.AverageDaysBehindLatest != 40 {
+			t.Fatalf("average days behind latest = %d, want 40", result.Summary.AverageDaysBehindLatest)
+		}
+		if len(result.Dependencies) != 1 {
+			t.Fatalf("dependencies length = %d, want 1", len(result.Dependencies))
+		}
+		if result.Dependencies[0].Name != "jest" {
+			t.Fatalf("first dependency = %q, want jest", result.Dependencies[0].Name)
+		}
+		if result.Dependencies[0].DaysBehindLatest != 91 {
+			t.Fatalf("jest days behind latest = %d, want 91", result.Dependencies[0].DaysBehindLatest)
+		}
+	})
+}
+
+func seedFreshnessVersions(t *testing.T, repoDir string) {
+	t.Helper()
+
+	db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	mustTime := func(s string) time.Time {
+		t.Helper()
+		parsed, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatalf("parsing time %q: %v", s, err)
+		}
+		return parsed
+	}
+
+	versions := []database.CachedVersion{
+		{PURL: "pkg:npm/express@4.18.2", PackagePURL: "pkg:npm/express", PublishedAt: mustTime("2023-01-01T00:00:00Z")},
+		{PURL: "pkg:npm/express@4.19.0", PackagePURL: "pkg:npm/express", PublishedAt: mustTime("2023-01-31T00:00:00Z")},
+		{PURL: "pkg:npm/lodash@4.17.21", PackagePURL: "pkg:npm/lodash", PublishedAt: mustTime("2021-02-20T00:00:00Z")},
+		{PURL: "pkg:npm/jest@29.7.0", PackagePURL: "pkg:npm/jest", PublishedAt: mustTime("2023-01-01T00:00:00Z")},
+		{PURL: "pkg:npm/jest@30.0.0", PackagePURL: "pkg:npm/jest", PublishedAt: mustTime("2023-04-02T00:00:00Z")},
+	}
+	if err := db.SaveVersions(versions); err != nil {
+		t.Fatalf("saving versions: %v", err)
+	}
+}

--- a/cmd/pager_test.go
+++ b/cmd/pager_test.go
@@ -15,6 +15,7 @@ func TestPagerFlagAccepted(t *testing.T) {
 		"why",
 		"stats",
 		"stale",
+		"freshness",
 		"log",
 		"list",
 		"history",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,7 @@ func NewRootCmd() *cobra.Command {
 	addTreeCmd(cmd)
 	addStatsCmd(cmd)
 	addStaleCmd(cmd)
+	addFreshnessCmd(cmd)
 	addBranchCmd(cmd)
 	addOutdatedCmd(cmd)
 	addChangelogCmd(cmd)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -150,7 +150,7 @@ See [vulns.md](vulns.md) for command documentation.
 
 ## Package Enrichment
 
-The `outdated`, `changelog`, `licenses`, `sbom`, and `integrity --registry` commands fetch metadata from external sources. The [`github.com/git-pkgs/enrichment`](https://github.com/git-pkgs/enrichment) library provides a unified interface with two backends:
+The `outdated`, `freshness`, `changelog`, `licenses`, `sbom`, and `integrity --registry` commands fetch metadata from external sources. The [`github.com/git-pkgs/enrichment`](https://github.com/git-pkgs/enrichment) library provides a unified interface with two backends:
 
 - **ecosyste.ms** - Bulk API queries via [ecosyste-ms/ecosystems-go](https://github.com/ecosyste-ms/ecosystems-go). Efficient for public packages.
 - **registries** - Direct queries to package registries via [git-pkgs/registries](https://github.com/git-pkgs/registries). Required for private registries.


### PR DESCRIPTION
Closes #20

## Summary

Adds a new `git pkgs freshness` command for release-age freshness metrics.

The command compares installed dependency versions with registry version publish dates and reports:

- average days behind latest
- maximum days behind latest
- number of lagging dependencies
- dependencies with the largest release-date lag

## Options

Supports:

- `--limit`
- `--ecosystem`
- `--commit`
- `--branch`
- `--format json`

## Notes

This complements `git pkgs stale`:

- `stale` measures how long a dependency has been unchanged in the repo
- `freshness` measures how far installed versions lag behind latest registry releases

## Tests

- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`