### PR TITLE
Add JSON help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,15 @@ git pkgs install -x --legacy-peer-deps      # pass extra flags
 git pkgs add lodash -x --save-exact         # npm --save-exact
 ```
 
+### Structured command metadata
+
+```bash
+git pkgs help --format json
+git pkgs help list --format json
+```
+
+Prints the command tree as JSON, including descriptions, aliases, subcommands, and flag metadata. This is useful for tools that need to discover git-pkgs commands without scraping text help output.
+
 ### Browse package source
 
 Open the source code of an installed package in your editor:

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type helpCommandDoc struct {
+	Name            string           `json:"name"`
+	Use             string           `json:"use"`
+	CommandPath     string           `json:"command_path"`
+	Short           string           `json:"short,omitempty"`
+	Long            string           `json:"long,omitempty"`
+	Example         string           `json:"example,omitempty"`
+	Aliases         []string         `json:"aliases,omitempty"`
+	GroupID         string           `json:"group_id,omitempty"`
+	Runnable        bool             `json:"runnable"`
+	Hidden          bool             `json:"hidden,omitempty"`
+	Deprecated      string           `json:"deprecated,omitempty"`
+	Flags           []helpFlagDoc    `json:"flags,omitempty"`
+	PersistentFlags []helpFlagDoc    `json:"persistent_flags,omitempty"`
+	InheritedFlags  []helpFlagDoc    `json:"inherited_flags,omitempty"`
+	Subcommands     []helpCommandDoc `json:"subcommands,omitempty"`
+}
+
+type helpFlagDoc struct {
+	Name        string   `json:"name"`
+	Shorthand   string   `json:"shorthand,omitempty"`
+	Type        string   `json:"type"`
+	Default     string   `json:"default"`
+	Usage       string   `json:"usage,omitempty"`
+	Required    bool     `json:"required,omitempty"`
+	Hidden      bool     `json:"hidden,omitempty"`
+	Deprecated  string   `json:"deprecated,omitempty"`
+	Annotations []string `json:"annotations,omitempty"`
+}
+
+func addJSONHelpCommand(root *cobra.Command) {
+	helpCmd := &cobra.Command{
+		Use:   "help [command]",
+		Short: "Help about any command",
+		Long:  "Help provides help for any command in the application.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, _ := cmd.Flags().GetString("format")
+			switch format {
+			case "text", "":
+				target, err := helpTargetCommand(root, args)
+				if err != nil {
+					return err
+				}
+				target.SetOut(cmd.OutOrStdout())
+				target.SetErr(cmd.ErrOrStderr())
+				return target.Help()
+			case "json":
+				target, err := helpTargetCommand(root, args)
+				if err != nil {
+					return err
+				}
+				encoder := json.NewEncoder(cmd.OutOrStdout())
+				encoder.SetIndent("", "  ")
+				encoder.SetEscapeHTML(false)
+				return encoder.Encode(buildHelpCommandDoc(target))
+			default:
+				return fmt.Errorf("unsupported help format %q; supported formats: text, json", format)
+			}
+		},
+	}
+	helpCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	root.SetHelpCommand(helpCmd)
+}
+
+func helpTargetCommand(root *cobra.Command, args []string) (*cobra.Command, error) {
+	if len(args) == 0 {
+		return root, nil
+	}
+	target, remaining, err := root.Find(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(remaining) > 0 {
+		return nil, fmt.Errorf("unknown help topic %q", strings.Join(remaining, " "))
+	}
+	return target, nil
+}
+
+func buildHelpCommandDoc(cmd *cobra.Command) helpCommandDoc {
+	doc := helpCommandDoc{
+		Name:        cmd.Name(),
+		Use:         cmd.UseLine(),
+		CommandPath: cmd.CommandPath(),
+		Short:       cmd.Short,
+		Long:        cmd.Long,
+		Example:     cmd.Example,
+		Aliases:     append([]string(nil), cmd.Aliases...),
+		GroupID:     cmd.GroupID,
+		Runnable:    cmd.Runnable(),
+		Hidden:      cmd.Hidden,
+		Deprecated:  cmd.Deprecated,
+	}
+
+	doc.Flags = collectHelpFlags(cmd.LocalNonPersistentFlags())
+	doc.PersistentFlags = collectHelpFlags(cmd.PersistentFlags())
+	doc.InheritedFlags = collectHelpFlags(cmd.InheritedFlags())
+
+	for _, child := range cmd.Commands() {
+		if child.Hidden {
+			continue
+		}
+		doc.Subcommands = append(doc.Subcommands, buildHelpCommandDoc(child))
+	}
+
+	return doc
+}
+
+func collectHelpFlags(flags *pflag.FlagSet) []helpFlagDoc {
+	if flags == nil {
+		return nil
+	}
+	var docs []helpFlagDoc
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		docs = append(docs, helpFlagDoc{
+			Name:        flag.Name,
+			Shorthand:   flag.Shorthand,
+			Type:        flag.Value.Type(),
+			Default:     flag.DefValue,
+			Usage:       flag.Usage,
+			Required:    isRequiredFlag(flag),
+			Hidden:      flag.Hidden,
+			Deprecated:  flag.Deprecated,
+			Annotations: helpFlagAnnotations(flag),
+		})
+	})
+	return docs
+}
+
+func isRequiredFlag(flag *pflag.Flag) bool {
+	if flag == nil || flag.Annotations == nil {
+		return false
+	}
+	required := flag.Annotations[cobra.BashCompOneRequiredFlag]
+	return len(required) > 0 && required[0] == "true"
+}
+
+func helpFlagAnnotations(flag *pflag.Flag) []string {
+	if flag == nil || len(flag.Annotations) == 0 {
+		return nil
+	}
+	annotations := make([]string, 0, len(flag.Annotations))
+	for key, values := range flag.Annotations {
+		annotations = append(annotations, key+"="+strings.Join(values, ","))
+	}
+	sort.Strings(annotations)
+	return annotations
+}

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHelpJSONRoot(t *testing.T) {
+	doc := runHelpJSON(t, "help", "--format", "json")
+
+	if doc.Name != "git-pkgs" {
+		t.Fatalf("name = %q, want git-pkgs", doc.Name)
+	}
+	if doc.CommandPath != "git-pkgs" {
+		t.Fatalf("command_path = %q, want git-pkgs", doc.CommandPath)
+	}
+	if !hasHelpCommand(doc, "list") {
+		t.Fatalf("root JSON help missing list command")
+	}
+	if !hasHelpCommand(doc, "help") {
+		t.Fatalf("root JSON help missing help command")
+	}
+	if !hasHelpFlag(doc.PersistentFlags, "color", "string") {
+		t.Fatalf("root JSON help missing persistent color flag")
+	}
+}
+
+func TestHelpJSONSpecificCommand(t *testing.T) {
+	doc := runHelpJSON(t, "help", "list", "--format", "json")
+
+	if doc.Name != "list" {
+		t.Fatalf("name = %q, want list", doc.Name)
+	}
+	if doc.CommandPath != "git-pkgs list" {
+		t.Fatalf("command_path = %q, want git-pkgs list", doc.CommandPath)
+	}
+	if !hasHelpFlag(doc.Flags, "format", "string") {
+		t.Fatalf("list JSON help missing format flag")
+	}
+	if !hasHelpFlag(doc.Flags, "ecosystem", "string") {
+		t.Fatalf("list JSON help missing ecosystem flag")
+	}
+	if !hasHelpFlag(doc.InheritedFlags, "quiet", "bool") {
+		t.Fatalf("list JSON help missing inherited quiet flag")
+	}
+}
+
+func TestHelpJSONIncludesEmptyStringDefaults(t *testing.T) {
+	output := runHelpJSONOutput(t, "help", "list", "--format", "json")
+
+	var raw struct {
+		Flags []map[string]any `json:"flags"`
+	}
+	if err := json.Unmarshal(output, &raw); err != nil {
+		t.Fatalf("unmarshal help JSON: %v\noutput:\n%s", err, string(output))
+	}
+
+	for _, flag := range raw.Flags {
+		if flag["name"] != "ecosystem" {
+			continue
+		}
+		defaultValue, ok := flag["default"]
+		if !ok {
+			t.Fatalf("ecosystem flag missing default key: %#v", flag)
+		}
+		if defaultValue != "" {
+			t.Fatalf("ecosystem default = %#v, want empty string", defaultValue)
+		}
+		return
+	}
+	t.Fatal("list JSON help missing ecosystem flag")
+}
+
+func TestHelpJSONRejectsUnsupportedFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	root := NewRootCmd()
+	root.SetArgs([]string{"help", "--format", "yaml"})
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected unsupported format error")
+	}
+	if !strings.Contains(err.Error(), `unsupported help format "yaml"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestHelpJSONIncludesPlugins(t *testing.T) {
+	dir := t.TempDir()
+	pluginPath := filepath.Join(dir, "git-pkgs-hello")
+	if err := os.WriteFile(pluginPath, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write plugin: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	doc := runHelpJSON(t, "help", "--format", "json")
+	pluginDoc, ok := findHelpCommand(doc, "hello")
+	if !ok {
+		t.Fatal("root JSON help missing plugin command")
+	}
+	if pluginDoc.Short != "[plugin] git-pkgs-hello" {
+		t.Fatalf("plugin short = %q", pluginDoc.Short)
+	}
+}
+
+func runHelpJSON(t *testing.T, args ...string) helpCommandDoc {
+	t.Helper()
+	output := runHelpJSONOutput(t, args...)
+
+	var doc helpCommandDoc
+	if err := json.Unmarshal(output, &doc); err != nil {
+		t.Fatalf("unmarshal help JSON: %v\noutput:\n%s", err, string(output))
+	}
+	return doc
+}
+
+func runHelpJSONOutput(t *testing.T, args ...string) []byte {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	root := NewRootCmd()
+	root.SetArgs(args)
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("%v failed: %v\nstderr: %s", args, err, stderr.String())
+	}
+
+	return stdout.Bytes()
+}
+
+func hasHelpCommand(doc helpCommandDoc, name string) bool {
+	_, ok := findHelpCommand(doc, name)
+	return ok
+}
+
+func findHelpCommand(doc helpCommandDoc, name string) (helpCommandDoc, bool) {
+	for _, child := range doc.Subcommands {
+		if child.Name == name {
+			return child, true
+		}
+	}
+	return helpCommandDoc{}, false
+}
+
+func hasHelpFlag(flags []helpFlagDoc, name, flagType string) bool {
+	for _, flag := range flags {
+		if flag.Name == name && flag.Type == flagType {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,6 +109,7 @@ func NewRootCmd() *cobra.Command {
 
 	// External plugins (git-pkgs-* on PATH)
 	addPluginCmds(cmd)
+	addJSONHelpCommand(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
## Summary

Adds structured command discovery via `git pkgs help --format json`, as a prerequisite for the MCP server work in #114.

Ref #114

## Changes

- Add a custom Cobra help command with `--format text|json`
- Preserve existing text help behavior
- Serialize command metadata as JSON:
  - command name/path/usage
  - short and long descriptions
  - aliases
  - runnable status
  - local, persistent and inherited flags
  - nested subcommands
- Include discovered plugin commands in the JSON command tree
- Document the new structured help output in the README
- Add tests for root JSON help, command-specific JSON help, unsupported formats and plugin discovery

## Testing

- `go test ./cmd -run HelpJSON`
- `go run . help where --format json`
- `go run . help list`
- `go test ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`
- `go build ./...`