### PR TITLE
Centralize git-pkgs user agent string

### DIFF
--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -64,7 +64,7 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), changelogTimeout)
 	defer cancel()
 
-	client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
 	if err != nil {
 		return fmt.Errorf("creating API client: %w", err)
 	}

--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -137,7 +137,7 @@ func fetchDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[st
 	ctx, cancel := context.WithTimeout(context.Background(), deprecatedLookupTimeout)
 	defer cancel()
 
-	fetched := registries.BulkFetchVersions(ctx, misses, registries.NewClient().WithUserAgent("git-pkgs/"+version))
+	fetched := registries.BulkFetchVersions(ctx, misses, registries.NewClient().WithUserAgent(userAgent))
 	for purlStr, version := range fetched {
 		versionData[purlStr] = version
 	}

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -200,7 +200,7 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 		return result, nil
 	}
 
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/funding.go
+++ b/cmd/funding.go
@@ -177,7 +177,7 @@ func fetchFundingPackageData(db *database.DB, deps []database.Dependency) (map[s
 }
 
 func fetchFundingMetadata(purls []string) (map[string]*enrichment.PackageInfo, error) {
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -269,7 +269,7 @@ func runRegistryCheck(cmd *cobra.Command, deps []database.Dependency, format str
 	}
 
 	// Create enrichment client
-	client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
 	if err != nil {
 		return fmt.Errorf("creating enrichment client: %w", err)
 	}

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -289,7 +289,7 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
-		client, err := NewEnrichmentClient(enrichment.WithUserAgent("git-pkgs/" + version))
+		client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -212,7 +212,7 @@ func getPackageData(db *database.DB, purls []string, purlToDep map[string]databa
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
-		client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+		client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +291,7 @@ func findLatestAtDateCached(db *database.DB, ecosystem, name, purl string, atTim
 	}
 
 	// Fall back to API
-	client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+	client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
 	if err != nil {
 		return ""
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ var version = versionUnknown
 var commit = versionUnknown
 var date = versionUnknown
 var versionStr string
+var userAgent string
 
 func init() {
 	if version == versionUnknown {
@@ -34,6 +35,7 @@ func init() {
 	if date != versionUnknown {
 		versionStr += "\n            date " + date
 	}
+	userAgent = "git-pkgs/" + version
 }
 
 const shortDesc = "Track package dependencies across git history"

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -166,7 +166,7 @@ func getSBOMLicenseData(db *database.DB, purls []string, purlToDep map[string]da
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
-		client, err := enrichment.NewClient(enrichment.WithUserAgent("git-pkgs/" + version))
+		client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -58,7 +58,7 @@ func runUrls(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	reg, err := registries.New(purlType, "", registries.NewClient().WithUserAgent("git-pkgs/"+version))
+	reg, err := registries.New(purlType, "", registries.NewClient().WithUserAgent(userAgent))
 	if err != nil {
 		return fmt.Errorf("unsupported ecosystem %q: %w", purlType, err)
 	}

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -119,7 +119,7 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+	source := osv.New(osv.WithUserAgent(userAgent))
 	return syncVulnerabilitiesForDeps(db, source, lockfileDeps, force, quiet, cmd.OutOrStdout())
 }
 
@@ -421,7 +421,7 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 
 	// Auto-sync before cached scan (skip for --live and --no-sync)
 	if !live && !noSync && db != nil {
-		source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+		source := osv.New(osv.WithUserAgent(userAgent))
 		if err := syncVulnerabilitiesForDeps(db, source, lockfileDeps, false, false, cmd.OutOrStdout()); err != nil {
 			return fmt.Errorf("syncing vulnerabilities: %w", err)
 		}
@@ -475,7 +475,7 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 }
 
 func scanLive(deps []database.Dependency, minSeverity int) ([]VulnResult, error) {
-	source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+	source := osv.New(osv.WithUserAgent(userAgent))
 	purls := make([]*purl.PURL, len(deps))
 	for i, d := range deps {
 		purls[i] = purl.MakePURL(d.Ecosystem, d.Name, d.Requirement)
@@ -811,7 +811,7 @@ func runVulnsShow(cmd *cobra.Command, args []string) error {
 	ref, _ := cmd.Flags().GetString("ref")
 	branchName, _ := cmd.Flags().GetString("branch")
 
-	source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+	source := osv.New(osv.WithUserAgent(userAgent))
 	ctx, cancel := context.WithTimeout(context.Background(), vulnsShowTimeout)
 	defer cancel()
 
@@ -1563,7 +1563,7 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting commits: %w", err)
 	}
 
-	source := osv.New(osv.WithUserAgent("git-pkgs/" + version))
+	source := osv.New(osv.WithUserAgent(userAgent))
 	var history []VulnHistoryEntry
 
 	for _, c := range commits {


### PR DESCRIPTION
Follow-up to #224. Replaces 17 inline `"git-pkgs/" + version` concatenations across `cmd/` with a single package-level `userAgent` variable populated in `init()` after `version` resolves.

New callers reach for `userAgent` instead of reconstructing the string, so the format lives in one place.