### PR TITLE
Set git-pkgs user agent on registries calls

### DIFF
--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -137,7 +137,7 @@ func fetchDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[st
 	ctx, cancel := context.WithTimeout(context.Background(), deprecatedLookupTimeout)
 	defer cancel()
 
-	fetched := registries.BulkFetchVersions(ctx, misses, nil)
+	fetched := registries.BulkFetchVersions(ctx, misses, registries.NewClient().WithUserAgent("git-pkgs/"+version))
 	for purlStr, version := range fetched {
 		versionData[purlStr] = version
 	}

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -58,7 +58,7 @@ func runUrls(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	reg, err := registries.New(purlType, "", nil)
+	reg, err := registries.New(purlType, "", registries.NewClient().WithUserAgent("git-pkgs/"+version))
 	if err != nil {
 		return fmt.Errorf("unsupported ecosystem %q: %w", purlType, err)
 	}


### PR DESCRIPTION
Two call sites passed a nil client to the `registries` package and got the library default User-Agent of `registries`:

- `cmd/urls.go:61` — `registries.New(purlType, "", nil)`
- `cmd/deprecated.go:140` — `registries.BulkFetchVersions(ctx, misses, nil)`

Both now pass `registries.NewClient().WithUserAgent("git-pkgs/"+version)`, matching the `git-pkgs/<version>` UA used by every other outbound call (enrichment, OSV).