### PR TITLE
Treat Maven manifest versions as resolved dependencies

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -64,7 +64,8 @@ func shortSHA(sha string) string {
 }
 
 func isResolvedDependency(d database.Dependency) bool {
-	return d.Requirement != "" && (d.ManifestKind == manifestKindLockfile || d.Ecosystem == "golang")
+	return d.Requirement != "" &&
+		(d.ManifestKind == manifestKindLockfile || d.Ecosystem == "golang" || d.Ecosystem == "maven")
 }
 
 func IsPURL(s string) bool {

--- a/cmd/java_test.go
+++ b/cmd/java_test.go
@@ -1,0 +1,73 @@
+package cmd_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+const mavenPomXML = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+`
+
+func TestOutdatedUsesMavenManifestDependencies(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "pom.xml", mavenPomXML, "Add Maven pom")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	_, _, err := runCmd(t, "init")
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	err = db.SavePackageEnrichment(
+		"pkg:maven/junit/junit",
+		"maven",
+		"junit:junit",
+		"4.13.2",
+		"EPL-1.0",
+		"https://repo.maven.apache.org/maven2",
+		"test",
+	)
+	if closeErr := db.Close(); closeErr != nil {
+		t.Fatalf("close db: %v", closeErr)
+	}
+	if err != nil {
+		t.Fatalf("save package enrichment: %v", err)
+	}
+
+	stdout, _, err := runCmd(t, "outdated", "--ecosystem", "maven")
+	if err != nil {
+		t.Fatalf("outdated failed: %v", err)
+	}
+	if strings.Contains(stdout, "No lockfile dependencies found") {
+		t.Fatalf("outdated ignored Maven manifest dependencies: %s", stdout)
+	}
+	if !strings.Contains(stdout, "junit:junit") {
+		t.Fatalf("expected Maven dependency in output, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "4.12") || !strings.Contains(stdout, "4.13.2") {
+		t.Fatalf("expected current and latest versions in output, got: %s", stdout)
+	}
+}

--- a/cmd/resolved_test.go
+++ b/cmd/resolved_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestIsResolvedDependency(t *testing.T) {
+	tests := []struct {
+		name string
+		dep  database.Dependency
+		want bool
+	}{
+		{
+			name: "lockfile dependency with version",
+			dep: database.Dependency{
+				Ecosystem:    "npm",
+				Requirement:  "1.0.0",
+				ManifestKind: manifestKindLockfile,
+			},
+			want: true,
+		},
+		{
+			name: "go module manifest dependency with version",
+			dep: database.Dependency{
+				Ecosystem:    "golang",
+				Requirement:  "1.0.0",
+				ManifestKind: "manifest",
+			},
+			want: true,
+		},
+		{
+			name: "maven manifest dependency with version",
+			dep: database.Dependency{
+				Ecosystem:    "maven",
+				Requirement:  "4.13.2",
+				ManifestKind: "manifest",
+			},
+			want: true,
+		},
+		{
+			name: "maven manifest dependency without version",
+			dep: database.Dependency{
+				Ecosystem:    "maven",
+				ManifestKind: "manifest",
+			},
+			want: false,
+		},
+		{
+			name: "npm manifest dependency with version range",
+			dep: database.Dependency{
+				Ecosystem:    "npm",
+				Requirement:  "^1.0.0",
+				ManifestKind: "manifest",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isResolvedDependency(tt.dep)
+			if got != tt.want {
+				t.Fatalf("isResolvedDependency() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

fixes #187 by treating Maven manifest dependencies with explicit versions as resolved dependencies, similar to Go modules...

## Changes

- Includes Maven dependencies in `isResolvedDependency` when they have a concrete requirement.
- Adds coverage for Maven manifest dependencies in `outdated`.
- Adds focused tests for resolved dependency classification.

## Verification

- `go test ./cmd -run 'Resolved|Maven|OutdatedUsesMaven'`
- `go test ./...`
- `go tool golangci-lint run ./cmd --tests=false`