### PR TITLE
Sort diff-driver output by scope as final tiebreaker

### DIFF
--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -198,13 +198,16 @@ func convertLockfile(cmd *cobra.Command, filePath string) error {
 		return nil
 	}
 
-	// Sort dependencies by name, then version for deterministic output
+	// Sort dependencies by name, then version, then scope for deterministic output
 	deps := result.Dependencies
 	sort.Slice(deps, func(i, j int) bool {
 		if deps[i].Name != deps[j].Name {
 			return deps[i].Name < deps[j].Name
 		}
-		return deps[i].Version < deps[j].Version
+		if deps[i].Version != deps[j].Version {
+			return deps[i].Version < deps[j].Version
+		}
+		return deps[i].Scope < deps[j].Scope
 	})
 
 	// Output sorted list

--- a/cmd/diff_driver_test.go
+++ b/cmd/diff_driver_test.go
@@ -67,4 +67,54 @@ BUNDLED WITH
 			}
 		}
 	})
+
+	t.Run("sorts by scope when name and version match", func(t *testing.T) {
+		// A Pipfile.lock can list the same package at the same version in both
+		// the default and develop sections. The parser emits two entries that
+		// differ only in scope; without scope in the sort key the relative
+		// order of those lines is non-deterministic (#217).
+		lockContent := `{
+  "_meta": {"hash": {"sha256": ""}, "pipfile-spec": 6},
+  "default": {
+    "alpha":   {"version": "==1.0.0"},
+    "bravo":   {"version": "==1.0.0"},
+    "charlie": {"version": "==1.0.0"},
+    "delta":   {"version": "==1.0.0"},
+    "echo":    {"version": "==1.0.0"},
+    "foxtrot": {"version": "==1.0.0"}
+  },
+  "develop": {
+    "alpha":   {"version": "==1.0.0"},
+    "bravo":   {"version": "==1.0.0"},
+    "charlie": {"version": "==1.0.0"},
+    "delta":   {"version": "==1.0.0"},
+    "echo":    {"version": "==1.0.0"},
+    "foxtrot": {"version": "==1.0.0"}
+  }
+}`
+		tmpDir := t.TempDir()
+		lockPath := filepath.Join(tmpDir, "Pipfile.lock")
+		if err := os.WriteFile(lockPath, []byte(lockContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"diff-driver", lockPath})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("diff-driver failed: %v", err)
+		}
+
+		lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+		if len(lines) != 12 {
+			t.Fatalf("expected 12 lines, got %d:\n%s", len(lines), stdout.String())
+		}
+		for i := 1; i < len(lines); i++ {
+			if lines[i-1] > lines[i] {
+				t.Errorf("lines not sorted: %q came before %q", lines[i-1], lines[i])
+			}
+		}
+	})
 }


### PR DESCRIPTION
PR #166 added scope to each diff-driver output line but the sort comparator in `convertLockfile` still only considered name and version. When a lockfile lists the same package and version under more than one scope (e.g. Pipfile.lock `default` + `develop`, or npm with nested dev/prod copies), those entries compared equal and `sort.Slice` ordered them however the parser emitted them, so `git diff` showed hunks where nothing had actually changed.

This adds `Scope` as the third sort key and a regression test using a Pipfile.lock with packages duplicated across both sections.

Fixes #217