### PR TITLE
Add license drift detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,11 @@ git pkgs licenses               # show license for each dependency
 git pkgs licenses --permissive  # flag copyleft licenses
 git pkgs licenses --allow=MIT,Apache-2.0  # explicit allow list
 git pkgs licenses --group       # group output by license
+git pkgs licenses --drift       # detect installed-to-latest license changes
 ```
 
 Fetches license information from package registries. Exits with code 1 if violations are found, making it suitable for CI.
+Use `--drift` to compare resolved dependency versions with the latest package metadata and flag changes like MIT to GPL.
 
 ### Vulnerability scanning
 

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/git-pkgs/enrichment"
@@ -40,6 +42,7 @@ Licenses are normalized to SPDX identifiers when possible.`,
 	licensesCmd.Flags().Bool("copyleft", false, "Flag copyleft licenses (GPL, AGPL)")
 	licensesCmd.Flags().Bool("unknown", false, "Flag packages with unknown licenses")
 	licensesCmd.Flags().Bool("group", false, "Group output by license")
+	licensesCmd.Flags().Bool("drift", false, "Detect dependencies whose license changed between installed and latest versions")
 	parent.AddCommand(licensesCmd)
 }
 
@@ -55,6 +58,29 @@ type LicenseInfo struct {
 	FlagReason   string   `json:"flag_reason,omitempty"`
 }
 
+type LicenseDriftSummary struct {
+	TotalDependencies      int `json:"total_dependencies"`
+	CheckedDependencies    int `json:"checked_dependencies"`
+	DriftedDependencies    int `json:"drifted_dependencies"`
+	UnresolvedDependencies int `json:"unresolved_dependencies"`
+}
+
+type LicenseDriftEntry struct {
+	Name           string `json:"name"`
+	Ecosystem      string `json:"ecosystem"`
+	CurrentVersion string `json:"current_version"`
+	LatestVersion  string `json:"latest_version,omitempty"`
+	CurrentLicense string `json:"current_license"`
+	LatestLicense  string `json:"latest_license"`
+	ManifestPath   string `json:"manifest_path"`
+	PURL           string `json:"purl,omitempty"`
+}
+
+type LicenseDriftResult struct {
+	Summary      LicenseDriftSummary `json:"summary"`
+	Dependencies []LicenseDriftEntry `json:"dependencies"`
+}
+
 func runLicenses(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
@@ -66,6 +92,13 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	flagCopyleft, _ := cmd.Flags().GetBool("copyleft")
 	flagUnknown, _ := cmd.Flags().GetBool("unknown")
 	groupBy, _ := cmd.Flags().GetBool("group")
+	driftOnly, _ := cmd.Flags().GetBool("drift")
+
+	if driftOnly {
+		if err := validateLicenseDriftFlags(allowList, denyList, flagPermissive, flagCopyleft, flagUnknown, groupBy); err != nil {
+			return err
+		}
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {
@@ -81,6 +114,10 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, ecosystem)
+
+	if driftOnly {
+		return runLicenseDrift(cmd, db, deps, format)
+	}
 
 	// Filter to manifest dependencies (direct deps)
 	var directDeps []database.Dependency
@@ -254,10 +291,37 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func validateLicenseDriftFlags(allowList, denyList []string, flagPermissive, flagCopyleft, flagUnknown, groupBy bool) error {
+	var incompatible []string
+	if len(allowList) > 0 {
+		incompatible = append(incompatible, "--allow")
+	}
+	if len(denyList) > 0 {
+		incompatible = append(incompatible, "--deny")
+	}
+	if flagPermissive {
+		incompatible = append(incompatible, "--permissive")
+	}
+	if flagCopyleft {
+		incompatible = append(incompatible, "--copyleft")
+	}
+	if flagUnknown {
+		incompatible = append(incompatible, "--unknown")
+	}
+	if groupBy {
+		incompatible = append(incompatible, "--group")
+	}
+	if len(incompatible) == 0 {
+		return nil
+	}
+	return fmt.Errorf("--drift cannot be combined with %s", strings.Join(incompatible, ", "))
+}
+
 type licenseData struct {
-	License   string
-	Name      string
-	Ecosystem string
+	License       string
+	Name          string
+	Ecosystem     string
+	LatestVersion string
 }
 
 func getLicenseData(db *database.DB, purls []string, purlToDep map[string]database.Dependency) (map[string]*licenseData, error) {
@@ -272,9 +336,10 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 		}
 		for purl, cp := range cached {
 			result[purl] = &licenseData{
-				License:   cp.License,
-				Name:      cp.Name,
-				Ecosystem: cp.Ecosystem,
+				License:       cp.License,
+				Name:          cp.Name,
+				Ecosystem:     cp.Ecosystem,
+				LatestVersion: cp.LatestVersion,
 			}
 		}
 		// Find uncached PURLs
@@ -308,6 +373,7 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 			if pkg != nil {
 				data.Name = pkg.Name
 				data.Ecosystem = pkg.Ecosystem
+				data.LatestVersion = pkg.LatestVersion
 				// Normalize license to SPDX identifier
 				if pkg.License != "" {
 					if normalized, err := spdx.Normalize(pkg.License); err == nil {
@@ -328,6 +394,369 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 	}
 
 	return result, nil
+}
+
+func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Dependency, format string) error {
+	resolved := make([]database.Dependency, 0, len(deps))
+	for _, dep := range deps {
+		if isResolvedDependency(dep) {
+			resolved = append(resolved, dep)
+		}
+	}
+
+	if len(resolved) == 0 {
+		result := emptyLicenseDriftResult()
+		if format == formatJSON {
+			return outputLicenseDriftJSON(cmd, result)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No resolved dependencies found.")
+		return nil
+	}
+
+	result, err := computeLicenseDrift(db, resolved)
+	if err != nil {
+		return err
+	}
+
+	switch format {
+	case formatJSON:
+		return outputLicenseDriftJSON(cmd, result)
+	case "csv":
+		return outputLicenseDriftCSV(cmd, result.Dependencies)
+	default:
+		outputLicenseDriftText(cmd, result)
+		return nil
+	}
+}
+
+func computeLicenseDrift(db *database.DB, deps []database.Dependency) (*LicenseDriftResult, error) {
+	result := emptyLicenseDriftResult()
+	result.Summary.TotalDependencies = len(deps)
+
+	packagePURLs := make([]string, 0, len(deps))
+	purlToDep := make(map[string]database.Dependency)
+	seenPURLs := make(map[string]bool)
+	for _, dep := range deps {
+		packagePURL := licensePackagePURLForDependency(dep)
+		if packagePURL == "" {
+			continue
+		}
+		if !seenPURLs[packagePURL] {
+			seenPURLs[packagePURL] = true
+			packagePURLs = append(packagePURLs, packagePURL)
+			purlToDep[packagePURL] = dep
+		}
+	}
+
+	packageLicenses, err := getLicenseData(db, packagePURLs, purlToDep)
+	if err != nil {
+		return nil, fmt.Errorf("looking up package licenses: %w", err)
+	}
+
+	versionLicenses, err := loadLicenseDriftVersionLicenses(db, deps)
+	if err != nil {
+		return nil, fmt.Errorf("looking up version licenses: %w", err)
+	}
+
+	seenDeps := make(map[string]bool)
+	for _, dep := range deps {
+		packagePURL := licensePackagePURLForDependency(dep)
+		versionedPURL := versionedPURLForDependency(dep)
+		key := packagePURL + "\x00" + dep.Requirement + "\x00" + dep.ManifestPath
+		if packagePURL == "" || versionedPURL == "" || seenDeps[key] {
+			continue
+		}
+		seenDeps[key] = true
+
+		packageData := packageLicenses[packagePURL]
+		currentLicense := normalizeLicenseString(versionLicenses[versionedPURL])
+		latestLicense := ""
+		latestVersion := ""
+		if packageData != nil {
+			latestLicense = normalizeLicenseString(packageData.License)
+			latestVersion = packageData.LatestVersion
+		}
+
+		if currentLicense == "" || latestLicense == "" {
+			result.Summary.UnresolvedDependencies++
+			continue
+		}
+
+		result.Summary.CheckedDependencies++
+		if currentLicense == latestLicense {
+			continue
+		}
+
+		result.Summary.DriftedDependencies++
+		result.Dependencies = append(result.Dependencies, LicenseDriftEntry{
+			Name:           dep.Name,
+			Ecosystem:      dep.Ecosystem,
+			CurrentVersion: dep.Requirement,
+			LatestVersion:  latestVersion,
+			CurrentLicense: currentLicense,
+			LatestLicense:  latestLicense,
+			ManifestPath:   dep.ManifestPath,
+			PURL:           versionedPURL,
+		})
+	}
+
+	sort.Slice(result.Dependencies, func(i, j int) bool {
+		if result.Dependencies[i].Name != result.Dependencies[j].Name {
+			return result.Dependencies[i].Name < result.Dependencies[j].Name
+		}
+		if result.Dependencies[i].ManifestPath != result.Dependencies[j].ManifestPath {
+			return result.Dependencies[i].ManifestPath < result.Dependencies[j].ManifestPath
+		}
+		return result.Dependencies[i].CurrentVersion < result.Dependencies[j].CurrentVersion
+	})
+
+	return result, nil
+}
+
+func licensePackagePURLForDependency(dep database.Dependency) string {
+	versionedPURL := versionedPURLForDependency(dep)
+	if versionedPURL != "" {
+		return packagePURLFromVersioned(versionedPURL)
+	}
+	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+}
+
+func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency) (map[string]string, error) {
+	needed := make(map[string]map[string]bool)
+	for _, dep := range deps {
+		versionedPURL := versionedPURLForDependency(dep)
+		packagePURL := licensePackagePURLForDependency(dep)
+		if versionedPURL == "" || packagePURL == "" || dep.Requirement == "" {
+			continue
+		}
+		if needed[packagePURL] == nil {
+			needed[packagePURL] = make(map[string]bool)
+		}
+		needed[packagePURL][dep.Requirement] = true
+	}
+
+	result := cachedLicenseDriftVersionLicenses(db, needed)
+	var missing []licenseDriftVersionLookup
+	for packagePURL, versions := range needed {
+		for version := range versions {
+			versionedPURL := licenseVersionedPURL(packagePURL, version)
+			if versionedPURL == "" || result[versionedPURL] != "" {
+				continue
+			}
+			missing = append(missing, licenseDriftVersionLookup{
+				PackagePURL:   packagePURL,
+				VersionedPURL: versionedPURL,
+			})
+		}
+	}
+	if len(missing) == 0 {
+		return result, nil
+	}
+
+	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	if err != nil {
+		return nil, err
+	}
+
+	const licenseDriftLookupTimeout = 5 * time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), licenseDriftLookupTimeout)
+	defer cancel()
+
+	fetched, fetchErrors := fetchLicenseDriftVersions(ctx, client, missing)
+	for _, fetchedVersion := range fetched {
+		saveLicenseDriftVersion(db, fetchedVersion.PackagePURL, fetchedVersion.VersionedPURL, fetchedVersion.Version)
+		if fetchedVersion.Version == nil || fetchedVersion.Version.License == "" {
+			continue
+		}
+		result[fetchedVersion.VersionedPURL] = normalizeLicenseString(fetchedVersion.Version.License)
+	}
+	if len(fetchErrors) == len(missing) {
+		return nil, fmt.Errorf("fetching license drift metadata failed for all %d uncached versions: %w",
+			len(missing), errors.Join(fetchErrors...))
+	}
+
+	return result, nil
+}
+
+type licenseDriftVersionLookup struct {
+	PackagePURL   string
+	VersionedPURL string
+}
+
+type fetchedLicenseDriftVersion struct {
+	licenseDriftVersionLookup
+	Version *enrichment.VersionInfo
+}
+
+func fetchLicenseDriftVersions(
+	ctx context.Context,
+	client enrichment.Client,
+	missing []licenseDriftVersionLookup,
+) ([]fetchedLicenseDriftVersion, []error) {
+	const licenseDriftLookupConcurrency = 8
+
+	workers := licenseDriftLookupConcurrency
+	if len(missing) < workers {
+		workers = len(missing)
+	}
+	jobs := make(chan licenseDriftVersionLookup)
+	results := make(chan fetchedLicenseDriftVersion, len(missing))
+	errorsCh := make(chan error, len(missing))
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for lookup := range jobs {
+				versionInfo, err := client.GetVersion(ctx, lookup.VersionedPURL)
+				if err != nil {
+					errorsCh <- fmt.Errorf("%s: %w", lookup.VersionedPURL, err)
+					continue
+				}
+				results <- fetchedLicenseDriftVersion{
+					licenseDriftVersionLookup: lookup,
+					Version:                   versionInfo,
+				}
+			}
+		}()
+	}
+
+	for _, lookup := range missing {
+		jobs <- lookup
+	}
+	close(jobs)
+	wg.Wait()
+	close(results)
+	close(errorsCh)
+
+	var fetched []fetchedLicenseDriftVersion
+	for result := range results {
+		fetched = append(fetched, result)
+	}
+	var fetchErrors []error
+	for err := range errorsCh {
+		fetchErrors = append(fetchErrors, err)
+	}
+	return fetched, fetchErrors
+}
+
+func cachedLicenseDriftVersionLicenses(db *database.DB, needed map[string]map[string]bool) map[string]string {
+	result := make(map[string]string)
+	if db == nil {
+		return result
+	}
+
+	for packagePURL := range needed {
+		cached, err := db.GetCachedVersions(packagePURL, enrichmentCacheTTL)
+		if err != nil {
+			continue
+		}
+		for _, cachedVersion := range cached {
+			if cachedVersion.License == "" {
+				continue
+			}
+			result[cachedVersion.PURL] = normalizeLicenseString(cachedVersion.License)
+		}
+	}
+	return result
+}
+
+func saveLicenseDriftVersion(db *database.DB, packagePURL string, versionedPURL string, versionInfo *enrichment.VersionInfo) {
+	if db == nil || versionInfo == nil || versionedPURL == "" {
+		return
+	}
+
+	_ = db.SaveVersions([]database.CachedVersion{{
+		PURL:        versionedPURL,
+		PackagePURL: packagePURL,
+		License:     normalizeLicenseString(versionInfo.License),
+		PublishedAt: versionInfo.PublishedAt,
+	}})
+}
+
+func licenseVersionedPURL(packagePURL string, version string) string {
+	if packagePURL == "" || version == "" {
+		return ""
+	}
+	parsed, err := purl.Parse(packagePURL)
+	if err != nil {
+		return ""
+	}
+	return parsed.WithVersion(version).String()
+}
+
+func normalizeLicenseString(license string) string {
+	license = strings.TrimSpace(license)
+	if license == "" {
+		return ""
+	}
+	if normalized, err := spdx.Normalize(license); err == nil {
+		return normalized
+	}
+	return license
+}
+
+func emptyLicenseDriftResult() *LicenseDriftResult {
+	return &LicenseDriftResult{
+		Dependencies: []LicenseDriftEntry{},
+	}
+}
+
+func outputLicenseDriftJSON(cmd *cobra.Command, result *LicenseDriftResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func outputLicenseDriftCSV(cmd *cobra.Command, entries []LicenseDriftEntry) error {
+	w := csv.NewWriter(cmd.OutOrStdout())
+	defer w.Flush()
+
+	if err := w.Write([]string{"Name", "Ecosystem", "Current Version", "Latest Version", "Current License", "Latest License", "Manifest", "PURL"}); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := w.Write([]string{
+			entry.Name,
+			entry.Ecosystem,
+			entry.CurrentVersion,
+			entry.LatestVersion,
+			entry.CurrentLicense,
+			entry.LatestLicense,
+			entry.ManifestPath,
+			entry.PURL,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func outputLicenseDriftText(cmd *cobra.Command, result *LicenseDriftResult) {
+	if len(result.Dependencies) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No license drift detected.")
+		if result.Summary.UnresolvedDependencies > 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Unresolved dependencies: %d\n", result.Summary.UnresolvedDependencies)
+		}
+		return
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Found %d dependencies with license drift:\n\n", len(result.Dependencies))
+	for _, entry := range result.Dependencies {
+		latestVersion := entry.LatestVersion
+		if latestVersion == "" {
+			latestVersion = "latest"
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s (%s): %s %s -> %s %s\n",
+			entry.Name,
+			entry.Ecosystem,
+			entry.CurrentVersion,
+			entry.CurrentLicense,
+			latestVersion,
+			entry.LatestLicense,
+		)
+	}
 }
 
 func outputLicensesJSON(cmd *cobra.Command, infos []LicenseInfo) error {

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/git-pkgs/enrichment"
@@ -14,10 +15,18 @@ import (
 
 // mockEnrichmentClient returns canned license data instead of calling external APIs.
 type mockEnrichmentClient struct {
-	packages map[string]*enrichment.PackageInfo
+	mu               sync.Mutex
+	packages         map[string]*enrichment.PackageInfo
+	versions         map[string][]enrichment.VersionInfo
+	versionInfos     map[string]*enrichment.VersionInfo
+	getVersionsCalls int
+	getVersionCalls  int
 }
 
 func (m *mockEnrichmentClient) BulkLookup(_ context.Context, purls []string) (map[string]*enrichment.PackageInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	result := make(map[string]*enrichment.PackageInfo)
 	for _, p := range purls {
 		if pkg, ok := m.packages[p]; ok {
@@ -27,22 +36,50 @@ func (m *mockEnrichmentClient) BulkLookup(_ context.Context, purls []string) (ma
 	return result, nil
 }
 
-func (m *mockEnrichmentClient) GetVersions(_ context.Context, _ string) ([]enrichment.VersionInfo, error) {
-	return nil, nil
+func (m *mockEnrichmentClient) GetVersions(_ context.Context, purl string) ([]enrichment.VersionInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.getVersionsCalls++
+	return m.versions[purl], nil
 }
 
-func (m *mockEnrichmentClient) GetVersion(_ context.Context, _ string) (*enrichment.VersionInfo, error) {
+func (m *mockEnrichmentClient) GetVersion(_ context.Context, purl string) (*enrichment.VersionInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.getVersionCalls++
+	if info, ok := m.versionInfos[purl]; ok {
+		return info, nil
+	}
 	return nil, nil
 }
 
 // setMockEnrichment replaces the enrichment client constructor with one that
 // returns a mock, and returns a cleanup function to restore the original.
 func setMockEnrichment(packages map[string]*enrichment.PackageInfo) func() {
+	return setMockEnrichmentWithVersions(packages, nil)
+}
+
+func setMockEnrichmentWithVersions(packages map[string]*enrichment.PackageInfo, versions map[string][]enrichment.VersionInfo) func() {
+	mock, restore := setMockEnrichmentClient(&mockEnrichmentClient{packages: packages, versions: versions})
+	_ = mock
+	return restore
+}
+
+func setMockEnrichmentWithVersionInfos(
+	packages map[string]*enrichment.PackageInfo,
+	versions map[string]*enrichment.VersionInfo,
+) (*mockEnrichmentClient, func()) {
+	return setMockEnrichmentClient(&mockEnrichmentClient{packages: packages, versionInfos: versions})
+}
+
+func setMockEnrichmentClient(mock *mockEnrichmentClient) (*mockEnrichmentClient, func()) {
 	orig := cmd.NewEnrichmentClient
 	cmd.NewEnrichmentClient = func(opts ...enrichment.Option) (enrichment.Client, error) {
-		return &mockEnrichmentClient{packages: packages}, nil
+		return mock, nil
 	}
-	return func() { cmd.NewEnrichmentClient = orig }
+	return mock, func() { cmd.NewEnrichmentClient = orig }
 }
 
 // Gemfile with a known copyleft dependency (sidekiq uses LGPL)
@@ -246,6 +283,136 @@ func TestLicensesCommand(t *testing.T) {
 		}
 		if err == nil {
 			t.Error("expected command to return error when non-allowed license found")
+		}
+	})
+
+	t.Run("drift flag reports installed version license changes", func(t *testing.T) {
+		mock, restore := setMockEnrichmentWithVersionInfos(
+			map[string]*enrichment.PackageInfo{
+				"pkg:npm/express": {Ecosystem: "npm", Name: "express", LatestVersion: "5.0.0", License: "GPL-3.0-only"},
+				"pkg:npm/lodash":  {Ecosystem: "npm", Name: "lodash", LatestVersion: "4.17.21", License: "MIT"},
+				"pkg:npm/jest":    {Ecosystem: "npm", Name: "jest", LatestVersion: "29.7.0", License: "MIT"},
+			},
+			map[string]*enrichment.VersionInfo{
+				"pkg:npm/express@4.18.2": {Number: "4.18.2", License: "MIT"},
+				"pkg:npm/lodash@4.17.21": {Number: "4.17.21", License: "MIT"},
+				"pkg:npm/jest@29.7.0":    {Number: "29.7.0", License: "MIT"},
+			},
+		)
+		defer restore()
+
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add lockfile")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		var stdout, stderr bytes.Buffer
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--drift", "--format", "json"})
+		rootCmd.SetOut(&stdout)
+		rootCmd.SetErr(&stderr)
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("licenses --drift failed: %v\nstderr: %s", err, stderr.String())
+		}
+
+		var result cmd.LicenseDriftResult
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("failed to parse drift JSON: %v\nOutput: %s", err, stdout.String())
+		}
+		if result.Summary.DriftedDependencies != 1 {
+			t.Fatalf("expected one drifted dependency, got %+v", result.Summary)
+		}
+		if len(result.Dependencies) != 1 {
+			t.Fatalf("expected one drift entry, got %d", len(result.Dependencies))
+		}
+
+		entry := result.Dependencies[0]
+		if entry.Name != "express" {
+			t.Fatalf("expected express drift entry, got %q", entry.Name)
+		}
+		if entry.CurrentLicense != "MIT" || entry.LatestLicense != "GPL-3.0-only" {
+			t.Fatalf("unexpected license drift values: %+v", entry)
+		}
+
+		mock.mu.Lock()
+		getVersionCalls := mock.getVersionCalls
+		getVersionsCalls := mock.getVersionsCalls
+		mock.mu.Unlock()
+		if getVersionCalls == 0 {
+			t.Fatal("expected drift lookup to call GetVersion")
+		}
+		if getVersionsCalls != 0 {
+			t.Fatalf("GetVersions calls = %d, want 0", getVersionsCalls)
+		}
+	})
+
+	t.Run("drift text output omits repeated package names", func(t *testing.T) {
+		_, restore := setMockEnrichmentWithVersionInfos(
+			map[string]*enrichment.PackageInfo{
+				"pkg:npm/express": {Ecosystem: "npm", Name: "express", LatestVersion: "5.0.0", License: "GPL-3.0-only"},
+				"pkg:npm/lodash":  {Ecosystem: "npm", Name: "lodash", LatestVersion: "4.17.21", License: "MIT"},
+				"pkg:npm/jest":    {Ecosystem: "npm", Name: "jest", LatestVersion: "29.7.0", License: "MIT"},
+			},
+			map[string]*enrichment.VersionInfo{
+				"pkg:npm/express@4.18.2": {Number: "4.18.2", License: "MIT"},
+				"pkg:npm/lodash@4.17.21": {Number: "4.17.21", License: "MIT"},
+				"pkg:npm/jest@29.7.0":    {Number: "29.7.0", License: "MIT"},
+			},
+		)
+		defer restore()
+
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add lockfile")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		var stdout, stderr bytes.Buffer
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--drift"})
+		rootCmd.SetOut(&stdout)
+		rootCmd.SetErr(&stderr)
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("licenses --drift failed: %v\nstderr: %s", err, stderr.String())
+		}
+
+		output := stdout.String()
+		if !strings.Contains(output, "express (npm): 4.18.2 MIT -> 5.0.0 GPL-3.0-only") {
+			t.Fatalf("drift text output missing compact entry: %q", output)
+		}
+		if strings.Contains(output, "express@4.18.2") || strings.Contains(output, "express@5.0.0") {
+			t.Fatalf("drift text output repeats package name: %q", output)
+		}
+	})
+
+	t.Run("drift rejects incompatible license filters", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add lockfile")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--drift", "--permissive", "--allow", "MIT"})
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("expected licenses --drift with filters to fail")
+		}
+		if !strings.Contains(err.Error(), "--drift cannot be combined with --allow, --permissive") {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -159,6 +159,8 @@ By default, a hybrid approach routes requests based on PURL qualifiers: packages
 
 Data is cached in the `packages` and `versions` tables with a 24-hour TTL. The `packages` table stores provenance: `repository_url` (the registry queried) and `source` (ecosystems or registries). The `funding` command stores package funding links in `packages`, the `maintainers` command stores package maintainer lists in `packages`, and the `deprecated` command uses the `versions` cache and fetches exact-version status from registries when cached deprecation metadata is missing.
 
+The `licenses --drift` check reads per-version license data from the `versions` cache and falls back to enrichment version lookups for uncached installed versions.
+
 ## Package Management
 
 The `install`, `add`, `remove`, and `update` commands use [git-pkgs/managers](https://github.com/git-pkgs/managers) to translate generic operations into package manager CLI commands. The library builds commands programmatically from YAML definitions rather than constructing shell strings.


### PR DESCRIPTION
Closes #23
## Summary
- Add `git pkgs licenses --drift` to detect resolved dependencies whose installed-version license differs from latest package metadata
- Support text, JSON, and CSV output for license drift results
- Reuse cached package/version metadata and fetch uncached version license data through enrichment
- Document the new `--drift` option in the README

## Tests
- `go test ./cmd -run 'TestLicensesCommand|TestSpdxPermissiveCheck'`
- `go test ./...`
- `git diff --check`

