### PR TITLE
Add diff summary stat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,11 +401,12 @@ git pkgs diff                             # HEAD vs working tree
 git pkgs diff --from=abc123 --to=def456   # between two commits
 git pkgs diff --from=HEAD~10              # HEAD~10 vs working tree
 git pkgs diff main..feature               # compare branches
+git pkgs diff main..feature --stat        # aggregate counts only
 git pkgs diff --type=development          # only dev dependency changes
 git pkgs diff --ecosystem=npm             # filter by ecosystem
 ```
 
-With no arguments, compares HEAD against the working tree (like `git diff`). Shows added, removed, and modified packages with version info.
+With no arguments, compares HEAD against the working tree (like `git diff`). Shows added, removed, and modified packages with version info. Use `--stat` or `--summary` for one-line aggregate counts.
 
 ### Diff between files
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -28,6 +28,8 @@ Supports range syntax (main..feature) or explicit --from/--to flags.`,
 	diffCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
 	diffCmd.Flags().StringP("type", "t", "", "Filter by dependency type (runtime, development, etc.)")
 	diffCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	diffCmd.Flags().Bool("stat", false, "Show aggregate dependency change counts")
+	diffCmd.Flags().Bool("summary", false, "Show aggregate dependency change counts")
 	parent.AddCommand(diffCmd)
 }
 
@@ -46,12 +48,24 @@ type DiffEntry struct {
 	ToRequirement   string `json:"to_requirement,omitempty"`
 }
 
+type DiffStat struct {
+	Added        int `json:"added"`
+	Removed      int `json:"removed"`
+	Updated      int `json:"updated"`
+	MajorUpdates int `json:"major_updates"`
+	MinorUpdates int `json:"minor_updates"`
+	PatchUpdates int `json:"patch_updates"`
+	OtherUpdates int `json:"other_updates"`
+}
+
 func runDiff(cmd *cobra.Command, args []string) error {
 	fromRef, _ := cmd.Flags().GetString("from")
 	toRef, _ := cmd.Flags().GetString("to")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	depType, _ := cmd.Flags().GetString("type")
 	format, _ := cmd.Flags().GetString("format")
+	stat, _ := cmd.Flags().GetBool("stat")
+	summary, _ := cmd.Flags().GetBool("summary")
 	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
 
 	// Parse range syntax if provided
@@ -92,6 +106,11 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	// Apply filters
 	if ecosystem != "" || depType != "" {
 		result = filterDiffResult(result, ecosystem, depType)
+	}
+
+	if stat || summary {
+		outputDiffStat(cmd, buildDiffStat(result))
+		return nil
 	}
 
 	if len(result.Added) == 0 && len(result.Modified) == 0 && len(result.Removed) == 0 {
@@ -357,6 +376,63 @@ func outputDiffJSON(cmd *cobra.Command, result *DiffResult) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
 	return enc.Encode(result)
+}
+
+func buildDiffStat(result *DiffResult) DiffStat {
+	stat := DiffStat{
+		Added:   len(result.Added),
+		Removed: len(result.Removed),
+		Updated: len(result.Modified),
+	}
+
+	for _, entry := range result.Modified {
+		switch classifyUpdate(entry.FromRequirement, entry.ToRequirement) {
+		case updateMajor:
+			stat.MajorUpdates++
+		case updateMinor:
+			stat.MinorUpdates++
+		case updatePatch:
+			stat.PatchUpdates++
+		default:
+			stat.OtherUpdates++
+		}
+	}
+
+	return stat
+}
+
+func outputDiffStat(cmd *cobra.Command, stat DiffStat) {
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s, %s, %s",
+		formatCount(stat.Added, "added"),
+		formatCount(stat.Removed, "removed"),
+		formatCount(stat.Updated, "updated"))
+
+	parts := diffUpdateStatParts(stat)
+	if len(parts) > 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), " (%s)", strings.Join(parts, ", "))
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+}
+
+func diffUpdateStatParts(stat DiffStat) []string {
+	parts := make([]string, 0, 4) //nolint:mnd
+	if stat.MajorUpdates > 0 {
+		parts = append(parts, formatCount(stat.MajorUpdates, updateMajor))
+	}
+	if stat.MinorUpdates > 0 {
+		parts = append(parts, formatCount(stat.MinorUpdates, updateMinor))
+	}
+	if stat.PatchUpdates > 0 {
+		parts = append(parts, formatCount(stat.PatchUpdates, updatePatch))
+	}
+	if stat.OtherUpdates > 0 {
+		parts = append(parts, formatCount(stat.OtherUpdates, "other"))
+	}
+	return parts
+}
+
+func formatCount(count int, label string) string {
+	return fmt.Sprintf("%d %s", count, label)
 }
 
 func outputDiffText(cmd *cobra.Command, result *DiffResult) error {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -398,6 +399,64 @@ func TestComputeDiff_Modified(t *testing.T) {
 	}
 	if result.Removed[0].Name != "express" {
 		t.Errorf("expected removed entry for express, got %s", result.Removed[0].Name)
+	}
+}
+
+func TestDiffStat(t *testing.T) {
+	result := &DiffResult{
+		Added: []DiffEntry{
+			{Name: "axios"},
+			{Name: "zod"},
+		},
+		Removed: []DiffEntry{
+			{Name: "request"},
+		},
+		Modified: []DiffEntry{
+			{Name: "major", FromRequirement: "1.0.0", ToRequirement: "2.0.0"},
+			{Name: "minor", FromRequirement: "1.0.0", ToRequirement: "1.1.0"},
+			{Name: "patch", FromRequirement: "1.0.0", ToRequirement: "1.0.1"},
+		},
+	}
+
+	stat := buildDiffStat(result)
+	if stat.Added != 2 {
+		t.Fatalf("added = %d, want 2", stat.Added)
+	}
+	if stat.Removed != 1 {
+		t.Fatalf("removed = %d, want 1", stat.Removed)
+	}
+	if stat.Updated != 3 {
+		t.Fatalf("updated = %d, want 3", stat.Updated)
+	}
+	if stat.MajorUpdates != 1 {
+		t.Fatalf("major updates = %d, want 1", stat.MajorUpdates)
+	}
+	if stat.MinorUpdates != 1 {
+		t.Fatalf("minor updates = %d, want 1", stat.MinorUpdates)
+	}
+	if stat.PatchUpdates != 1 {
+		t.Fatalf("patch updates = %d, want 1", stat.PatchUpdates)
+	}
+}
+
+func TestOutputDiffStat(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+
+	outputDiffStat(root, DiffStat{
+		Added:        2,
+		Removed:      1,
+		Updated:      3,
+		MajorUpdates: 1,
+		MinorUpdates: 1,
+		PatchUpdates: 1,
+	})
+
+	got := strings.TrimSpace(buf.String())
+	want := "2 added, 1 removed, 3 updated (1 major, 1 minor, 1 patch)"
+	if got != want {
+		t.Fatalf("diff stat output = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #123

## Summary
- Add `git pkgs diff --stat` for one-line aggregate dependency change counts
- Add `git pkgs diff --summary` as an alias for the same compact output
- Count added, removed, and updated dependencies
- Break updated dependencies down into major, minor, patch and other version changes
- Document the new diff summary mode in README

## Testing
- `go test ./cmd -run 'TestDiff|TestComputeDiff|TestPagerFlagAccepted'`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`
- `go run . diff --help`