### PR TITLE
Add notes import command

### DIFF
--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func addNotesCmd(parent *cobra.Command) {
@@ -43,6 +45,16 @@ notes (e.g. "security", "audit", "review"). The default namespace is empty.`,
 	appendCmd.Flags().String("namespace", "", "Note namespace for categorization")
 	appendCmd.Flags().String("origin", "git-pkgs", "Tool or system that created this note")
 	appendCmd.Flags().StringArray("set", nil, "Set metadata key=value pair")
+
+	importCmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import notes from a YAML or JSON file",
+		Long:  `Import notes from a YAML or JSON file. Imported notes are upserted by purl+namespace.`,
+		Args:  cobra.ExactArgs(1),
+		RunE:  runNotesImport,
+	}
+	importCmd.Flags().String("namespace", "", "Default namespace for imported notes")
+	importCmd.Flags().String("origin", "git-pkgs", "Tool or system that created imported notes")
 
 	showCmd := &cobra.Command{
 		Use:   "show <purl>",
@@ -82,7 +94,7 @@ notes (e.g. "security", "audit", "review"). The default namespace is empty.`,
 	namespacesCmd.Flags().String("purl-filter", "", "Filter by purl substring")
 	namespacesCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
 
-	notesCmd.AddCommand(addCmd, appendCmd, showCmd, listCmd, removeCmd, namespacesCmd)
+	notesCmd.AddCommand(addCmd, appendCmd, importCmd, showCmd, listCmd, removeCmd, namespacesCmd)
 	parent.AddCommand(notesCmd)
 }
 
@@ -163,6 +175,79 @@ func runNotesAppend(cmd *cobra.Command, args []string) error {
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Appended to note for %s\n", purl)
 	return nil
+}
+
+type noteImportEntry struct {
+	PURL      string            `json:"purl" yaml:"purl"`
+	Namespace string            `json:"namespace" yaml:"namespace"`
+	Origin    string            `json:"origin" yaml:"origin"`
+	Message   string            `json:"message" yaml:"message"`
+	Metadata  map[string]string `json:"metadata" yaml:"metadata"`
+}
+
+func runNotesImport(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	namespace, _ := cmd.Flags().GetString("namespace")
+	origin, _ := cmd.Flags().GetString("origin")
+
+	notes, err := loadNotesImportFile(path, namespace, origin)
+	if err != nil {
+		return err
+	}
+
+	_, db, err := openDatabase()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, note := range notes {
+		if err := db.InsertNote(note); err != nil {
+			return fmt.Errorf("importing note for %s: %w", note.PURL, err)
+		}
+	}
+
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Imported %d notes from %s\n", len(notes), path)
+	return nil
+}
+
+func loadNotesImportFile(path, defaultNamespace, defaultOrigin string) ([]database.Note, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading notes file: %w", err)
+	}
+
+	var entries []noteImportEntry
+	if err := yaml.Unmarshal(data, &entries); err != nil {
+		return nil, fmt.Errorf("parsing notes file: %w", err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("notes file contains no notes")
+	}
+
+	notes := make([]database.Note, 0, len(entries))
+	for i, entry := range entries {
+		if strings.TrimSpace(entry.PURL) == "" {
+			return nil, fmt.Errorf("note %d missing purl", i+1)
+		}
+
+		note := database.Note{
+			PURL:      strings.TrimSpace(entry.PURL),
+			Namespace: entry.Namespace,
+			Origin:    entry.Origin,
+			Message:   entry.Message,
+			Metadata:  entry.Metadata,
+		}
+		if note.Namespace == "" {
+			note.Namespace = defaultNamespace
+		}
+		if note.Origin == "" {
+			note.Origin = defaultOrigin
+		}
+		notes = append(notes, note)
+	}
+
+	return notes, nil
 }
 
 func runNotesShow(cmd *cobra.Command, args []string) error {

--- a/cmd/notes_test.go
+++ b/cmd/notes_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -417,6 +418,130 @@ func TestNotesAppend(t *testing.T) {
 		}
 		if !strings.Contains(stdout, "new note via append") {
 			t.Errorf("expected message in output, got: %s", stdout)
+		}
+	})
+}
+
+func TestNotesImport(t *testing.T) {
+	t.Run("imports yaml notes with default namespace", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		policy := `- purl: "pkg:npm/lodash"
+  message: "Approved for production use"
+  metadata:
+    status: approved
+    reviewed: "2026-01-15"
+- purl: "pkg:npm/express"
+  namespace: audit
+  message: "Needs annual review"
+  metadata:
+    status: pending
+`
+		if err := os.WriteFile("policy.yaml", []byte(policy), 0o644); err != nil {
+			t.Fatalf("write policy: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "import", "policy.yaml", "--namespace", "policy", "--origin", "policy-file")
+		if err != nil {
+			t.Fatalf("notes import failed: %v", err)
+		}
+		if !strings.Contains(stdout, "Imported 2 notes") {
+			t.Fatalf("expected import summary, got: %s", stdout)
+		}
+
+		stdout, _, err = runCmd(t, "notes", "show", "pkg:npm/lodash", "--namespace", "policy", "-f", "json")
+		if err != nil {
+			t.Fatalf("show imported note failed: %v", err)
+		}
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("parse note json: %v", err)
+		}
+		if note.Message != "Approved for production use" {
+			t.Fatalf("message = %q, want approved message", note.Message)
+		}
+		if note.Origin != "policy-file" {
+			t.Fatalf("origin = %q, want policy-file", note.Origin)
+		}
+		if note.Metadata["status"] != "approved" || note.Metadata["reviewed"] != "2026-01-15" {
+			t.Fatalf("unexpected metadata: %v", note.Metadata)
+		}
+
+		stdout, _, err = runCmd(t, "notes", "show", "pkg:npm/express", "--namespace", "audit", "-f", "json")
+		if err != nil {
+			t.Fatalf("show note with file namespace failed: %v", err)
+		}
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("parse note json: %v", err)
+		}
+		if note.Namespace != "audit" {
+			t.Fatalf("namespace = %q, want audit", note.Namespace)
+		}
+	})
+
+	t.Run("imports json notes", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		policy := `[{"purl":"pkg:npm/lodash","namespace":"policy","message":"JSON import","metadata":{"status":"approved"}}]`
+		if err := os.WriteFile("policy.json", []byte(policy), 0o644); err != nil {
+			t.Fatalf("write policy: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "import", "policy.json")
+		if err != nil {
+			t.Fatalf("notes import json failed: %v", err)
+		}
+
+		stdout, _, err := runCmd(t, "notes", "show", "pkg:npm/lodash", "--namespace", "policy", "-f", "json")
+		if err != nil {
+			t.Fatalf("show json imported note failed: %v", err)
+		}
+		var note database.Note
+		if err := json.Unmarshal([]byte(stdout), &note); err != nil {
+			t.Fatalf("parse note json: %v", err)
+		}
+		if note.Message != "JSON import" {
+			t.Fatalf("message = %q, want JSON import", note.Message)
+		}
+	})
+
+	t.Run("rejects entries without purl", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		if err := os.WriteFile("bad-policy.yaml", []byte("- message: missing purl\n"), 0o644); err != nil {
+			t.Fatalf("write policy: %v", err)
+		}
+
+		_, _, err = runCmd(t, "notes", "import", "bad-policy.yaml")
+		if err == nil {
+			t.Fatal("expected missing purl error")
+		}
+		if !strings.Contains(err.Error(), "missing purl") {
+			t.Fatalf("expected missing purl error, got: %v", err)
 		}
 	})
 }

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -30,6 +30,27 @@ Append more information later:
 $ git pkgs notes append pkg:npm/lodash@4.17.21 -m "re-reviewed Q1 2026" --set reviewer=alice
 ```
 
+Import notes from a version-controlled YAML or JSON policy file:
+
+```yaml
+# policy.yaml
+- purl: "pkg:npm/lodash"
+  message: "Approved for production use"
+  metadata:
+    status: approved
+    reviewed: "2026-01-15"
+- purl: "pkg:npm/moment"
+  message: "Deprecated, use dayjs instead"
+  metadata:
+    status: deprecated
+    alternative: "pkg:npm/dayjs"
+```
+
+```
+$ git pkgs notes import policy.yaml --namespace policy
+Imported 2 notes from policy.yaml
+```
+
 List all notes:
 
 ```
@@ -99,6 +120,7 @@ All subcommands that take a purl accept both versioned (`pkg:npm/lodash@4.17.21`
 ```
 add <purl>     Create a note (--force to overwrite)
 append <purl>  Append message text and merge metadata (creates if missing)
+import <file>  Import notes from a YAML or JSON file
 show <purl>    Display a note
 list           List all notes
 remove <purl>  Delete a note
@@ -116,6 +138,8 @@ Common flags:
 --force            Overwrite existing note (add only)
 --purl-filter=STR  Filter by purl substring (list only)
 ```
+
+For imports, `--namespace` is used as the default namespace when an entry does not set one, and `--origin` is used as the default origin. Existing notes with the same purl and namespace are updated.
 
 ## Ideas for tooling integration
 
@@ -173,10 +197,7 @@ git pkgs notes add pkg:npm/some-lib --namespace license-review \
 Mark packages as approved, deprecated, or banned for your org:
 
 ```bash
-git pkgs notes add pkg:npm/moment --namespace policy \
-  -m "Use dayjs instead" --set status=deprecated --set alternative=dayjs
-git pkgs notes add pkg:npm/event-stream --namespace policy \
-  -m "Compromised in 2018" --set status=banned
+git pkgs notes import policy.yaml --namespace policy
 ```
 
 A CI check could compare current dependencies against policy notes and fail if any banned package is present.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
 )
 
@@ -257,7 +258,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	honnef.co/go/tools v0.7.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect


### PR DESCRIPTION
closes #124 

## Summary

Adds `git pkgs notes import <file>` for bulk-importing package notes from YAML or JSON policy files...

## Changes

- Add `notes import <file>` subcommand
- Support YAML and JSON arrays with `purl`, `namespace`, `origin`, `message` and `metadata`
- Use `--namespace` and `--origin` as defaults when entries omit those fields
- Upsert imported notes by existing `purl + namespace`
- Document policy-file imports in `docs/notes.md`
- Add integration tests for YAML import, JSON import, and missing `purl` validation

## Testing

- `go test ./cmd -run Notes`
- `go test ./cmd -run TestNotesImport -count=1`
- `go test ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`