### PR TITLE
Recover from panics in library goroutines

### DIFF
--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -196,6 +196,11 @@ func (w *BatchWriter) FlushAsync() {
 	w.flushDone = make(chan error, 1)
 	ch := w.flushDone
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ch <- fmt.Errorf("panic during async flush: %v", r)
+			}
+		}()
 		ch <- w.flushPending(commits, changes, snapshots)
 	}()
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -77,13 +77,19 @@ func (idx *Indexer) Run() (*Result, error) {
 		var r refResult
 		r.tags = make(map[string][]string)
 		r.branches = make(map[string][]string)
+		defer func() {
+			// go-git iterates attacker-controlled refs/packfiles here when
+			// embedded server-side; a panic in that path must not take the
+			// host process down or leave the receiver blocked on refCh.
+			_ = recover()
+			refCh <- r
+		}()
 		if tags, err := idx.repo.Tags(); err == nil {
 			r.tags = tags
 		}
 		if branches, err := idx.repo.LocalBranches(); err == nil {
 			r.branches = branches
 		}
-		refCh <- r
 	}()
 
 	writer := database.NewBatchWriter(idx.db)


### PR DESCRIPTION
When git-pkgs is embedded as a library (the upcoming silo server), a caller can wrap `Indexer.Run` in a `recover()` to survive a panic on hostile input, but that does not cover goroutines spawned inside the call.

There are exactly two such goroutines in non-test, non-cmd code:

`internal/indexer/indexer.go` collects tags and branches via go-git concurrently with the commit walk. go-git is iterating attacker-controlled refs and packfiles here, so a panic in that path would kill the host process and leave the receiver blocked on `refCh`. The send is moved into a `defer` that swallows any panic; `r` is initialised before the defer is registered so the receiver always gets a valid (possibly partial) result.

`internal/database/batch_writer.go` runs `flushPending` in the background during `FlushAsync`. A panic there now surfaces as an error on `flushDone` so `WaitForFlush` returns it instead of hanging.