### PR TITLE
Fix urls command using version ranges and wrong name from db lookup

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -64,8 +64,15 @@ func shortSHA(sha string) string {
 }
 
 func isResolvedDependency(d database.Dependency) bool {
-	return d.Requirement != "" &&
-		(d.ManifestKind == manifestKindLockfile || d.Ecosystem == "golang" || d.Ecosystem == "maven")
+	return d.Requirement != "" && hasResolvedRequirement(d.Ecosystem, d.ManifestKind)
+}
+
+// hasResolvedRequirement reports whether a dependency row from the given
+// ecosystem and manifest kind carries an exact version in its requirement
+// field rather than a range constraint. Lockfiles always do; go.mod and
+// Maven poms pin exact versions despite being manifests.
+func hasResolvedRequirement(ecosystem, manifestKind string) bool {
+	return manifestKind == manifestKindLockfile || ecosystem == "golang" || ecosystem == "maven"
 }
 
 func IsPURL(s string) bool {

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/registries"
 	_ "github.com/git-pkgs/registries/all"
@@ -113,37 +114,52 @@ func lookupPackage(name, ecosystem string) (purlType, pkgName, version string, e
 	}
 
 	// Filter to exact name matches if any exist
-	var exact []struct{ eco, req string }
+	var matches []database.SearchResult
 	for _, r := range results {
 		if strings.EqualFold(r.Name, name) {
-			exact = append(exact, struct{ eco, req string }{r.Ecosystem, r.Requirement})
+			matches = append(matches, r)
 		}
 	}
 
-	if len(exact) == 0 {
-		// No exact match, use the first result
-		exact = append(exact, struct{ eco, req string }{results[0].Ecosystem, results[0].Requirement})
+	if len(matches) == 0 {
+		// No exact match, use the first substring result
+		matches = append(matches, results[0])
 	}
 
-	// Deduplicate by ecosystem
-	seen := make(map[string]bool)
-	var unique []struct{ eco, req string }
-	for _, e := range exact {
-		if !seen[e.eco] {
-			seen[e.eco] = true
-			unique = append(unique, e)
+	// Deduplicate by ecosystem, preferring rows that carry a resolved
+	// version (lockfiles, or manifests from ecosystems that pin exact
+	// versions) over rows with range constraints.
+	seen := make(map[string]int)
+	var unique []database.SearchResult
+	for _, m := range matches {
+		if i, ok := seen[m.Ecosystem]; ok {
+			prev := unique[i]
+			if !hasResolvedRequirement(prev.Ecosystem, prev.ManifestKind) && hasResolvedRequirement(m.Ecosystem, m.ManifestKind) {
+				unique[i] = m
+			}
+			continue
 		}
+		seen[m.Ecosystem] = len(unique)
+		unique = append(unique, m)
 	}
 
 	if len(unique) > 1 && ecosystem == "" {
 		ecos := make([]string, len(unique))
 		for i, u := range unique {
-			ecos[i] = u.eco
+			ecos[i] = u.Ecosystem
 		}
 		return "", "", "", fmt.Errorf("ambiguous: %q found in multiple ecosystems (%s). Use --ecosystem to specify", name, strings.Join(ecos, ", "))
 	}
 
 	match := unique[0]
-	pt := purl.EcosystemToPURLType(match.eco)
-	return pt, name, match.req, nil
+	pt := purl.EcosystemToPURLType(match.Ecosystem)
+
+	// Manifest requirements are constraints (^1.2.3, ~> 2.0), not versions.
+	// Only return the requirement as a version when it's known to be exact.
+	resolved := ""
+	if hasResolvedRequirement(match.Ecosystem, match.ManifestKind) {
+		resolved = match.Requirement
+	}
+
+	return pt, match.Name, resolved, nil
 }

--- a/cmd/urls_test.go
+++ b/cmd/urls_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
@@ -95,42 +96,94 @@ func TestUrlsPURL(t *testing.T) {
 	})
 }
 
+func initRepoWithFiles(t *testing.T, files map[string]string) {
+	t.Helper()
+	repoDir := createTestRepo(t)
+	for path, content := range files {
+		addFileAndCommit(t, repoDir, path, content, "Add "+path)
+	}
+	cleanup := chdir(t, repoDir)
+	t.Cleanup(cleanup)
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+}
+
+func runUrlsJSON(t *testing.T, args ...string) map[string]string {
+	t.Helper()
+	args = append([]string{"urls"}, args...)
+	args = append(args, "-f", "json")
+	stdout, _, err := runCmd(t, args...)
+	if err != nil {
+		t.Fatalf("urls failed: %v", err)
+	}
+	var urls map[string]string
+	if err := json.Unmarshal([]byte(stdout), &urls); err != nil {
+		t.Fatalf("failed to parse JSON: %v\noutput: %s", err, stdout)
+	}
+	return urls
+}
+
 func TestUrlsNameLookup(t *testing.T) {
-	t.Run("looks up package by name", func(t *testing.T) {
-		repoDir := createTestRepo(t)
-		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
-		cleanup := chdir(t, repoDir)
-		defer cleanup()
+	t.Run("manifest-only lookup omits version range", func(t *testing.T) {
+		initRepoWithFiles(t, map[string]string{"package.json": packageJSON})
 
-		_, _, err := runCmd(t, "init")
-		if err != nil {
-			t.Fatalf("init failed: %v", err)
+		urls := runUrlsJSON(t, "lodash", "-e", "npm")
+		if urls["registry"] == "" {
+			t.Errorf("expected registry URL, got: %v", urls)
 		}
+		if urls["purl"] != "pkg:npm/lodash" {
+			t.Errorf("expected versionless purl pkg:npm/lodash, got: %q", urls["purl"])
+		}
+		if urls["download"] != "" {
+			t.Errorf("expected no download URL without resolved version, got: %q", urls["download"])
+		}
+	})
 
-		stdout, _, err := runCmd(t, "urls", "lodash", "-e", "npm")
+	t.Run("substring lookup uses matched name", func(t *testing.T) {
+		initRepoWithFiles(t, map[string]string{"package.json": packageJSON})
+
+		urls := runUrlsJSON(t, "lod", "-e", "npm")
+		if urls["purl"] != "pkg:npm/lodash" {
+			t.Errorf("expected purl for matched package lodash, got: %q", urls["purl"])
+		}
+		if !strings.Contains(urls["registry"], "/lodash") {
+			t.Errorf("expected registry URL for lodash, got: %q", urls["registry"])
+		}
+	})
+
+	t.Run("lockfile lookup uses resolved version", func(t *testing.T) {
+		initRepoWithFiles(t, map[string]string{
+			"package.json":      packageJSON,
+			"package-lock.json": packageLockJSON,
+		})
+
+		urls := runUrlsJSON(t, "lodash", "-e", "npm")
+		if urls["purl"] != "pkg:npm/lodash@4.17.21" {
+			t.Errorf("expected purl pkg:npm/lodash@4.17.21, got: %q", urls["purl"])
+		}
+		if urls["download"] != "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz" {
+			t.Errorf("expected exact download URL, got: %q", urls["download"])
+		}
+	})
+
+	t.Run("go.mod lookup keeps exact version", func(t *testing.T) {
+		goMod, err := os.ReadFile("testdata/ades-go.mod")
 		if err != nil {
-			t.Fatalf("urls failed: %v", err)
+			t.Fatalf("read fixture: %v", err)
 		}
-		if !strings.Contains(stdout, "npmjs") {
-			t.Errorf("expected 'npmjs' in output, got: %s", stdout)
-		}
-		if !strings.Contains(stdout, "registry") {
-			t.Errorf("expected 'registry' key in output, got: %s", stdout)
+		initRepoWithFiles(t, map[string]string{"go.mod": string(goMod)})
+
+		urls := runUrlsJSON(t, "golang.org/x/mod", "-e", "golang")
+		if urls["purl"] != "pkg:golang/golang.org/x/mod@v0.32.0" {
+			t.Errorf("expected versioned purl, got: %q", urls["purl"])
 		}
 	})
 
 	t.Run("errors when package not found", func(t *testing.T) {
-		repoDir := createTestRepo(t)
-		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
-		cleanup := chdir(t, repoDir)
-		defer cleanup()
+		initRepoWithFiles(t, map[string]string{"package.json": packageJSON})
 
-		_, _, err := runCmd(t, "init")
-		if err != nil {
-			t.Fatalf("init failed: %v", err)
-		}
-
-		_, _, err = runCmd(t, "urls", "nonexistent-package-xyz")
+		_, _, err := runCmd(t, "urls", "nonexistent-package-xyz")
 		if err == nil {
 			t.Error("expected error for non-existent package")
 		}


### PR DESCRIPTION
Fixes #239.

`lookupPackage` had two problems when resolving a plain name from the database:

- It returned the original query string as the package name even when the match came from a substring search, so `git pkgs urls lod -e npm` built URLs for `lod` using lodash's data.
- It returned the manifest requirement (e.g. `^4.17.21`) as the version, producing invalid download URLs like `https://registry.npmjs.org/lodash/-/lodash-^4.17.21.tgz` and purls like `pkg:npm/lodash@^4.17.21`.

This change keeps the full `SearchResult` through the dedup so the matched name is returned, prefers lockfile rows over manifest rows for the same ecosystem, and only passes the requirement through as a version when it is known to be exact (lockfile entries, or go.mod / Maven manifests). Otherwise the version is left empty and `registries.BuildURLs` emits a versionless purl and skips the download URL.

The lockfile/golang/maven check is pulled out of `isResolvedDependency` into `hasResolvedRequirement` so both call sites share it.