### PR TITLE
Add dependency maintainer data command

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ git pkgs maintainers --all        # include transitive lockfile deps
 git pkgs maintainers --format=json
 ```
 
-Checks package metadata for maintainer data and shows maintainer count plus names or logins. Single-maintainer packages are useful review targets, though they are not inherently unsafe.
+Checks ecosyste.ms package metadata for maintainer data and shows maintainer count plus names or logins. Single-maintainer packages are useful review targets, though they are not inherently unsafe.
 
 ### View changelogs
 
@@ -748,7 +748,7 @@ GIT_PKGS_DIRECT=1 git pkgs outdated  # one-off via environment
 
 By default, git-pkgs uses a hybrid approach: packages with a `repository_url` qualifier in their PURL (indicating a private registry) are queried directly, while public packages go through ecosyste.ms for efficiency.
 
-**Private registries and proxies:** For commands that query registries (`outdated`, `licenses`, `maintainers`, SBOM enrichment), git-pkgs extracts registry URLs from lockfiles when available:
+**Private registries and proxies:** For commands that query registries (`outdated`, `licenses`, SBOM enrichment), git-pkgs extracts registry URLs from lockfiles when available:
 
 - npm: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock` (from `resolved` URLs)
 - pypi: `Pipfile.lock`, `poetry.lock`, `uv.lock` (from source configuration)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For best results, commit your lockfiles. Manifests show version ranges but lockf
 
 It works across many ecosystems (Gemfile, package.json, Dockerfile, GitHub Actions workflows) giving you one unified history instead of separate tools per ecosystem. The database lives in your `.git` directory where you can use it in CI to catch dependency changes in pull requests.
 
-The core commands (`list`, `history`, `blame`, `diff`, `stale`, etc.) work entirely from your git history with no network access. Additional commands fetch external data: `vulns` checks [OSV](https://osv.dev) for known CVEs, `outdated`, `freshness`, `licenses`, and `funding` query [ecosyste.ms](https://packages.ecosyste.ms/) for registry metadata, `deprecated` checks registries for deprecation metadata, and `changelog` fetches upstream changelogs so you can see what changed between versions.
+The core commands (`list`, `history`, `blame`, `diff`, `stale`, etc.) work entirely from your git history with no network access. Additional commands fetch external data: `vulns` checks [OSV](https://osv.dev) for known CVEs, `outdated`, `freshness`, `licenses`, `funding`, and `maintainers` query [ecosyste.ms](https://packages.ecosyste.ms/) for registry metadata, `deprecated` checks registries for deprecation metadata, and `changelog` fetches upstream changelogs so you can see what changed between versions.
 
 ## Installation
 
@@ -48,6 +48,7 @@ git pkgs outdated       # find packages with newer versions
 git pkgs freshness      # release-age freshness metrics
 git pkgs deprecated     # find deprecated installed versions
 git pkgs funding        # show packages with funding links
+git pkgs maintainers    # show dependency maintainer counts
 git pkgs changelog lodash -e npm --from 4.17.20 --to 4.17.21  # view changelog
 git pkgs update         # update all dependencies
 git pkgs add lodash     # add a package
@@ -295,6 +296,17 @@ git pkgs funding --format=json
 ```
 
 Checks ecosyste.ms package metadata for funding links so you can see which dependencies publish sponsorship information and which ones do not.
+
+### Show maintainer data
+
+```bash
+git pkgs maintainers              # show maintainer counts for direct deps
+git pkgs maintainers --single     # only packages with one maintainer
+git pkgs maintainers --all        # include transitive lockfile deps
+git pkgs maintainers --format=json
+```
+
+Checks package metadata for maintainer data and shows maintainer count plus names or logins. Single-maintainer packages are useful review targets, though they are not inherently unsafe.
 
 ### View changelogs
 
@@ -736,7 +748,7 @@ GIT_PKGS_DIRECT=1 git pkgs outdated  # one-off via environment
 
 By default, git-pkgs uses a hybrid approach: packages with a `repository_url` qualifier in their PURL (indicating a private registry) are queried directly, while public packages go through ecosyste.ms for efficiency.
 
-**Private registries and proxies:** For commands that query registries (`outdated`, `licenses`, SBOM enrichment), git-pkgs extracts registry URLs from lockfiles when available:
+**Private registries and proxies:** For commands that query registries (`outdated`, `licenses`, `maintainers`, SBOM enrichment), git-pkgs extracts registry URLs from lockfiles when available:
 
 - npm: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock` (from `resolved` URLs)
 - pypi: `Pipfile.lock`, `poetry.lock`, `uv.lock` (from source configuration)

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -101,7 +101,7 @@ func runMaintainers(cmd *cobra.Command, args []string) error {
 	deps = selectMaintainerDependencies(deps, includeTransitive)
 	if len(deps) == 0 {
 		if includeTransitive {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies found.")
 		} else {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No direct dependencies found.")
 		}
@@ -136,7 +136,7 @@ func selectMaintainerDependencies(deps []database.Dependency, includeTransitive 
 	var selected []database.Dependency
 	for _, dep := range deps {
 		if includeTransitive {
-			if isResolvedDependency(dep) {
+			if dep.ManifestKind == "manifest" || isResolvedDependency(dep) {
 				selected = append(selected, dep)
 			}
 			continue
@@ -223,13 +223,11 @@ func buildMaintainersResult(
 	result := &MaintainersResult{}
 	result.Summary.TotalDependencies = len(deps)
 
-	seen := make(map[string]bool)
 	for _, dep := range deps {
 		purlStr := maintainerPURLForDependency(dep)
-		if purlStr == "" || seen[purlStr] {
+		if purlStr == "" {
 			continue
 		}
-		seen[purlStr] = true
 
 		data, ok := lookup[purlStr]
 		if !ok {

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -6,27 +6,22 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
-	"github.com/git-pkgs/registries"
-	_ "github.com/git-pkgs/registries/all"
 	"github.com/spf13/cobra"
 )
 
-const (
-	maintainerLookupConcurrency = 8
-	maintainerLookupTimeout     = 5 * time.Minute
-)
+const maintainerLookupTimeout = 5 * time.Minute
 
 func addMaintainersCmd(parent *cobra.Command) {
 	maintainersCmd := &cobra.Command{
 		Use:   "maintainers",
 		Short: "Show dependency maintainer information",
-		Long:  `Fetch package registry maintainer data and show maintainer counts for dependencies.`,
+		Long:  `Fetch package maintainer metadata and show maintainer counts for dependencies.`,
 		RunE:  runMaintainers,
 	}
 
@@ -49,7 +44,6 @@ type MaintainersSummary struct {
 }
 
 type MaintainerInfo struct {
-	UUID  string `json:"uuid,omitempty"`
 	Login string `json:"login,omitempty"`
 	Name  string `json:"name,omitempty"`
 	Email string `json:"email,omitempty"`
@@ -75,7 +69,7 @@ type MaintainersResult struct {
 }
 
 type maintainerLookupResult struct {
-	Maintainers []registries.Maintainer
+	Maintainers []MaintainerInfo
 	Error       string
 }
 
@@ -228,7 +222,7 @@ func cachedMaintainerData(db *database.DB, purls []string) map[string]maintainer
 		return results
 	}
 	for purlStr, cachedMaintainers := range cached {
-		var maintainers []registries.Maintainer
+		var maintainers []MaintainerInfo
 		if err := json.Unmarshal([]byte(cachedMaintainers.Data), &maintainers); err != nil {
 			continue
 		}
@@ -243,38 +237,32 @@ func fetchMaintainerDataUncached(ctx context.Context, purls []string) map[string
 		return results
 	}
 
-	client := registries.DefaultClient().WithUserAgent("git-pkgs/" + version)
-	jobs := make(chan string)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	workerCount := maintainerLookupConcurrency
-	if len(purls) < workerCount {
-		workerCount = len(purls)
+	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	if err != nil {
+		for _, purlStr := range purls {
+			results[purlStr] = maintainerLookupResult{Error: fmt.Sprintf("creating enrichment client: %v", err)}
+		}
+		return results
 	}
 
-	for range workerCount {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for purlStr := range jobs {
-				maintainers, err := registries.FetchMaintainersFromPURL(ctx, purlStr, client)
-				result := maintainerLookupResult{Maintainers: maintainers}
-				if err != nil {
-					result.Error = err.Error()
-				}
-				mu.Lock()
-				results[purlStr] = result
-				mu.Unlock()
-			}
-		}()
+	packages, err := client.BulkLookup(ctx, purls)
+	if err != nil {
+		for _, purlStr := range purls {
+			results[purlStr] = maintainerLookupResult{Error: err.Error()}
+		}
+		return results
 	}
 
 	for _, purlStr := range purls {
-		jobs <- purlStr
+		pkg := packages[purlStr]
+		if pkg == nil {
+			results[purlStr] = maintainerLookupResult{}
+			continue
+		}
+		results[purlStr] = maintainerLookupResult{
+			Maintainers: maintainerInfosFromEnrichment(pkg.Maintainers),
+		}
 	}
-	close(jobs)
-	wg.Wait()
 	return results
 }
 
@@ -392,12 +380,25 @@ func emptyMaintainersResult() *MaintainersResult {
 	}
 }
 
-func normalizeMaintainers(maintainers []registries.Maintainer) []MaintainerInfo {
+func maintainerInfosFromEnrichment(maintainers []enrichment.Maintainer) []MaintainerInfo {
+	infos := make([]MaintainerInfo, 0, len(maintainers))
+	for _, maintainer := range maintainers {
+		infos = append(infos, MaintainerInfo{
+			Login: maintainer.Login,
+			Name:  maintainer.Name,
+			Email: maintainer.Email,
+			URL:   maintainer.URL,
+			Role:  maintainer.Role,
+		})
+	}
+	return infos
+}
+
+func normalizeMaintainers(maintainers []MaintainerInfo) []MaintainerInfo {
 	seen := make(map[string]bool)
 	infos := make([]MaintainerInfo, 0, len(maintainers))
 	for _, maintainer := range maintainers {
 		info := MaintainerInfo{
-			UUID:  maintainer.UUID,
 			Login: maintainer.Login,
 			Name:  maintainer.Name,
 			Email: maintainer.Email,
@@ -423,7 +424,6 @@ func maintainerDisplay(maintainer MaintainerInfo) string {
 		maintainer.Name,
 		maintainer.Email,
 		maintainer.URL,
-		maintainer.UUID,
 	}
 	for _, part := range parts {
 		if strings.TrimSpace(part) != "" {

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -100,6 +100,9 @@ func runMaintainers(cmd *cobra.Command, args []string) error {
 	deps = filterByEcosystem(deps, ecosystem)
 	deps = selectMaintainerDependencies(deps, includeTransitive)
 	if len(deps) == 0 {
+		if format == formatJSON {
+			return outputMaintainersJSON(cmd, emptyMaintainersResult())
+		}
 		if includeTransitive {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies found.")
 		} else {
@@ -112,9 +115,12 @@ func runMaintainers(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	data := fetchMaintainerData(ctx, purls)
+	data := fetchMaintainerData(ctx, db, deps, purls)
 	result := buildMaintainersResult(deps, data, singleOnly)
 	if len(result.Dependencies) == 0 {
+		if format == formatJSON {
+			return outputMaintainersJSON(cmd, result)
+		}
 		if singleOnly {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No single-maintainer dependencies found.")
 		} else {
@@ -174,7 +180,61 @@ func maintainerPURLForDependency(dep database.Dependency) string {
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 }
 
-func fetchMaintainerData(ctx context.Context, purls []string) map[string]maintainerLookupResult {
+func fetchMaintainerData(
+	ctx context.Context,
+	db *database.DB,
+	deps []database.Dependency,
+	purls []string,
+) map[string]maintainerLookupResult {
+	results := make(map[string]maintainerLookupResult, len(purls))
+	if len(purls) == 0 {
+		return results
+	}
+
+	for purlStr, result := range cachedMaintainerData(db, purls) {
+		results[purlStr] = result
+	}
+
+	misses := make([]string, 0)
+	for _, purlStr := range purls {
+		if _, ok := results[purlStr]; !ok {
+			misses = append(misses, purlStr)
+		}
+	}
+	if len(misses) == 0 {
+		return results
+	}
+
+	fetched := fetchMaintainerDataUncached(ctx, misses)
+	for purlStr, result := range fetched {
+		results[purlStr] = result
+	}
+	saveMaintainerData(db, deps, fetched)
+
+	return results
+}
+
+func cachedMaintainerData(db *database.DB, purls []string) map[string]maintainerLookupResult {
+	results := make(map[string]maintainerLookupResult, len(purls))
+	if db == nil {
+		return results
+	}
+
+	cached, err := db.GetCachedMaintainers(purls, enrichmentCacheTTL)
+	if err != nil {
+		return results
+	}
+	for purlStr, cachedMaintainers := range cached {
+		var maintainers []registries.Maintainer
+		if err := json.Unmarshal([]byte(cachedMaintainers.Data), &maintainers); err != nil {
+			continue
+		}
+		results[purlStr] = maintainerLookupResult{Maintainers: maintainers}
+	}
+	return results
+}
+
+func fetchMaintainerDataUncached(ctx context.Context, purls []string) map[string]maintainerLookupResult {
 	results := make(map[string]maintainerLookupResult, len(purls))
 	if len(purls) == 0 {
 		return results
@@ -215,12 +275,57 @@ func fetchMaintainerData(ctx context.Context, purls []string) map[string]maintai
 	return results
 }
 
+func saveMaintainerData(db *database.DB, deps []database.Dependency, lookup map[string]maintainerLookupResult) {
+	if db == nil || len(lookup) == 0 {
+		return
+	}
+
+	packages := maintainerPackageData(deps)
+	toSave := make([]database.PackageMaintainersData, 0, len(lookup))
+	for purlStr, result := range lookup {
+		if result.Error != "" {
+			continue
+		}
+		pkg, ok := packages[purlStr]
+		if !ok {
+			continue
+		}
+		raw, err := json.Marshal(result.Maintainers)
+		if err != nil {
+			continue
+		}
+		pkg.Maintainers = string(raw)
+		toSave = append(toSave, pkg)
+	}
+
+	_ = db.SavePackageMaintainersBatch(toSave)
+}
+
+func maintainerPackageData(deps []database.Dependency) map[string]database.PackageMaintainersData {
+	packages := make(map[string]database.PackageMaintainersData)
+	for _, dep := range deps {
+		purlStr := maintainerPURLForDependency(dep)
+		if purlStr == "" {
+			continue
+		}
+		if _, ok := packages[purlStr]; ok {
+			continue
+		}
+		packages[purlStr] = database.PackageMaintainersData{
+			PURL:      purlStr,
+			Ecosystem: dep.Ecosystem,
+			Name:      dep.Name,
+		}
+	}
+	return packages
+}
+
 func buildMaintainersResult(
 	deps []database.Dependency,
 	lookup map[string]maintainerLookupResult,
 	singleOnly bool,
 ) *MaintainersResult {
-	result := &MaintainersResult{}
+	result := emptyMaintainersResult()
 	result.Summary.TotalDependencies = len(deps)
 
 	for _, dep := range deps {
@@ -276,6 +381,12 @@ func buildMaintainersResult(
 	})
 
 	return result
+}
+
+func emptyMaintainersResult() *MaintainersResult {
+	return &MaintainersResult{
+		Dependencies: []MaintainersEntry{},
+	}
 }
 
 func normalizeMaintainers(maintainers []registries.Maintainer) []MaintainerInfo {

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -1,0 +1,380 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/registries"
+	_ "github.com/git-pkgs/registries/all"
+	"github.com/spf13/cobra"
+)
+
+const maintainerLookupConcurrency = 8
+
+func addMaintainersCmd(parent *cobra.Command) {
+	maintainersCmd := &cobra.Command{
+		Use:   "maintainers",
+		Short: "Show dependency maintainer information",
+		Long:  `Fetch package registry maintainer data and show maintainer counts for dependencies.`,
+		RunE:  runMaintainers,
+	}
+
+	maintainersCmd.Flags().StringP("commit", "c", "", "Check dependencies at specific commit (default: HEAD)")
+	maintainersCmd.Flags().StringP("branch", "b", "", "Branch to query (default: current branch)")
+	maintainersCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
+	maintainersCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	maintainersCmd.Flags().Bool("single", false, "Only show dependencies with exactly one maintainer")
+	maintainersCmd.Flags().Bool("all", false, "Include transitive dependencies from lockfiles")
+	parent.AddCommand(maintainersCmd)
+}
+
+type MaintainersSummary struct {
+	TotalDependencies   int `json:"total_dependencies"`
+	QueriedDependencies int `json:"queried_dependencies"`
+	WithMaintainers     int `json:"with_maintainers"`
+	WithoutMaintainers  int `json:"without_maintainers"`
+	SingleMaintainer    int `json:"single_maintainer"`
+	LookupErrors        int `json:"lookup_errors"`
+}
+
+type MaintainerInfo struct {
+	UUID  string `json:"uuid,omitempty"`
+	Login string `json:"login,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+	URL   string `json:"url,omitempty"`
+	Role  string `json:"role,omitempty"`
+}
+
+type MaintainersEntry struct {
+	Name             string           `json:"name"`
+	Ecosystem        string           `json:"ecosystem"`
+	Version          string           `json:"version,omitempty"`
+	ManifestPath     string           `json:"manifest_path"`
+	PURL             string           `json:"purl,omitempty"`
+	MaintainerCount  int              `json:"maintainer_count"`
+	SingleMaintainer bool             `json:"single_maintainer"`
+	Maintainers      []MaintainerInfo `json:"maintainers"`
+	Error            string           `json:"error,omitempty"`
+}
+
+type MaintainersResult struct {
+	Summary      MaintainersSummary `json:"summary"`
+	Dependencies []MaintainersEntry `json:"dependencies"`
+}
+
+type maintainerLookupResult struct {
+	Maintainers []registries.Maintainer
+	Error       string
+}
+
+func runMaintainers(cmd *cobra.Command, args []string) error {
+	commit, _ := cmd.Flags().GetString("commit")
+	branchName, _ := cmd.Flags().GetString("branch")
+	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	format, _ := cmd.Flags().GetString("format")
+	singleOnly, _ := cmd.Flags().GetBool("single")
+	includeTransitive, _ := cmd.Flags().GetBool("all")
+
+	repo, err := git.OpenRepository(".")
+	if err != nil {
+		return fmt.Errorf("not in a git repository: %w", err)
+	}
+
+	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	if db != nil {
+		defer func() { _ = db.Close() }()
+	}
+	if err != nil {
+		return fmt.Errorf("loading dependencies: %w", err)
+	}
+
+	deps = filterByEcosystem(deps, ecosystem)
+	deps = selectMaintainerDependencies(deps, includeTransitive)
+	if len(deps) == 0 {
+		if includeTransitive {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
+		} else {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No direct dependencies found.")
+		}
+		return nil
+	}
+
+	purls := uniqueMaintainerPURLs(deps)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	data := fetchMaintainerData(ctx, purls)
+	result := buildMaintainersResult(deps, data, singleOnly)
+	if len(result.Dependencies) == 0 {
+		if singleOnly {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No single-maintainer dependencies found.")
+		} else {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No maintainer data found.")
+		}
+		return nil
+	}
+
+	switch format {
+	case formatJSON:
+		return outputMaintainersJSON(cmd, result)
+	default:
+		outputMaintainersText(cmd, result, singleOnly)
+		return nil
+	}
+}
+
+func selectMaintainerDependencies(deps []database.Dependency, includeTransitive bool) []database.Dependency {
+	var selected []database.Dependency
+	for _, dep := range deps {
+		if includeTransitive {
+			if isResolvedDependency(dep) {
+				selected = append(selected, dep)
+			}
+			continue
+		}
+		if dep.ManifestKind == "manifest" {
+			selected = append(selected, dep)
+		}
+	}
+	return selected
+}
+
+func uniqueMaintainerPURLs(deps []database.Dependency) []string {
+	seen := make(map[string]bool)
+	var purls []string
+	for _, dep := range deps {
+		purlStr := maintainerPURLForDependency(dep)
+		if purlStr == "" || seen[purlStr] {
+			continue
+		}
+		seen[purlStr] = true
+		purls = append(purls, purlStr)
+	}
+	sort.Strings(purls)
+	return purls
+}
+
+func maintainerPURLForDependency(dep database.Dependency) string {
+	if dep.PURL != "" {
+		parsed, err := purl.Parse(dep.PURL)
+		if err == nil {
+			parsed.Version = ""
+			return parsed.String()
+		}
+	}
+	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+}
+
+func fetchMaintainerData(ctx context.Context, purls []string) map[string]maintainerLookupResult {
+	results := make(map[string]maintainerLookupResult, len(purls))
+	if len(purls) == 0 {
+		return results
+	}
+
+	client := registries.DefaultClient().WithUserAgent("git-pkgs/" + version)
+	jobs := make(chan string)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	workerCount := maintainerLookupConcurrency
+	if len(purls) < workerCount {
+		workerCount = len(purls)
+	}
+
+	for range workerCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for purlStr := range jobs {
+				maintainers, err := registries.FetchMaintainersFromPURL(ctx, purlStr, client)
+				result := maintainerLookupResult{Maintainers: maintainers}
+				if err != nil {
+					result.Error = err.Error()
+				}
+				mu.Lock()
+				results[purlStr] = result
+				mu.Unlock()
+			}
+		}()
+	}
+
+	for _, purlStr := range purls {
+		jobs <- purlStr
+	}
+	close(jobs)
+	wg.Wait()
+	return results
+}
+
+func buildMaintainersResult(
+	deps []database.Dependency,
+	lookup map[string]maintainerLookupResult,
+	singleOnly bool,
+) *MaintainersResult {
+	result := &MaintainersResult{}
+	result.Summary.TotalDependencies = len(deps)
+
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		purlStr := maintainerPURLForDependency(dep)
+		if purlStr == "" || seen[purlStr] {
+			continue
+		}
+		seen[purlStr] = true
+
+		data, ok := lookup[purlStr]
+		if !ok {
+			data.Error = "maintainer lookup was not run"
+		}
+
+		entry := MaintainersEntry{
+			Name:         dep.Name,
+			Ecosystem:    dep.Ecosystem,
+			Version:      dep.Requirement,
+			ManifestPath: dep.ManifestPath,
+			PURL:         purlStr,
+			Error:        data.Error,
+		}
+		entry.Maintainers = normalizeMaintainers(data.Maintainers)
+		entry.MaintainerCount = len(entry.Maintainers)
+		entry.SingleMaintainer = entry.MaintainerCount == 1
+
+		result.Summary.QueriedDependencies++
+		switch {
+		case entry.Error != "":
+			result.Summary.LookupErrors++
+		case entry.MaintainerCount == 0:
+			result.Summary.WithoutMaintainers++
+		default:
+			result.Summary.WithMaintainers++
+			if entry.SingleMaintainer {
+				result.Summary.SingleMaintainer++
+			}
+		}
+
+		if singleOnly && !entry.SingleMaintainer {
+			continue
+		}
+		result.Dependencies = append(result.Dependencies, entry)
+	}
+
+	sort.Slice(result.Dependencies, func(i, j int) bool {
+		if result.Dependencies[i].MaintainerCount != result.Dependencies[j].MaintainerCount {
+			return result.Dependencies[i].MaintainerCount < result.Dependencies[j].MaintainerCount
+		}
+		if result.Dependencies[i].Name != result.Dependencies[j].Name {
+			return result.Dependencies[i].Name < result.Dependencies[j].Name
+		}
+		return result.Dependencies[i].Ecosystem < result.Dependencies[j].Ecosystem
+	})
+
+	return result
+}
+
+func normalizeMaintainers(maintainers []registries.Maintainer) []MaintainerInfo {
+	seen := make(map[string]bool)
+	infos := make([]MaintainerInfo, 0, len(maintainers))
+	for _, maintainer := range maintainers {
+		info := MaintainerInfo{
+			UUID:  maintainer.UUID,
+			Login: maintainer.Login,
+			Name:  maintainer.Name,
+			Email: maintainer.Email,
+			URL:   maintainer.URL,
+			Role:  maintainer.Role,
+		}
+		key := maintainerDisplay(info)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		infos = append(infos, info)
+	}
+	sort.Slice(infos, func(i, j int) bool {
+		return maintainerDisplay(infos[i]) < maintainerDisplay(infos[j])
+	})
+	return infos
+}
+
+func maintainerDisplay(maintainer MaintainerInfo) string {
+	parts := []string{
+		maintainer.Login,
+		maintainer.Name,
+		maintainer.Email,
+		maintainer.URL,
+		maintainer.UUID,
+	}
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			return part
+		}
+	}
+	return ""
+}
+
+func outputMaintainersJSON(cmd *cobra.Command, result *MaintainersResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func outputMaintainersText(cmd *cobra.Command, result *MaintainersResult, singleOnly bool) {
+	if singleOnly {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Found %d single-maintainer dependencies:\n\n", len(result.Dependencies))
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Found maintainer data for %d dependencies:\n\n", len(result.Dependencies))
+	}
+
+	maxNameLen := 0
+	for _, dep := range result.Dependencies {
+		if len(dep.Name) > maxNameLen {
+			maxNameLen = len(dep.Name)
+		}
+	}
+
+	for _, dep := range result.Dependencies {
+		maintainers := formatMaintainerNames(dep.Maintainers)
+		if dep.Error != "" {
+			maintainers = "lookup error: " + dep.Error
+		} else if maintainers == "" {
+			maintainers = "none reported"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-*s  %2d  %s  %s\n",
+			maxNameLen,
+			dep.Name,
+			dep.MaintainerCount,
+			maintainers,
+			Dim("("+dep.ManifestPath+")"))
+	}
+
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Checked: %d, with maintainers: %d, without maintainers: %d, single maintainer: %d, lookup errors: %d\n",
+		result.Summary.QueriedDependencies,
+		result.Summary.WithMaintainers,
+		result.Summary.WithoutMaintainers,
+		result.Summary.SingleMaintainer,
+		result.Summary.LookupErrors)
+}
+
+func formatMaintainerNames(maintainers []MaintainerInfo) string {
+	names := make([]string, 0, len(maintainers))
+	for _, maintainer := range maintainers {
+		name := maintainerDisplay(maintainer)
+		if maintainer.Role != "" && name != "" {
+			name += " (" + maintainer.Role + ")"
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -17,7 +17,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const maintainerLookupConcurrency = 8
+const (
+	maintainerLookupConcurrency = 8
+	maintainerLookupTimeout     = 5 * time.Minute
+)
 
 func addMaintainersCmd(parent *cobra.Command) {
 	maintainersCmd := &cobra.Command{
@@ -112,7 +115,7 @@ func runMaintainers(cmd *cobra.Command, args []string) error {
 	}
 
 	purls := uniqueMaintainerPURLs(deps)
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), maintainerLookupTimeout)
 	defer cancel()
 
 	data := fetchMaintainerData(ctx, db, deps, purls)

--- a/cmd/maintainers_test.go
+++ b/cmd/maintainers_test.go
@@ -1,10 +1,16 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/registries"
+	"github.com/spf13/cobra"
 )
 
 func TestMaintainerPURLForDependency(t *testing.T) {
@@ -146,6 +152,56 @@ func TestBuildMaintainersResult(t *testing.T) {
 			t.Fatalf("maintainer count = %d, want 1", result.Dependencies[0].MaintainerCount)
 		}
 	})
+}
+
+func TestFetchMaintainerDataUsesCache(t *testing.T) {
+	db, err := database.Create(filepath.Join(t.TempDir(), "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	maintainers := []registries.Maintainer{{Login: "alice"}}
+	raw, err := json.Marshal(maintainers)
+	if err != nil {
+		t.Fatalf("marshal maintainers: %v", err)
+	}
+	err = db.SavePackageMaintainersBatch([]database.PackageMaintainersData{
+		{
+			PURL:        "pkg:npm/express",
+			Ecosystem:   "npm",
+			Name:        "express",
+			Maintainers: string(raw),
+		},
+	})
+	if err != nil {
+		t.Fatalf("save maintainers: %v", err)
+	}
+
+	deps := []database.Dependency{
+		{Name: "express", Ecosystem: "npm", ManifestKind: "manifest"},
+	}
+	got := fetchMaintainerData(context.Background(), db, deps, []string{"pkg:npm/express"})
+	result := got["pkg:npm/express"]
+	if result.Error != "" {
+		t.Fatalf("lookup error = %q, want none", result.Error)
+	}
+	if len(result.Maintainers) != 1 || result.Maintainers[0].Login != "alice" {
+		t.Fatalf("maintainers = %#v, want alice", result.Maintainers)
+	}
+}
+
+func TestOutputMaintainersJSONEmptyResult(t *testing.T) {
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	if err := outputMaintainersJSON(cmd, emptyMaintainersResult()); err != nil {
+		t.Fatalf("output json: %v", err)
+	}
+	if !strings.Contains(out.String(), `"dependencies": []`) {
+		t.Fatalf("json output = %q, want empty dependencies array", out.String())
+	}
 }
 
 func TestFormatMaintainerNames(t *testing.T) {

--- a/cmd/maintainers_test.go
+++ b/cmd/maintainers_test.go
@@ -4,14 +4,45 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
-	"github.com/git-pkgs/registries"
 	"github.com/spf13/cobra"
 )
+
+type mockMaintainersEnrichmentClient struct {
+	packages map[string]*enrichment.PackageInfo
+}
+
+func (m *mockMaintainersEnrichmentClient) BulkLookup(_ context.Context, purls []string) (map[string]*enrichment.PackageInfo, error) {
+	result := make(map[string]*enrichment.PackageInfo)
+	for _, purlStr := range purls {
+		if pkg, ok := m.packages[purlStr]; ok {
+			result[purlStr] = pkg
+		}
+	}
+	return result, nil
+}
+
+func (m *mockMaintainersEnrichmentClient) GetVersions(_ context.Context, _ string) ([]enrichment.VersionInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockMaintainersEnrichmentClient) GetVersion(_ context.Context, _ string) (*enrichment.VersionInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+func setMaintainersMockEnrichment(packages map[string]*enrichment.PackageInfo) func() {
+	orig := NewEnrichmentClient
+	NewEnrichmentClient = func(opts ...enrichment.Option) (enrichment.Client, error) {
+		return &mockMaintainersEnrichmentClient{packages: packages}, nil
+	}
+	return func() { NewEnrichmentClient = orig }
+}
 
 func TestMaintainerPURLForDependency(t *testing.T) {
 	t.Run("builds package PURL without version", func(t *testing.T) {
@@ -96,7 +127,7 @@ func TestBuildMaintainersResult(t *testing.T) {
 	}
 	lookup := map[string]maintainerLookupResult{
 		"pkg:npm/express": {
-			Maintainers: []registries.Maintainer{
+			Maintainers: []MaintainerInfo{
 				{Login: "alice"},
 				{Login: "alice"},
 			},
@@ -161,7 +192,7 @@ func TestFetchMaintainerDataUsesCache(t *testing.T) {
 	}
 	defer func() { _ = db.Close() }()
 
-	maintainers := []registries.Maintainer{{Login: "alice"}}
+	maintainers := []MaintainerInfo{{Login: "alice"}}
 	raw, err := json.Marshal(maintainers)
 	if err != nil {
 		t.Fatalf("marshal maintainers: %v", err)
@@ -188,6 +219,33 @@ func TestFetchMaintainerDataUsesCache(t *testing.T) {
 	}
 	if len(result.Maintainers) != 1 || result.Maintainers[0].Login != "alice" {
 		t.Fatalf("maintainers = %#v, want alice", result.Maintainers)
+	}
+}
+
+func TestFetchMaintainerDataUncachedUsesEnrichmentBulkLookup(t *testing.T) {
+	restore := setMaintainersMockEnrichment(map[string]*enrichment.PackageInfo{
+		"pkg:npm/express": {
+			Maintainers: []enrichment.Maintainer{
+				{Login: "alice", Role: "owner"},
+			},
+		},
+	})
+	defer restore()
+
+	got := fetchMaintainerDataUncached(context.Background(), []string{"pkg:npm/express", "pkg:npm/private"})
+	express := got["pkg:npm/express"]
+	if express.Error != "" {
+		t.Fatalf("express error = %q, want none", express.Error)
+	}
+	if len(express.Maintainers) != 1 || express.Maintainers[0].Login != "alice" || express.Maintainers[0].Role != "owner" {
+		t.Fatalf("express maintainers = %#v, want alice owner", express.Maintainers)
+	}
+	private := got["pkg:npm/private"]
+	if private.Error != "" {
+		t.Fatalf("private error = %q, want none", private.Error)
+	}
+	if len(private.Maintainers) != 0 {
+		t.Fatalf("private maintainers = %#v, want empty", private.Maintainers)
 	}
 }
 

--- a/cmd/maintainers_test.go
+++ b/cmd/maintainers_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/registries"
+)
+
+func TestMaintainerPURLForDependency(t *testing.T) {
+	t.Run("builds package PURL without version", func(t *testing.T) {
+		got := maintainerPURLForDependency(database.Dependency{
+			Name:        "serde",
+			Ecosystem:   "cargo",
+			Requirement: "1.0.0",
+		})
+		if got != "pkg:cargo/serde" {
+			t.Fatalf("maintainer PURL = %q, want pkg:cargo/serde", got)
+		}
+	})
+
+	t.Run("strips version from existing PURL", func(t *testing.T) {
+		got := maintainerPURLForDependency(database.Dependency{
+			PURL:        "pkg:npm/%40scope/pkg@1.0.0?repository_url=https://registry.example.test",
+			Name:        "@scope/pkg",
+			Ecosystem:   "npm",
+			Requirement: "1.0.0",
+		})
+		want := "pkg:npm/%40scope/pkg?repository_url=https:%2F%2Fregistry.example.test"
+		if got != want {
+			t.Fatalf("maintainer PURL = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestSelectMaintainerDependencies(t *testing.T) {
+	deps := []database.Dependency{
+		{Name: "express", ManifestKind: "manifest"},
+		{Name: "accepts", Requirement: "1.3.8", ManifestKind: manifestKindLockfile},
+		{Name: "go", Ecosystem: "golang", Requirement: "1.0.0", ManifestKind: "manifest"},
+	}
+
+	direct := selectMaintainerDependencies(deps, false)
+	if len(direct) != 2 {
+		t.Fatalf("direct deps length = %d, want 2", len(direct))
+	}
+	if direct[0].Name != "express" || direct[1].Name != "go" {
+		t.Fatalf("direct deps = %#v, want express and go", direct)
+	}
+
+	all := selectMaintainerDependencies(deps, true)
+	if len(all) != 2 {
+		t.Fatalf("all deps length = %d, want 2", len(all))
+	}
+	if all[0].Name != "accepts" || all[1].Name != "go" {
+		t.Fatalf("all deps = %#v, want accepts and go", all)
+	}
+}
+
+func TestBuildMaintainersResult(t *testing.T) {
+	deps := []database.Dependency{
+		{
+			Name:         "express",
+			Ecosystem:    "npm",
+			Requirement:  "4.18.2",
+			ManifestPath: "package.json",
+			ManifestKind: "manifest",
+		},
+		{
+			Name:         "lodash",
+			Ecosystem:    "npm",
+			Requirement:  "4.17.21",
+			ManifestPath: "package.json",
+			ManifestKind: "manifest",
+		},
+		{
+			Name:         "broken",
+			Ecosystem:    "npm",
+			Requirement:  "1.0.0",
+			ManifestPath: "package.json",
+			ManifestKind: "manifest",
+		},
+		{
+			Name:         "express",
+			Ecosystem:    "npm",
+			Requirement:  "4.18.2",
+			ManifestPath: "other/package.json",
+			ManifestKind: "manifest",
+		},
+	}
+	lookup := map[string]maintainerLookupResult{
+		"pkg:npm/express": {
+			Maintainers: []registries.Maintainer{
+				{Login: "alice"},
+				{Login: "alice"},
+			},
+		},
+		"pkg:npm/lodash": {},
+		"pkg:npm/broken": {Error: "unsupported ecosystem"},
+	}
+
+	t.Run("all packages", func(t *testing.T) {
+		result := buildMaintainersResult(deps, lookup, false)
+		if result.Summary.TotalDependencies != 4 {
+			t.Fatalf("total dependencies = %d, want 4", result.Summary.TotalDependencies)
+		}
+		if result.Summary.QueriedDependencies != 3 {
+			t.Fatalf("queried dependencies = %d, want 3", result.Summary.QueriedDependencies)
+		}
+		if result.Summary.WithMaintainers != 1 {
+			t.Fatalf("with maintainers = %d, want 1", result.Summary.WithMaintainers)
+		}
+		if result.Summary.WithoutMaintainers != 1 {
+			t.Fatalf("without maintainers = %d, want 1", result.Summary.WithoutMaintainers)
+		}
+		if result.Summary.SingleMaintainer != 1 {
+			t.Fatalf("single maintainer = %d, want 1", result.Summary.SingleMaintainer)
+		}
+		if result.Summary.LookupErrors != 1 {
+			t.Fatalf("lookup errors = %d, want 1", result.Summary.LookupErrors)
+		}
+		if len(result.Dependencies) != 3 {
+			t.Fatalf("dependencies length = %d, want 3", len(result.Dependencies))
+		}
+	})
+
+	t.Run("single maintainer only", func(t *testing.T) {
+		result := buildMaintainersResult(deps, lookup, true)
+		if len(result.Dependencies) != 1 {
+			t.Fatalf("dependencies length = %d, want 1", len(result.Dependencies))
+		}
+		if result.Dependencies[0].Name != "express" {
+			t.Fatalf("dependency = %q, want express", result.Dependencies[0].Name)
+		}
+		if result.Dependencies[0].MaintainerCount != 1 {
+			t.Fatalf("maintainer count = %d, want 1", result.Dependencies[0].MaintainerCount)
+		}
+	})
+}
+
+func TestFormatMaintainerNames(t *testing.T) {
+	got := formatMaintainerNames([]MaintainerInfo{
+		{Login: "alice", Role: "owner"},
+		{Name: "Bob"},
+	})
+	want := "alice (owner), Bob"
+	if got != want {
+		t.Fatalf("maintainer names = %q, want %q", got, want)
+	}
+}

--- a/cmd/maintainers_test.go
+++ b/cmd/maintainers_test.go
@@ -49,11 +49,11 @@ func TestSelectMaintainerDependencies(t *testing.T) {
 	}
 
 	all := selectMaintainerDependencies(deps, true)
-	if len(all) != 2 {
-		t.Fatalf("all deps length = %d, want 2", len(all))
+	if len(all) != 3 {
+		t.Fatalf("all deps length = %d, want 3", len(all))
 	}
-	if all[0].Name != "accepts" || all[1].Name != "go" {
-		t.Fatalf("all deps = %#v, want accepts and go", all)
+	if all[0].Name != "express" || all[1].Name != "accepts" || all[2].Name != "go" {
+		t.Fatalf("all deps = %#v, want express, accepts, and go", all)
 	}
 }
 
@@ -104,30 +104,40 @@ func TestBuildMaintainersResult(t *testing.T) {
 		if result.Summary.TotalDependencies != 4 {
 			t.Fatalf("total dependencies = %d, want 4", result.Summary.TotalDependencies)
 		}
-		if result.Summary.QueriedDependencies != 3 {
-			t.Fatalf("queried dependencies = %d, want 3", result.Summary.QueriedDependencies)
+		if result.Summary.QueriedDependencies != 4 {
+			t.Fatalf("queried dependencies = %d, want 4", result.Summary.QueriedDependencies)
 		}
-		if result.Summary.WithMaintainers != 1 {
-			t.Fatalf("with maintainers = %d, want 1", result.Summary.WithMaintainers)
+		if result.Summary.WithMaintainers != 2 {
+			t.Fatalf("with maintainers = %d, want 2", result.Summary.WithMaintainers)
 		}
 		if result.Summary.WithoutMaintainers != 1 {
 			t.Fatalf("without maintainers = %d, want 1", result.Summary.WithoutMaintainers)
 		}
-		if result.Summary.SingleMaintainer != 1 {
-			t.Fatalf("single maintainer = %d, want 1", result.Summary.SingleMaintainer)
+		if result.Summary.SingleMaintainer != 2 {
+			t.Fatalf("single maintainer = %d, want 2", result.Summary.SingleMaintainer)
 		}
 		if result.Summary.LookupErrors != 1 {
 			t.Fatalf("lookup errors = %d, want 1", result.Summary.LookupErrors)
 		}
-		if len(result.Dependencies) != 3 {
-			t.Fatalf("dependencies length = %d, want 3", len(result.Dependencies))
+		if len(result.Dependencies) != 4 {
+			t.Fatalf("dependencies length = %d, want 4", len(result.Dependencies))
+		}
+
+		manifestPaths := map[string]bool{}
+		for _, dep := range result.Dependencies {
+			if dep.Name == "express" {
+				manifestPaths[dep.ManifestPath] = true
+			}
+		}
+		if !manifestPaths["package.json"] || !manifestPaths["other/package.json"] {
+			t.Fatalf("expected express entries for both manifests, got %#v", result.Dependencies)
 		}
 	})
 
 	t.Run("single maintainer only", func(t *testing.T) {
 		result := buildMaintainersResult(deps, lookup, true)
-		if len(result.Dependencies) != 1 {
-			t.Fatalf("dependencies length = %d, want 1", len(result.Dependencies))
+		if len(result.Dependencies) != 2 {
+			t.Fatalf("dependencies length = %d, want 2", len(result.Dependencies))
 		}
 		if result.Dependencies[0].Name != "express" {
 			t.Fatalf("dependency = %q, want express", result.Dependencies[0].Name)

--- a/cmd/pager_test.go
+++ b/cmd/pager_test.go
@@ -18,6 +18,7 @@ func TestPagerFlagAccepted(t *testing.T) {
 		"freshness",
 		"deprecated",
 		"funding",
+		"maintainers",
 		"log",
 		"list",
 		"history",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,7 @@ func NewRootCmd() *cobra.Command {
 	addBranchCmd(cmd)
 	addOutdatedCmd(cmd)
 	addFundingCmd(cmd)
+	addMaintainersCmd(cmd)
 	addChangelogCmd(cmd)
 	addLicensesCmd(cmd)
 	addIntegrityCmd(cmd)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -157,9 +157,7 @@ The `outdated`, `freshness`, `deprecated`, `funding`, `maintainers`, `changelog`
 
 By default, a hybrid approach routes requests based on PURL qualifiers: packages with a `repository_url` qualifier (indicating a private registry) go directly to that registry, while public packages go through ecosyste.ms. Set `git config pkgs.direct true` or `GIT_PKGS_DIRECT=1` to skip ecosyste.ms and query all registries directly.
 
-Data is cached in the `packages` and `versions` tables with a 24-hour TTL. The `packages` table stores provenance: `repository_url` (the registry queried) and `source` (ecosystems or registries). The `funding` command stores package funding links in `packages`, and the `deprecated` command uses the `versions` cache and fetches exact-version status from registries when cached deprecation metadata is missing.
-
-The `maintainers` command stores package maintainer lists in `packages` and uses the same 24-hour TTL as other package metadata commands.
+Data is cached in the `packages` and `versions` tables with a 24-hour TTL. The `packages` table stores provenance: `repository_url` (the registry queried) and `source` (ecosystems or registries). The `funding` command stores package funding links in `packages`, the `maintainers` command stores package maintainer lists in `packages`, and the `deprecated` command uses the `versions` cache and fetches exact-version status from registries when cached deprecation metadata is missing.
 
 ## Package Management
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -2,7 +2,7 @@
 
 git-pkgs walks a repository's commit history, parses manifest files at each commit, and stores dependency changes in a SQLite database. This lets you query what changed, when, and who did it.
 
-The tool works with two types of data. Intrinsic data comes from your git history: dependency names, versions from manifests, who added them, when, and why. Commands like `list`, `history`, `blame`, `diff`, and `stale` use only intrinsic data and require no network access. Extrinsic data comes from external sources: vulnerability info from [OSV](https://osv.dev), and registry metadata (latest versions, licenses, funding links, deprecation status) from [ecosyste.ms](https://packages.ecosyste.ms/) and package registries. Commands like `vulns`, `outdated`, `freshness`, `licenses`, `deprecated`, and `funding` fetch and cache this external data.
+The tool works with two types of data. Intrinsic data comes from your git history: dependency names, versions from manifests, who added them, when, and why. Commands like `list`, `history`, `blame`, `diff`, and `stale` use only intrinsic data and require no network access. Extrinsic data comes from external sources: vulnerability info from [OSV](https://osv.dev), and registry metadata (latest versions, licenses, funding links, maintainer data, deprecation status) from [ecosyste.ms](https://packages.ecosyste.ms/) and package registries. Commands like `vulns`, `outdated`, `freshness`, `licenses`, `deprecated`, `funding`, and `maintainers` fetch and cache this external data.
 
 ## Package Structure
 
@@ -150,7 +150,7 @@ See [vulns.md](vulns.md) for command documentation.
 
 ## Package Enrichment
 
-The `outdated`, `freshness`, `deprecated`, `funding`, `changelog`, `licenses`, `sbom`, and `integrity --registry` commands fetch metadata from external sources. The [`github.com/git-pkgs/enrichment`](https://github.com/git-pkgs/enrichment) library provides a unified interface with two backends:
+The `outdated`, `freshness`, `deprecated`, `funding`, `maintainers`, `changelog`, `licenses`, `sbom`, and `integrity --registry` commands fetch metadata from external sources. The [`github.com/git-pkgs/enrichment`](https://github.com/git-pkgs/enrichment) library provides a unified interface with two backends:
 
 - **ecosyste.ms** - Bulk API queries via [ecosyste-ms/ecosystems-go](https://github.com/ecosyste-ms/ecosystems-go). Efficient for public packages.
 - **registries** - Direct queries to package registries via [git-pkgs/registries](https://github.com/git-pkgs/registries). Required for private registries.
@@ -158,6 +158,8 @@ The `outdated`, `freshness`, `deprecated`, `funding`, `changelog`, `licenses`, `
 By default, a hybrid approach routes requests based on PURL qualifiers: packages with a `repository_url` qualifier (indicating a private registry) go directly to that registry, while public packages go through ecosyste.ms. Set `git config pkgs.direct true` or `GIT_PKGS_DIRECT=1` to skip ecosyste.ms and query all registries directly.
 
 Data is cached in the `packages` and `versions` tables with a 24-hour TTL. The `packages` table stores provenance: `repository_url` (the registry queried) and `source` (ecosystems or registries). The `funding` command stores package funding links in `packages`, and the `deprecated` command uses the `versions` cache and fetches exact-version status from registries when cached deprecation metadata is missing.
+
+The `maintainers` command stores package maintainer lists in `packages` and uses the same 24-hour TTL as other package metadata commands.
 
 ## Package Management
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -133,6 +133,8 @@ Caches package metadata from registries and vulnerability sync status.
 | funding_synced_at | datetime | When funding metadata was last fetched |
 | supplier_name | text | Package supplier/maintainer name |
 | supplier_type | text | Supplier type (person, organization) |
+| maintainers | text | JSON-encoded package maintainer data |
+| maintainers_synced_at | datetime | When maintainer data was last fetched |
 | source | text | Data source: "ecosystems" or "registries" |
 | enriched_at | datetime | When package metadata was last fetched |
 | vulns_synced_at | datetime | When vulnerabilities were last synced from OSV |

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -8,7 +8,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 11
+const SchemaVersion = 12
 
 type DB struct {
 	*sql.DB

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1756,6 +1756,13 @@ type CachedPackageFunding struct {
 	SyncedAt     time.Time `json:"synced_at"`
 }
 
+// CachedMaintainers represents cached package maintainer data.
+type CachedMaintainers struct {
+	PURL     string    `json:"purl"`
+	Data     string    `json:"data"`
+	SyncedAt time.Time `json:"synced_at"`
+}
+
 // CachedVersion represents cached version data for a package.
 type CachedVersion struct {
 	PURL            string         `json:"purl"`
@@ -1889,6 +1896,64 @@ func (db *DB) GetCachedPackageFunding(purls []string, staleDuration time.Duratio
 	return result, nil
 }
 
+// GetCachedMaintainers returns cached maintainer data for the given PURLs that isn't stale.
+func (db *DB) GetCachedMaintainers(purls []string, staleDuration time.Duration) (map[string]*CachedMaintainers, error) {
+	if len(purls) == 0 {
+		return make(map[string]*CachedMaintainers), nil
+	}
+
+	staleThreshold := time.Now().Add(-staleDuration)
+	result := make(map[string]*CachedMaintainers)
+
+	const batchSize = 500
+	for i := 0; i < len(purls); i += batchSize {
+		end := i + batchSize
+		if end > len(purls) {
+			end = len(purls)
+		}
+		batch := purls[i:end]
+
+		placeholders := make([]string, len(batch))
+		args := make([]interface{}, len(batch)+1)
+		args[0] = staleThreshold.Format(time.RFC3339)
+		for j, purl := range batch {
+			placeholders[j] = "?"
+			args[j+1] = purl
+		}
+
+		query := `SELECT purl, maintainers, maintainers_synced_at
+			FROM packages
+			WHERE maintainers_synced_at >= ? AND purl IN (` + strings.Join(placeholders, ",") + `)`
+
+		rows, err := db.Query(query, args...)
+		if err != nil {
+			return nil, err
+		}
+
+		for rows.Next() {
+			var cached CachedMaintainers
+			var maintainers sql.NullString
+			var syncedAt string
+			if err := rows.Scan(&cached.PURL, &maintainers, &syncedAt); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			if maintainers.Valid {
+				cached.Data = maintainers.String
+			}
+			cached.SyncedAt, _ = time.Parse(time.RFC3339, syncedAt)
+			result[cached.PURL] = &cached
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+
+	return result, nil
+}
+
 // SavePackageEnrichment saves or updates enrichment data for a package.
 func (db *DB) SavePackageEnrichment(purl, ecosystem, name, latestVersion, license, registryURL, source string) error {
 	now := time.Now().Format(time.RFC3339)
@@ -1997,6 +2062,51 @@ func (db *DB) SavePackageFundingBatch(packages []PackageFundingData) error {
 			return err
 		}
 		_, err = stmt.Exec(p.PURL, p.Ecosystem, p.Name, string(raw), now, now, now)
+		if err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	_ = stmt.Close()
+	return tx.Commit()
+}
+
+// PackageMaintainersData holds maintainer data for batch saving.
+type PackageMaintainersData struct {
+	PURL        string
+	Ecosystem   string
+	Name        string
+	Maintainers string
+}
+
+// SavePackageMaintainersBatch saves package maintainer data in a single transaction.
+func (db *DB) SavePackageMaintainersBatch(packages []PackageMaintainersData) error {
+	if len(packages) == 0 {
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().Format(time.RFC3339)
+	stmt, err := tx.Prepare(`
+		INSERT INTO packages (purl, ecosystem, name, maintainers, maintainers_synced_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(purl) DO UPDATE SET
+			maintainers = excluded.maintainers,
+			maintainers_synced_at = excluded.maintainers_synced_at,
+			updated_at = excluded.updated_at`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+
+	for _, p := range packages {
+		_, err = stmt.Exec(p.PURL, p.Ecosystem, p.Name, p.Maintainers, now, now, now)
 		if err != nil {
 			_ = stmt.Close()
 			_ = tx.Rollback()

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -106,6 +106,8 @@ func (db *DB) CreateSchema() error {
 		funding_synced_at DATETIME,
 		supplier_name TEXT,
 		supplier_type TEXT,
+		maintainers TEXT,
+		maintainers_synced_at DATETIME,
 		source TEXT,
 		enriched_at DATETIME,
 		vulns_synced_at DATETIME,


### PR DESCRIPTION
Closes #111

## Summary
- Add `git pkgs maintainers` to show package maintainer counts and identities
- Add `--single` to highlight dependencies with exactly one maintainer
- Add `--all` to include transitive lockfile dependencies
- Support ecosystem/ref filters and JSON output
- Document the new command in README and internals docs

## Testing
- `go test ./cmd -run 'TestMaintainer|TestPagerFlagAccepted'`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`
- `go run . maintainers --help`

