### PR TITLE
Add ecosystem matching mode for dependency diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,11 +453,12 @@ git pkgs diff --from=abc123 --to=def456   # between two commits
 git pkgs diff --from=HEAD~10              # HEAD~10 vs working tree
 git pkgs diff main..feature               # compare branches
 git pkgs diff main..feature --stat        # aggregate counts only
+git pkgs diff main..feature --by=ecosystem # compare package sets across lockfile migrations
 git pkgs diff --type=development          # only dev dependency changes
 git pkgs diff --ecosystem=npm             # filter by ecosystem
 ```
 
-With no arguments, compares HEAD against the working tree (like `git diff`). Shows added, removed, and modified packages with version info. Use `--stat` or `--summary` for one-line aggregate counts.
+With no arguments, compares HEAD against the working tree (like `git diff`). Shows added, removed, and modified packages with version info. Use `--stat` or `--summary` for one-line aggregate counts. Use `--by=ecosystem` when lockfile paths changed, such as a migration from `package-lock.json` to `pnpm-lock.yaml`, and you want to compare package names and versions rather than manifest filenames.
 
 ### Diff between files
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -28,10 +28,16 @@ Supports range syntax (main..feature) or explicit --from/--to flags.`,
 	diffCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
 	diffCmd.Flags().StringP("type", "t", "", "Filter by dependency type (runtime, development, etc.)")
 	diffCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	diffCmd.Flags().String("by", diffByManifest, "Match dependencies by: manifest, ecosystem")
 	diffCmd.Flags().Bool("stat", false, "Show aggregate dependency change counts")
 	diffCmd.Flags().Bool("summary", false, "Show aggregate dependency change counts")
 	parent.AddCommand(diffCmd)
 }
+
+const (
+	diffByManifest  = "manifest"
+	diffByEcosystem = "ecosystem"
+)
 
 type DiffResult struct {
 	Added    []DiffEntry `json:"added,omitempty"`
@@ -64,9 +70,14 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	depType, _ := cmd.Flags().GetString("type")
 	format, _ := cmd.Flags().GetString("format")
+	by, _ := cmd.Flags().GetString("by")
 	stat, _ := cmd.Flags().GetBool("stat")
 	summary, _ := cmd.Flags().GetBool("summary")
 	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
+
+	if by != diffByManifest && by != diffByEcosystem {
+		return fmt.Errorf("--by must be one of: %s, %s", diffByManifest, diffByEcosystem)
+	}
 
 	// Parse range syntax if provided
 	if len(args) > 0 {
@@ -95,9 +106,9 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	// When comparing to working tree, use direct parsing since there's
 	// no database state for uncommitted changes
 	if toRef == "" {
-		result, err = diffWithWorkingTree(repo, fromRef, includeSubmodules)
+		result, err = diffWithWorkingTree(repo, fromRef, includeSubmodules, by)
 	} else {
-		result, err = diffBetweenCommits(repo, fromRef, toRef)
+		result, err = diffBetweenCommits(repo, fromRef, toRef, by)
 	}
 	if err != nil {
 		return err
@@ -128,7 +139,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 }
 
 // diffBetweenCommits compares dependencies between two commits using on-demand indexing.
-func diffBetweenCommits(repo *git.Repository, fromRef, toRef string) (*DiffResult, error) {
+func diffBetweenCommits(repo *git.Repository, fromRef, toRef, by string) (*DiffResult, error) {
 	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
@@ -139,11 +150,11 @@ func diffBetweenCommits(repo *git.Repository, fromRef, toRef string) (*DiffResul
 		return nil, fmt.Errorf("getting deps at %s: %w", toRef, err)
 	}
 
-	return computeDiff(fromDeps, toDeps), nil
+	return computeDiffBy(fromDeps, toDeps, by), nil
 }
 
 // diffWithWorkingTree compares dependencies between a commit and the working tree.
-func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules bool) (*DiffResult, error) {
+func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules bool, by string) (*DiffResult, error) {
 	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
@@ -157,7 +168,7 @@ func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules
 	}
 	toDeps := changesToDeps(toChanges)
 
-	return computeDiff(fromDeps, toDeps), nil
+	return computeDiffBy(fromDeps, toDeps, by), nil
 }
 
 func changesToDeps(changes []analyzer.Change) []database.Dependency {
@@ -166,8 +177,10 @@ func changesToDeps(changes []analyzer.Change) []database.Dependency {
 		deps = append(deps, database.Dependency{
 			Name:           c.Name,
 			Ecosystem:      c.Ecosystem,
+			PURL:           c.PURL,
 			Requirement:    c.Requirement,
 			ManifestPath:   c.ManifestPath,
+			ManifestKind:   c.Kind,
 			DependencyType: c.DependencyType,
 		})
 	}
@@ -175,24 +188,23 @@ func changesToDeps(changes []analyzer.Change) []database.Dependency {
 }
 
 func computeDiff(fromDeps, toDeps []database.Dependency) *DiffResult {
+	return computeDiffBy(fromDeps, toDeps, diffByManifest)
+}
+
+func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResult {
 	result := &DiffResult{}
 
-	// Build multi-maps keyed by manifest:name, since lockfiles can contain
-	// the same package at multiple versions (e.g. npm dependency hoisting).
-	type depKey struct {
-		ManifestPath string
-		Name         string
-	}
-
-	fromMulti := make(map[depKey][]database.Dependency)
+	// Build multi-maps keyed by the selected matching mode, since lockfiles
+	// can contain the same package at multiple versions (e.g. npm hoisting).
+	fromMulti := make(map[diffDepKey][]database.Dependency)
 	for _, d := range fromDeps {
-		key := depKey{d.ManifestPath, d.Name}
+		key := diffDepKeyFor(d, by)
 		fromMulti[key] = append(fromMulti[key], d)
 	}
 
-	toMulti := make(map[depKey][]database.Dependency)
+	toMulti := make(map[diffDepKey][]database.Dependency)
 	for _, d := range toDeps {
-		key := depKey{d.ManifestPath, d.Name}
+		key := diffDepKeyFor(d, by)
 		toMulti[key] = append(toMulti[key], d)
 	}
 
@@ -327,6 +339,19 @@ func computeDiff(fromDeps, toDeps []database.Dependency) *DiffResult {
 	sortDiffEntries(result.Removed)
 
 	return result
+}
+
+type diffDepKey struct {
+	ManifestPath string
+	Ecosystem    string
+	Name         string
+}
+
+func diffDepKeyFor(d database.Dependency, by string) diffDepKey {
+	if by == diffByEcosystem {
+		return diffDepKey{Ecosystem: d.Ecosystem, Name: d.Name}
+	}
+	return diffDepKey{ManifestPath: d.ManifestPath, Name: d.Name}
 }
 
 func sortDiffEntries(entries []DiffEntry) {

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -528,6 +528,65 @@ func TestComputeDiff_DuplicatePackageVersionsInLockfile(t *testing.T) {
 	}
 }
 
+func TestComputeDiffByEcosystem_IgnoresLockfileMigration(t *testing.T) {
+	fromDeps := []database.Dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: "manifest", DependencyType: "runtime"},
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.21", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile, DependencyType: "development"},
+		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile, DependencyType: "runtime"},
+	}
+	toDeps := []database.Dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: "manifest", DependencyType: "runtime"},
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.21", ManifestPath: "pnpm-lock.yaml", ManifestKind: manifestKindLockfile},
+		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2", ManifestPath: "pnpm-lock.yaml", ManifestKind: manifestKindLockfile},
+	}
+
+	defaultResult := computeDiff(fromDeps, toDeps)
+	if len(defaultResult.Added) != 2 {
+		t.Fatalf("default added = %d, want 2: %+v", len(defaultResult.Added), defaultResult.Added)
+	}
+	if len(defaultResult.Removed) != 2 {
+		t.Fatalf("default removed = %d, want 2: %+v", len(defaultResult.Removed), defaultResult.Removed)
+	}
+
+	result := computeDiffBy(fromDeps, toDeps, diffByEcosystem)
+	if len(result.Added) != 0 {
+		t.Fatalf("added = %d, want 0: %+v", len(result.Added), result.Added)
+	}
+	if len(result.Modified) != 0 {
+		t.Fatalf("modified = %d, want 0: %+v", len(result.Modified), result.Modified)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("removed = %d, want 0: %+v", len(result.Removed), result.Removed)
+	}
+}
+
+func TestComputeDiffByEcosystem_ReportsVersionChangeAcrossLockfileMigration(t *testing.T) {
+	fromDeps := []database.Dependency{
+		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+	}
+	toDeps := []database.Dependency{
+		{Name: "express", Ecosystem: "npm", Requirement: "5.0.0", ManifestPath: "pnpm-lock.yaml", ManifestKind: manifestKindLockfile},
+	}
+
+	result := computeDiffBy(fromDeps, toDeps, diffByEcosystem)
+	if len(result.Added) != 0 {
+		t.Fatalf("added = %d, want 0: %+v", len(result.Added), result.Added)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("removed = %d, want 0: %+v", len(result.Removed), result.Removed)
+	}
+	if len(result.Modified) != 1 {
+		t.Fatalf("modified = %d, want 1: %+v", len(result.Modified), result.Modified)
+	}
+	entry := result.Modified[0]
+	if entry.FromRequirement != "4.18.2" || entry.ToRequirement != "5.0.0" {
+		t.Fatalf("requirements = %s -> %s, want 4.18.2 -> 5.0.0", entry.FromRequirement, entry.ToRequirement)
+	}
+	if entry.ManifestPath != "pnpm-lock.yaml" {
+		t.Fatalf("manifest path = %q, want pnpm-lock.yaml", entry.ManifestPath)
+	}
+}
+
 func TestComputeDiff_MultiVersionUpgrade(t *testing.T) {
 	// glob exists at three versions; one version gets a patch bump.
 	// Should produce 1 Modified, not 1 Added + 1 Removed.


### PR DESCRIPTION
closes #190
## Summary

Adds an opt-in `git pkgs diff --by=ecosystem` mode for comparing dependency sets across lockfile migrations.

## Changes

- Add `--by=manifest|ecosystem` to `git pkgs diff`
- Keep existing manifest-path-sensitive behavior as the default
- Match by ecosystem + package name when `--by=ecosystem` is used
- Suppress add/remove noise when identical resolved packages move between lockfiles
- Still report real version changes across lockfile migrations
- Document the new mode in the README

## Testing

- `go test ./cmd -run 'Diff|ComputeDiff'`
- `go test ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`