### PR TITLE
Add scorecard plugin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,20 @@ builds:
       - -X github.com/git-pkgs/git-pkgs/cmd.version={{.Version}}
       - -X github.com/git-pkgs/git-pkgs/cmd.commit={{.Commit}}
       - -X github.com/git-pkgs/git-pkgs/cmd.date={{.Date}}
+  - main: ./plugins/scorecard
+    binary: git-pkgs-scorecard
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - -s -w
 
 archives:
   - formats: tar.gz

--- a/README.md
+++ b/README.md
@@ -696,6 +696,21 @@ Plugins appear in a separate "Plugin commands" section in `git pkgs --help`. All
 
 If a plugin name collides with a built-in command, the built-in takes precedence. When the same name exists in multiple `$PATH` directories, the first match wins.
 
+### First-party scorecard plugin
+
+This repository includes an OpenSSF Scorecard plugin candidate:
+
+```bash
+go build -o ~/bin/git-pkgs-scorecard ./plugins/scorecard
+git pkgs scorecard
+git pkgs scorecard --below=5
+git pkgs scorecard --checks=Maintained,Dangerous-Workflow --below=3
+git pkgs list --format json | git-pkgs-scorecard --input -
+git pkgs scorecard --format=json
+```
+
+The plugin consumes `git pkgs list --format json`, resolves package repository URLs through enrichment metadata, queries the OpenSSF Scorecard API, and reports overall scores plus selected checks.
+
 ## Configuration
 
 git-pkgs respects [standard git configuration](https://git-scm.com/docs/git-config).

--- a/plugins/scorecard/main.go
+++ b/plugins/scorecard/main.go
@@ -1,0 +1,521 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime/debug"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/enrichment/scorecard"
+	"github.com/git-pkgs/purl"
+)
+
+const formatJSON = "json"
+const versionUnknown = "unknown"
+
+type dependency struct {
+	Name         string `json:"name"`
+	Ecosystem    string `json:"ecosystem"`
+	PURL         string `json:"purl"`
+	Requirement  string `json:"requirement"`
+	ManifestPath string `json:"manifest_path"`
+}
+
+type scorecardSummary struct {
+	TotalDependencies      int `json:"total_dependencies"`
+	PackagesWithRepos      int `json:"packages_with_repos"`
+	CheckedRepositories    int `json:"checked_repositories"`
+	DisplayedDependencies  int `json:"displayed_dependencies"`
+	PolicyFailures         int `json:"policy_failures"`
+	SkippedNoRepository    int `json:"skipped_no_repository"`
+	SkippedUnsupportedRepo int `json:"skipped_unsupported_repository"`
+	LookupErrors           int `json:"lookup_errors"`
+}
+
+type scorecardEntry struct {
+	Name         string           `json:"name"`
+	Ecosystem    string           `json:"ecosystem"`
+	Version      string           `json:"version,omitempty"`
+	ManifestPath string           `json:"manifest_path,omitempty"`
+	PURL         string           `json:"purl,omitempty"`
+	Repository   string           `json:"repository"`
+	Score        float64          `json:"score"`
+	Date         string           `json:"date,omitempty"`
+	Checks       []scorecardCheck `json:"checks,omitempty"`
+	LookupError  string           `json:"lookup_error,omitempty"`
+}
+
+type scorecardCheck struct {
+	Name   string `json:"name"`
+	Score  int    `json:"score"`
+	Reason string `json:"reason,omitempty"`
+}
+
+type scorecardResult struct {
+	Summary      scorecardSummary `json:"summary"`
+	Dependencies []scorecardEntry `json:"dependencies"`
+}
+
+type options struct {
+	inputPath string
+	format    string
+	below     float64
+	checks    map[string]bool
+}
+
+type packageLookup interface {
+	BulkLookup(ctx context.Context, purls []string) (map[string]*enrichment.PackageInfo, error)
+}
+
+type scoreLookup interface {
+	GetScore(ctx context.Context, repoURL string) (*scorecard.Result, error)
+}
+
+var newPackageLookup = func() (packageLookup, error) {
+	return enrichment.NewClient(enrichment.WithUserAgent(scorecardUserAgent()))
+}
+
+var newScoreLookup = func() scoreLookup {
+	return scorecard.New(scorecardUserAgent())
+}
+
+func main() {
+	opts, err := parseOptions(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+
+	deps, err := loadDependencies(opts.inputPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "loading dependencies: %v\n", err)
+		os.Exit(1)
+	}
+
+	result, err := runScorecard(deps, opts)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "scorecard: %v\n", err)
+		os.Exit(1)
+	}
+
+	switch opts.format {
+	case formatJSON:
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(result); err != nil {
+			fmt.Fprintf(os.Stderr, "writing json: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		outputText(os.Stdout, result, opts)
+	}
+
+	if result.Summary.PolicyFailures > 0 {
+		os.Exit(1)
+	}
+}
+
+func scorecardUserAgent() string {
+	pluginVersion := versionUnknown
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		pluginVersion = info.Main.Version
+	}
+	return "git-pkgs/" + pluginVersion
+}
+
+func parseOptions(args []string) (options, error) {
+	fs := flag.NewFlagSet("git-pkgs-scorecard", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	input := fs.String("input", "", "Read dependency JSON from file instead of running git pkgs list --format json; use - for stdin")
+	format := fs.String("format", "text", "Output format: text, json")
+	below := fs.String("below", "", "Only show packages with an overall score or selected check score at or below N")
+	checks := fs.String("checks", "", "Comma-separated scorecard checks to include, such as Maintained,Dangerous-Workflow")
+	if err := fs.Parse(args); err != nil {
+		return options{}, err
+	}
+
+	threshold := -1.0
+	if *below != "" {
+		parsed, err := strconv.ParseFloat(*below, 64)
+		if err != nil {
+			return options{}, fmt.Errorf("--below must be a number")
+		}
+		if parsed < 0 || parsed > 10 {
+			return options{}, fmt.Errorf("--below must be between 0 and 10")
+		}
+		threshold = parsed
+	}
+
+	checkSet := make(map[string]bool)
+	for _, check := range strings.Split(*checks, ",") {
+		check = strings.TrimSpace(check)
+		if check == "" {
+			continue
+		}
+		checkSet[strings.ToLower(check)] = true
+	}
+
+	if *format != "text" && *format != formatJSON {
+		return options{}, fmt.Errorf("unknown format %q", *format)
+	}
+
+	return options{
+		inputPath: *input,
+		format:    *format,
+		below:     threshold,
+		checks:    checkSet,
+	}, nil
+}
+
+func loadDependencies(inputPath string) ([]dependency, error) {
+	var raw []byte
+	var err error
+
+	switch inputPath {
+	case "":
+		raw, err = exec.Command("git", "pkgs", "list", "--format", "json").CombinedOutput()
+	case "-":
+		raw, err = io.ReadAll(os.Stdin)
+	default:
+		raw, err = os.ReadFile(inputPath)
+	}
+	if err != nil {
+		output := strings.TrimSpace(string(raw))
+		if output == "" {
+			return nil, err
+		}
+		return nil, fmt.Errorf("%w: %s", err, output)
+	}
+
+	var deps []dependency
+	if err := json.Unmarshal(raw, &deps); err != nil {
+		return nil, err
+	}
+	return deps, nil
+}
+
+func runScorecard(deps []dependency, opts options) (*scorecardResult, error) {
+	deps = uniqueDependencies(deps)
+	result := &scorecardResult{
+		Summary: scorecardSummary{
+			TotalDependencies: len(deps),
+		},
+		Dependencies: []scorecardEntry{},
+	}
+	if len(deps) == 0 {
+		return result, nil
+	}
+
+	purls, depByPURL := packagePURLs(deps)
+	if len(purls) == 0 {
+		result.Summary.SkippedNoRepository = len(deps)
+		return result, nil
+	}
+
+	lookup, err := newPackageLookup()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	packages, err := lookup.BulkLookup(ctx, purls)
+	if err != nil {
+		return nil, err
+	}
+
+	scoreLookup := newScoreLookup()
+	reposSeen := make(map[string]bool)
+	repos := make([]string, 0, len(purls))
+	repoByPURL := make(map[string]string, len(purls))
+	for _, purlStr := range purls {
+		pkg := packages[purlStr]
+		if pkg == nil || pkg.Repository == "" {
+			result.Summary.SkippedNoRepository++
+			continue
+		}
+
+		repo := normalizeRepository(pkg.Repository)
+		if repo == "" {
+			result.Summary.SkippedUnsupportedRepo++
+			continue
+		}
+		result.Summary.PackagesWithRepos++
+		repoByPURL[purlStr] = repo
+
+		if !reposSeen[repo] {
+			reposSeen[repo] = true
+			repos = append(repos, repo)
+		}
+	}
+
+	scores, errorsByRepo := fetchScorecardResults(ctx, scoreLookup, repos)
+	result.Summary.LookupErrors = len(errorsByRepo)
+	result.Summary.CheckedRepositories = len(scores)
+
+	for _, purlStr := range purls {
+		dep := depByPURL[purlStr]
+		repo := repoByPURL[purlStr]
+		if repo == "" {
+			continue
+		}
+
+		entry := scorecardEntry{
+			Name:         dep.Name,
+			Ecosystem:    dep.Ecosystem,
+			Version:      dep.Requirement,
+			ManifestPath: dep.ManifestPath,
+			PURL:         purlStr,
+			Repository:   repo,
+		}
+		if errMsg := errorsByRepo[repo]; errMsg != "" {
+			entry.LookupError = errMsg
+		} else if score := scores[repo]; score != nil {
+			entry.Score = score.Score
+			entry.Date = score.Date
+			entry.Checks = filterChecks(score.Checks, opts.checks)
+		}
+
+		if includeEntry(entry, opts) {
+			if isPolicyFailure(entry, opts) {
+				result.Summary.PolicyFailures++
+			}
+			result.Dependencies = append(result.Dependencies, entry)
+		}
+	}
+
+	sort.Slice(result.Dependencies, func(i, j int) bool {
+		if result.Dependencies[i].Score != result.Dependencies[j].Score {
+			return result.Dependencies[i].Score < result.Dependencies[j].Score
+		}
+		if result.Dependencies[i].Repository != result.Dependencies[j].Repository {
+			return result.Dependencies[i].Repository < result.Dependencies[j].Repository
+		}
+		return result.Dependencies[i].Name < result.Dependencies[j].Name
+	})
+	result.Summary.DisplayedDependencies = len(result.Dependencies)
+
+	return result, nil
+}
+
+type scorecardFetchResult struct {
+	repo  string
+	score *scorecard.Result
+	err   error
+}
+
+func fetchScorecardResults(ctx context.Context, lookup scoreLookup, repos []string) (map[string]*scorecard.Result, map[string]string) {
+	const scorecardLookupConcurrency = 8
+
+	scores := make(map[string]*scorecard.Result, len(repos))
+	errorsByRepo := make(map[string]string)
+	if len(repos) == 0 {
+		return scores, errorsByRepo
+	}
+
+	workers := scorecardLookupConcurrency
+	if len(repos) < workers {
+		workers = len(repos)
+	}
+	jobs := make(chan string)
+	results := make(chan scorecardFetchResult, len(repos))
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for repo := range jobs {
+				score, err := lookup.GetScore(ctx, repo)
+				results <- scorecardFetchResult{repo: repo, score: score, err: err}
+			}
+		}()
+	}
+
+	for _, repo := range repos {
+		jobs <- repo
+	}
+	close(jobs)
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		if result.err != nil {
+			errorsByRepo[result.repo] = result.err.Error()
+			continue
+		}
+		if result.score != nil {
+			scores[result.repo] = result.score
+		}
+	}
+
+	return scores, errorsByRepo
+}
+
+func uniqueDependencies(deps []dependency) []dependency {
+	seen := make(map[string]bool)
+	var result []dependency
+	for _, dep := range deps {
+		key := strings.ToLower(dep.Ecosystem) + "\x00" + dep.Name + "\x00" + dep.ManifestPath + "\x00" + dep.Requirement
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, dep)
+	}
+	return result
+}
+
+func packagePURLs(deps []dependency) ([]string, map[string]dependency) {
+	var purls []string
+	depByPURL := make(map[string]dependency)
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		purlStr := packagePURLForDependency(dep)
+		if purlStr == "" || seen[purlStr] {
+			continue
+		}
+		seen[purlStr] = true
+		purls = append(purls, purlStr)
+		depByPURL[purlStr] = dep
+	}
+	return purls, depByPURL
+}
+
+func packagePURLForDependency(dep dependency) string {
+	if dep.PURL != "" {
+		parsed, err := purl.Parse(dep.PURL)
+		if err == nil {
+			parsed.Version = ""
+			return parsed.String()
+		}
+	}
+	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+}
+
+func normalizeRepository(repo string) string {
+	repo = strings.TrimSpace(repo)
+	repo = strings.TrimSuffix(repo, ".git")
+	if repo == "" {
+		return ""
+	}
+
+	if !strings.Contains(repo, "://") {
+		repo = "https://" + repo
+	}
+	parsed, err := url.Parse(repo)
+	if err != nil {
+		return ""
+	}
+
+	host := strings.ToLower(parsed.Hostname())
+	switch host {
+	case "github.com", "gitlab.com":
+	default:
+		return ""
+	}
+
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return host + "/" + parts[0] + "/" + parts[1]
+}
+
+func filterChecks(checks []scorecard.Check, selected map[string]bool) []scorecardCheck {
+	var result []scorecardCheck
+	for _, check := range checks {
+		if len(selected) > 0 && !selected[strings.ToLower(check.Name)] {
+			continue
+		}
+		result = append(result, scorecardCheck{
+			Name:   check.Name,
+			Score:  check.Score,
+			Reason: check.Reason,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+func includeEntry(entry scorecardEntry, opts options) bool {
+	if entry.LookupError != "" {
+		return true
+	}
+	if opts.below < 0 {
+		return true
+	}
+	if entry.Score <= opts.below {
+		return true
+	}
+	for _, check := range entry.Checks {
+		if float64(check.Score) <= opts.below {
+			return true
+		}
+	}
+	return false
+}
+
+func isPolicyFailure(entry scorecardEntry, opts options) bool {
+	if entry.LookupError != "" || opts.below < 0 {
+		return false
+	}
+	if entry.Score <= opts.below {
+		return true
+	}
+	for _, check := range entry.Checks {
+		if float64(check.Score) <= opts.below {
+			return true
+		}
+	}
+	return false
+}
+
+func outputText(w io.Writer, result *scorecardResult, opts options) {
+	if len(result.Dependencies) == 0 {
+		_, _ = fmt.Fprintln(w, "No scorecard results matched.")
+		if result.Summary.SkippedNoRepository > 0 {
+			_, _ = fmt.Fprintf(w, "Skipped without repository URL: %d\n", result.Summary.SkippedNoRepository)
+		}
+		if result.Summary.SkippedUnsupportedRepo > 0 {
+			_, _ = fmt.Fprintf(w, "Skipped unsupported repository host: %d\n", result.Summary.SkippedUnsupportedRepo)
+		}
+		if result.Summary.LookupErrors > 0 {
+			_, _ = fmt.Fprintf(w, "Scorecard lookup errors: %d\n", result.Summary.LookupErrors)
+		}
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "Scorecard results for %d dependencies:\n\n", len(result.Dependencies))
+	for _, entry := range result.Dependencies {
+		_, _ = fmt.Fprintf(w, "%s (%s): %.1f %s\n", entry.Name, entry.Ecosystem, entry.Score, entry.Repository)
+		if entry.LookupError != "" {
+			_, _ = fmt.Fprintf(w, "  error: %s\n", entry.LookupError)
+			continue
+		}
+		for _, check := range entry.Checks {
+			if opts.below >= 0 && float64(check.Score) > opts.below {
+				continue
+			}
+			_, _ = fmt.Fprintf(w, "  %s: %d", check.Name, check.Score)
+			if check.Reason != "" {
+				_, _ = fmt.Fprintf(w, " - %s", check.Reason)
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+}

--- a/plugins/scorecard/main_test.go
+++ b/plugins/scorecard/main_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/enrichment/scorecard"
+)
+
+type mockPackageLookup struct {
+	packages map[string]*enrichment.PackageInfo
+}
+
+func (m mockPackageLookup) BulkLookup(_ context.Context, purls []string) (map[string]*enrichment.PackageInfo, error) {
+	result := make(map[string]*enrichment.PackageInfo)
+	for _, purlStr := range purls {
+		if pkg, ok := m.packages[purlStr]; ok {
+			result[purlStr] = pkg
+		}
+	}
+	return result, nil
+}
+
+type mockScoreLookup struct {
+	results map[string]*scorecard.Result
+	errors  map[string]error
+}
+
+func (m mockScoreLookup) GetScore(_ context.Context, repoURL string) (*scorecard.Result, error) {
+	if err := m.errors[repoURL]; err != nil {
+		return nil, err
+	}
+	return m.results[repoURL], nil
+}
+
+func withMockLookups(packages map[string]*enrichment.PackageInfo, scores map[string]*scorecard.Result, errors map[string]error) func() {
+	origPackageLookup := newPackageLookup
+	origScoreLookup := newScoreLookup
+	newPackageLookup = func() (packageLookup, error) {
+		return mockPackageLookup{packages: packages}, nil
+	}
+	newScoreLookup = func() scoreLookup {
+		return mockScoreLookup{results: scores, errors: errors}
+	}
+	return func() {
+		newPackageLookup = origPackageLookup
+		newScoreLookup = origScoreLookup
+	}
+}
+
+func TestNormalizeRepository(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://github.com/lodash/lodash.git", "github.com/lodash/lodash"},
+		{"github.com/expressjs/express", "github.com/expressjs/express"},
+		{"https://gitlab.com/example/project", "gitlab.com/example/project"},
+		{"https://github.com/owner", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeRepository(tt.input)
+			if got != tt.want {
+				t.Fatalf("normalizeRepository(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScorecardUserAgentShape(t *testing.T) {
+	got := scorecardUserAgent()
+	if !strings.HasPrefix(got, "git-pkgs/") {
+		t.Fatalf("scorecard user agent = %q, want git-pkgs/<version>", got)
+	}
+}
+
+func TestRunScorecardFiltersBelowAndChecks(t *testing.T) {
+	restore := withMockLookups(
+		map[string]*enrichment.PackageInfo{
+			"pkg:npm/lodash":     {Repository: "https://github.com/lodash/lodash"},
+			"pkg:npm/express":    {Repository: "https://github.com/expressjs/express"},
+			"pkg:npm/gitlab-lib": {Repository: "https://gitlab.com/example/gitlab-lib"},
+			"pkg:npm/no-repo":    {},
+			"pkg:npm/bitbucket":  {Repository: "https://bitbucket.org/example/project"},
+		},
+		map[string]*scorecard.Result{
+			"github.com/lodash/lodash": {
+				Score: 8.5,
+				Date:  "2026-01-01",
+				Checks: []scorecard.Check{
+					{Name: "Maintained", Score: 2, Reason: "low maintenance signal"},
+					{Name: "Dangerous-Workflow", Score: 10},
+				},
+			},
+			"github.com/expressjs/express": {
+				Score: 6.1,
+				Date:  "2026-01-01",
+				Checks: []scorecard.Check{
+					{Name: "Maintained", Score: 9},
+				},
+			},
+			"gitlab.com/example/gitlab-lib": {
+				Score: 9.9,
+				Date:  "2026-01-01",
+			},
+		},
+		nil,
+	)
+	defer restore()
+
+	result, err := runScorecard([]dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.21"},
+		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2"},
+		{Name: "gitlab-lib", Ecosystem: "npm", Requirement: "1.0.0"},
+		{Name: "no-repo", Ecosystem: "npm", Requirement: "1.0.0"},
+		{Name: "bitbucket", Ecosystem: "npm", Requirement: "1.0.0"},
+	}, options{
+		below:  3,
+		checks: map[string]bool{"maintained": true},
+	})
+	if err != nil {
+		t.Fatalf("run scorecard: %v", err)
+	}
+
+	if result.Summary.TotalDependencies != 5 {
+		t.Fatalf("total dependencies = %d, want 5", result.Summary.TotalDependencies)
+	}
+	if result.Summary.PackagesWithRepos != 3 {
+		t.Fatalf("packages with repos = %d, want 3", result.Summary.PackagesWithRepos)
+	}
+	if result.Summary.SkippedNoRepository != 1 {
+		t.Fatalf("skipped no repository = %d, want 1", result.Summary.SkippedNoRepository)
+	}
+	if result.Summary.SkippedUnsupportedRepo != 1 {
+		t.Fatalf("skipped unsupported repository = %d, want 1", result.Summary.SkippedUnsupportedRepo)
+	}
+	if result.Summary.PolicyFailures != 1 {
+		t.Fatalf("policy failures = %d, want 1", result.Summary.PolicyFailures)
+	}
+	if len(result.Dependencies) != 1 {
+		t.Fatalf("dependencies length = %d, want 1: %#v", len(result.Dependencies), result.Dependencies)
+	}
+
+	entry := result.Dependencies[0]
+	if entry.Name != "lodash" {
+		t.Fatalf("entry name = %q, want lodash", entry.Name)
+	}
+	if len(entry.Checks) != 1 || entry.Checks[0].Name != "Maintained" {
+		t.Fatalf("checks = %#v, want Maintained only", entry.Checks)
+	}
+}
+
+func TestRunScorecardReportsLookupErrors(t *testing.T) {
+	restore := withMockLookups(
+		map[string]*enrichment.PackageInfo{
+			"pkg:npm/lodash": {Repository: "https://github.com/lodash/lodash"},
+		},
+		nil,
+		map[string]error{
+			"github.com/lodash/lodash": errors.New("scorecard unavailable"),
+		},
+	)
+	defer restore()
+
+	result, err := runScorecard([]dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.21"},
+	}, options{below: -1})
+	if err != nil {
+		t.Fatalf("run scorecard: %v", err)
+	}
+
+	if result.Summary.LookupErrors != 1 {
+		t.Fatalf("lookup errors = %d, want 1", result.Summary.LookupErrors)
+	}
+	if len(result.Dependencies) != 1 {
+		t.Fatalf("dependencies length = %d, want 1", len(result.Dependencies))
+	}
+	if result.Dependencies[0].LookupError != "scorecard unavailable" {
+		t.Fatalf("lookup error = %q, want scorecard unavailable", result.Dependencies[0].LookupError)
+	}
+	if result.Summary.PolicyFailures != 0 {
+		t.Fatalf("policy failures = %d, want 0", result.Summary.PolicyFailures)
+	}
+}
+
+func TestOutputTextAppliesBelowToChecksWithoutCheckFilter(t *testing.T) {
+	result := &scorecardResult{
+		Dependencies: []scorecardEntry{
+			{
+				Name:       "lodash",
+				Ecosystem:  "npm",
+				Repository: "github.com/lodash/lodash",
+				Score:      8.5,
+				Checks: []scorecardCheck{
+					{Name: "Maintained", Score: 2},
+					{Name: "Dangerous-Workflow", Score: 10},
+				},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	outputText(&out, result, options{below: 3})
+	got := out.String()
+	if !strings.Contains(got, "Maintained: 2") {
+		t.Fatalf("expected low check in output: %q", got)
+	}
+	if strings.Contains(got, "Dangerous-Workflow: 10") {
+		t.Fatalf("high-scoring check should be hidden by --below: %q", got)
+	}
+}
+
+func TestPackagePURLForDependencyStripsVersion(t *testing.T) {
+	got := packagePURLForDependency(dependency{
+		Name:      "lodash",
+		Ecosystem: "npm",
+		PURL:      "pkg:npm/lodash@4.17.21",
+	})
+	if got != "pkg:npm/lodash" {
+		t.Fatalf("package PURL = %q, want pkg:npm/lodash", got)
+	}
+}


### PR DESCRIPTION
Closes #113
## Summary
- Add a first-party `git-pkgs-scorecard` plugin candidate under `plugins/scorecard`
- Consume dependency input from `git pkgs list --format json`, stdin or a JSON file
- Resolve package repository URLs through enrichment metadata
- Query the existing OpenSSF Scorecard client
- Support `--below`, `--checks` and `--format=json`
- Document how to build and run the plugin

## Tests
- `go test ./plugins/scorecard`
- `go build -o /tmp/git-pkgs-scorecard ./plugins/scorecard`
- `go tool golangci-lint run ./...`
- `go test ./...`
- `git diff --check`