### PR TITLE
Add provenance metadata command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For best results, commit your lockfiles. Manifests show version ranges but lockf
 
 It works across many ecosystems (Gemfile, package.json, Dockerfile, GitHub Actions workflows) giving you one unified history instead of separate tools per ecosystem. The database lives in your `.git` directory where you can use it in CI to catch dependency changes in pull requests.
 
-The core commands (`list`, `history`, `blame`, `diff`, `stale`, etc.) work entirely from your git history with no network access. Additional commands fetch external data: `vulns` checks [OSV](https://osv.dev) for known CVEs, `outdated`, `freshness`, `licenses`, `funding`, `maintainers`, and `health` query [ecosyste.ms](https://packages.ecosyste.ms/) for registry metadata, `deprecated` checks registries for deprecation metadata, and `changelog` fetches upstream changelogs so you can see what changed between versions.
+The core commands (`list`, `history`, `blame`, `diff`, `stale`, etc.) work entirely from your git history with no network access. Additional commands fetch external data: `vulns` checks [OSV](https://osv.dev) for known CVEs, `outdated`, `freshness`, `licenses`, `funding`, `maintainers`, and `health` query [ecosyste.ms](https://packages.ecosyste.ms/) for registry metadata, `deprecated` checks registries for deprecation metadata, `provenance` checks registries for attestation metadata, and `changelog` fetches upstream changelogs so you can see what changed between versions.
 
 ## Installation
 
@@ -50,6 +50,7 @@ git pkgs deprecated     # find deprecated installed versions
 git pkgs funding        # show packages with funding links
 git pkgs maintainers    # show dependency maintainer counts
 git pkgs health         # score dependency maintenance health
+git pkgs provenance     # check trusted-publishing provenance
 git pkgs changelog lodash -e npm --from 4.17.20 --to 4.17.21  # view changelog
 git pkgs update         # update all dependencies
 git pkgs add lodash     # add a package
@@ -320,6 +321,17 @@ git pkgs health --format=json
 ```
 
 Scores dependency maintenance health from ecosyste.ms package metadata, including maintainer count and usage signals. Scores start at 100 and drop for missing maintainer data, a single maintainer, a small maintainer team, low dependent usage, missing usage data, and missing download data. `--threshold` controls both which dependencies are displayed and the `at_risk_dependencies` summary count. Results are sorted from lowest score to highest.
+
+### Check provenance metadata
+
+```bash
+git pkgs provenance                # show provenance status for resolved deps
+git pkgs provenance --missing      # only show deps without trusted publishing
+git pkgs provenance --ecosystem=npm
+git pkgs provenance --format=json
+```
+
+Checks exact installed versions for registry attestation metadata. Trusted-publishing attestations are reported when registries expose them; npm registry signatures are shown as a weaker integrity signal. Unsupported ecosystems and lookup errors are reported explicitly.
 
 ### View changelogs
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ git pkgs deprecated     # find deprecated installed versions
 git pkgs funding        # show packages with funding links
 git pkgs maintainers    # show dependency maintainer counts
 git pkgs health         # score dependency maintenance health
-git pkgs provenance     # check trusted-publishing provenance
+git pkgs provenance     # check provenance metadata
 git pkgs changelog lodash -e npm --from 4.17.20 --to 4.17.21  # view changelog
 git pkgs update         # update all dependencies
 git pkgs add lodash     # add a package
@@ -331,7 +331,7 @@ git pkgs provenance --ecosystem=npm
 git pkgs provenance --format=json
 ```
 
-Checks exact installed versions for registry attestation metadata. Trusted-publishing attestations are reported when registries expose them; npm registry signatures are shown as a weaker integrity signal. Unsupported ecosystems and lookup errors are reported explicitly.
+Checks exact installed versions for registry attestation metadata. Verified trusted-publishing signals are reported where registries expose them; npm attestations are reported separately because their metadata does not identify OIDC publishing. Registry signatures are shown as a weaker integrity signal. Unsupported ecosystems and lookup errors are reported explicitly.
 
 ### View changelogs
 

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -17,6 +17,7 @@ func TestUnsupportedFormatValuesAreRejected(t *testing.T) {
 		{name: "search", args: []string{"search", "lodash", "--format", "yaml"}, formats: "text, json"},
 		{name: "sbom", args: []string{"sbom", "--format", "yaml"}, formats: "json, xml"},
 		{name: "licenses", args: []string{"licenses", "--format", "xml"}, formats: "text, json, csv"},
+		{name: "provenance", args: []string{"provenance", "--format", "yaml"}, formats: "text, json"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/pager_test.go
+++ b/cmd/pager_test.go
@@ -20,6 +20,7 @@ func TestPagerFlagAccepted(t *testing.T) {
 		"funding",
 		"maintainers",
 		"health",
+		"provenance",
 		"log",
 		"list",
 		"history",

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -3,18 +3,14 @@ package cmd
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/git-pkgs/internal/provenance"
 	"github.com/git-pkgs/purl"
 	"github.com/spf13/cobra"
 )
@@ -22,23 +18,13 @@ import (
 const provenanceLookupTimeout = 5 * time.Minute
 const provenanceLookupConcurrency = 8
 
-type provenanceStatus string
-
 const (
-	provenanceStatusTrustedPublishing provenanceStatus = "trusted_publishing"
-	provenanceStatusSigned            provenanceStatus = "signed"
-	provenanceStatusMissing           provenanceStatus = "missing"
-	provenanceStatusUnsupported       provenanceStatus = "unsupported"
-	provenanceStatusError             provenanceStatus = "error"
+	provenanceStatusTrustedPublishing = provenance.StatusTrustedPublishing
+	provenanceStatusSigned            = provenance.StatusSigned
+	provenanceStatusMissing           = provenance.StatusMissing
+	provenanceStatusUnsupported       = provenance.StatusUnsupported
+	provenanceStatusError             = provenance.StatusError
 )
-
-type provenanceHTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-var newProvenanceHTTPClient = func() provenanceHTTPClient {
-	return &http.Client{Timeout: 30 * time.Second}
-}
 
 func addProvenanceCmd(parent *cobra.Command) {
 	provenanceCmd := &cobra.Command{
@@ -89,19 +75,16 @@ type ProvenanceResult struct {
 	Dependencies []ProvenanceEntry `json:"dependencies"`
 }
 
-type provenanceLookupData struct {
-	Status             provenanceStatus
-	TrustedPublishing  bool
-	RegistrySignatures int
-	Evidence           []string
-	Error              string
-}
+type provenanceLookupData = provenance.Result
 
 func runProvenance(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	showMissing, _ := cmd.Flags().GetBool("missing")
 
 	repo, err := git.OpenRepository(".")
@@ -174,7 +157,7 @@ func fetchProvenanceData(ctx context.Context, deps []database.Dependency) map[st
 	}
 
 	var wg sync.WaitGroup
-	client := newProvenanceHTTPClient()
+	client := provenance.NewClient(userAgent)
 	for range workers {
 		wg.Add(1)
 		go func() {
@@ -183,7 +166,11 @@ func fetchProvenanceData(ctx context.Context, deps []database.Dependency) map[st
 				dep := purlToDep[purlStr]
 				out <- lookupResult{
 					purl: purlStr,
-					data: lookupProvenance(ctx, client, dep),
+					data: client.Lookup(ctx, provenance.Dependency{
+						Ecosystem: dep.Ecosystem,
+						Name:      dep.Name,
+						Version:   dep.Requirement,
+					}),
 				}
 			}
 		}()
@@ -244,170 +231,6 @@ func provenancePURLForDependency(dep database.Dependency) string {
 		}
 	}
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, dep.Requirement)
-}
-
-func lookupProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
-	switch dep.Ecosystem {
-	case "npm":
-		return lookupNPMProvenance(ctx, client, dep)
-	case "pypi":
-		return lookupPyPIProvenance(ctx, client, dep)
-	case "rubygems":
-		return lookupRubyGemsProvenance(ctx, client, dep)
-	default:
-		return provenanceLookupData{
-			Status:   provenanceStatusUnsupported,
-			Evidence: []string{"provenance lookup is only supported for npm, pypi, and rubygems"},
-		}
-	}
-}
-
-func lookupNPMProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
-	endpoint := "https://registry.npmjs.org/" + url.PathEscape(dep.Name) + "/" + url.PathEscape(dep.Requirement)
-	var body map[string]any
-	if err := fetchJSON(ctx, client, endpoint, nil, &body); err != nil {
-		return provenanceLookupData{Status: provenanceStatusError, Error: err.Error()}
-	}
-
-	dist, _ := body["dist"].(map[string]any)
-	evidence := provenanceEvidence(dist)
-	signatures := countJSONList(dist["signatures"])
-
-	if len(evidence) > 0 {
-		return provenanceLookupData{
-			Status:             provenanceStatusTrustedPublishing,
-			TrustedPublishing:  true,
-			RegistrySignatures: signatures,
-			Evidence:           evidence,
-		}
-	}
-	if signatures > 0 {
-		return provenanceLookupData{
-			Status:             provenanceStatusSigned,
-			RegistrySignatures: signatures,
-			Evidence:           []string{"npm registry signature"},
-		}
-	}
-	return provenanceLookupData{Status: provenanceStatusMissing}
-}
-
-func lookupPyPIProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
-	endpoint := "https://pypi.org/pypi/" + pathEscape(dep.Name) + "/" + pathEscape(dep.Requirement) + "/json"
-	var body map[string]any
-	if err := fetchJSON(ctx, client, endpoint, nil, &body); err != nil {
-		return provenanceLookupData{Status: provenanceStatusError, Error: err.Error()}
-	}
-
-	evidence := provenanceEvidence(body)
-	if urls, ok := body["urls"].([]any); ok {
-		for _, raw := range urls {
-			if file, ok := raw.(map[string]any); ok {
-				evidence = append(evidence, provenanceEvidence(file)...)
-			}
-		}
-	}
-	evidence = uniqueStrings(evidence)
-	if len(evidence) > 0 {
-		return provenanceLookupData{
-			Status:            provenanceStatusTrustedPublishing,
-			TrustedPublishing: true,
-			Evidence:          evidence,
-		}
-	}
-	return provenanceLookupData{Status: provenanceStatusMissing}
-}
-
-func lookupRubyGemsProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
-	endpoint := "https://rubygems.org/api/v2/rubygems/" + pathEscape(dep.Name) + "/versions/" + pathEscape(dep.Requirement) + ".json"
-	var body map[string]any
-	if err := fetchJSON(ctx, client, endpoint, nil, &body); err != nil {
-		return provenanceLookupData{Status: provenanceStatusError, Error: err.Error()}
-	}
-
-	evidence := uniqueStrings(provenanceEvidence(body))
-	if len(evidence) > 0 {
-		return provenanceLookupData{
-			Status:            provenanceStatusTrustedPublishing,
-			TrustedPublishing: true,
-			Evidence:          evidence,
-		}
-	}
-	return provenanceLookupData{Status: provenanceStatusMissing}
-}
-
-func fetchJSON(ctx context.Context, client provenanceHTTPClient, endpoint string, headers map[string]string, target any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("User-Agent", userAgent)
-	req.Header.Set("Accept", "application/json")
-	for k, v := range headers {
-		req.Header.Set(k, v)
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return errors.New("package version not found")
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("registry returned HTTP %d", resp.StatusCode)
-	}
-
-	limited := io.LimitReader(resp.Body, 10<<20)
-	if err := json.NewDecoder(limited).Decode(target); err != nil {
-		return fmt.Errorf("decoding registry response: %w", err)
-	}
-	return nil
-}
-
-func provenanceEvidence(value any) []string {
-	object, ok := value.(map[string]any)
-	if !ok {
-		return nil
-	}
-
-	var evidence []string
-	for _, key := range []string{"attestations", "attestation", "provenance", "provenances", "trusted_publishing", "trustedPublishing"} {
-		if hasJSONValue(object[key]) {
-			evidence = append(evidence, key)
-		}
-	}
-	if dist, ok := object["dist"].(map[string]any); ok {
-		evidence = append(evidence, provenanceEvidence(dist)...)
-	}
-	return evidence
-}
-
-func hasJSONValue(value any) bool {
-	switch v := value.(type) {
-	case nil:
-		return false
-	case string:
-		return v != ""
-	case bool:
-		return v
-	case []any:
-		return len(v) > 0
-	case map[string]any:
-		return len(v) > 0
-	default:
-		return true
-	}
-}
-
-func countJSONList(value any) int {
-	switch v := value.(type) {
-	case []any:
-		return len(v)
-	default:
-		return 0
-	}
 }
 
 func buildProvenanceResult(
@@ -540,8 +363,4 @@ func outputProvenanceText(cmd *cobra.Command, result *ProvenanceResult, showMiss
 		result.Summary.WithoutProvenance,
 		result.Summary.UnsupportedEcosystems,
 		result.Summary.LookupErrors)
-}
-
-func pathEscape(value string) string {
-	return strings.ReplaceAll(url.PathEscape(value), "%2F", "/")
 }

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -256,8 +256,8 @@ func lookupProvenance(ctx context.Context, client provenanceHTTPClient, dep data
 		return lookupRubyGemsProvenance(ctx, client, dep)
 	default:
 		return provenanceLookupData{
-			Status: provenanceStatusUnsupported,
-			Error:  "provenance lookup is only supported for npm, pypi, and rubygems",
+			Status:   provenanceStatusUnsupported,
+			Evidence: []string{"provenance lookup is only supported for npm, pypi, and rubygems"},
 		}
 	}
 }

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -1,0 +1,547 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/purl"
+	"github.com/spf13/cobra"
+)
+
+const provenanceLookupTimeout = 5 * time.Minute
+const provenanceLookupConcurrency = 8
+
+type provenanceStatus string
+
+const (
+	provenanceStatusTrustedPublishing provenanceStatus = "trusted_publishing"
+	provenanceStatusSigned            provenanceStatus = "signed"
+	provenanceStatusMissing           provenanceStatus = "missing"
+	provenanceStatusUnsupported       provenanceStatus = "unsupported"
+	provenanceStatusError             provenanceStatus = "error"
+)
+
+type provenanceHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+var newProvenanceHTTPClient = func() provenanceHTTPClient {
+	return &http.Client{Timeout: 30 * time.Second}
+}
+
+func addProvenanceCmd(parent *cobra.Command) {
+	provenanceCmd := &cobra.Command{
+		Use:   "provenance",
+		Short: "Check dependency provenance metadata",
+		Long: `Check resolved dependencies for registry provenance and attestation metadata.
+
+The command reports trusted-publishing attestations where registry APIs expose
+them, registry signatures as a weaker integrity signal, and unsupported
+ecosystems explicitly instead of treating missing metadata as verified.`,
+		RunE: runProvenance,
+	}
+
+	provenanceCmd.Flags().StringP("commit", "c", "", "Check dependencies at specific commit (default: HEAD)")
+	provenanceCmd.Flags().StringP("branch", "b", "", "Branch to query (default: current branch)")
+	provenanceCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
+	provenanceCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
+	provenanceCmd.Flags().Bool("missing", false, "Only show dependencies without trusted-publishing provenance")
+	parent.AddCommand(provenanceCmd)
+}
+
+type ProvenanceSummary struct {
+	TotalDependencies      int `json:"total_dependencies"`
+	CheckedDependencies    int `json:"checked_dependencies"`
+	TrustedPublishing      int `json:"trusted_publishing"`
+	RegistrySignatures     int `json:"registry_signatures"`
+	WithoutProvenance      int `json:"without_provenance"`
+	UnsupportedEcosystems  int `json:"unsupported_ecosystems"`
+	LookupErrors           int `json:"lookup_errors"`
+	UnresolvedDependencies int `json:"unresolved_dependencies"`
+}
+
+type ProvenanceEntry struct {
+	Name               string   `json:"name"`
+	Ecosystem          string   `json:"ecosystem"`
+	Version            string   `json:"version"`
+	ManifestPath       string   `json:"manifest_path"`
+	PURL               string   `json:"purl,omitempty"`
+	Status             string   `json:"status"`
+	TrustedPublishing  bool     `json:"trusted_publishing"`
+	RegistrySignatures int      `json:"registry_signatures,omitempty"`
+	Evidence           []string `json:"evidence,omitempty"`
+	Error              string   `json:"error,omitempty"`
+}
+
+type ProvenanceResult struct {
+	Summary      ProvenanceSummary `json:"summary"`
+	Dependencies []ProvenanceEntry `json:"dependencies"`
+}
+
+type provenanceLookupData struct {
+	Status             provenanceStatus
+	TrustedPublishing  bool
+	RegistrySignatures int
+	Evidence           []string
+	Error              string
+}
+
+func runProvenance(cmd *cobra.Command, args []string) error {
+	commit, _ := cmd.Flags().GetString("commit")
+	branchName, _ := cmd.Flags().GetString("branch")
+	ecosystem, _ := cmd.Flags().GetString("ecosystem")
+	format, _ := cmd.Flags().GetString("format")
+	showMissing, _ := cmd.Flags().GetBool("missing")
+
+	repo, err := git.OpenRepository(".")
+	if err != nil {
+		return fmt.Errorf("not in a git repository: %w", err)
+	}
+
+	deps, err := repo.GetDependencies(commit, branchName)
+	if err != nil {
+		return fmt.Errorf("loading dependencies: %w", err)
+	}
+
+	deps = filterByEcosystem(deps, ecosystem)
+	resolved, unresolved := selectProvenanceDependencies(deps)
+	if len(resolved) == 0 {
+		result := emptyProvenanceResult()
+		result.Summary.UnresolvedDependencies = unresolved
+		if format == formatJSON {
+			return outputProvenanceJSON(cmd, result)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No resolved dependencies found.")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), provenanceLookupTimeout)
+	defer cancel()
+
+	lookupData := fetchProvenanceData(ctx, resolved)
+	result := buildProvenanceResult(resolved, unresolved, lookupData, showMissing)
+
+	switch format {
+	case formatJSON:
+		return outputProvenanceJSON(cmd, result)
+	default:
+		outputProvenanceText(cmd, result, showMissing)
+		return nil
+	}
+}
+
+func selectProvenanceDependencies(deps []database.Dependency) ([]database.Dependency, int) {
+	var resolved []database.Dependency
+	unresolved := 0
+	for _, dep := range deps {
+		if isResolvedDependency(dep) {
+			resolved = append(resolved, dep)
+			continue
+		}
+		unresolved++
+	}
+	return resolved, unresolved
+}
+
+func fetchProvenanceData(ctx context.Context, deps []database.Dependency) map[string]provenanceLookupData {
+	purls, purlToDep := uniqueProvenancePURLs(deps)
+	results := make(map[string]provenanceLookupData, len(purls))
+	if len(purls) == 0 {
+		return results
+	}
+
+	type lookupResult struct {
+		purl string
+		data provenanceLookupData
+	}
+
+	jobs := make(chan string)
+	out := make(chan lookupResult, len(purls))
+	workers := provenanceLookupConcurrency
+	if len(purls) < workers {
+		workers = len(purls)
+	}
+
+	var wg sync.WaitGroup
+	client := newProvenanceHTTPClient()
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for purlStr := range jobs {
+				dep := purlToDep[purlStr]
+				out <- lookupResult{
+					purl: purlStr,
+					data: lookupProvenance(ctx, client, dep),
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, purlStr := range purls {
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- purlStr:
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	for result := range out {
+		results[result.purl] = result.data
+	}
+	for _, purlStr := range purls {
+		if _, ok := results[purlStr]; !ok {
+			results[purlStr] = provenanceLookupData{
+				Status: provenanceStatusError,
+				Error:  ctx.Err().Error(),
+			}
+		}
+	}
+
+	return results
+}
+
+func uniqueProvenancePURLs(deps []database.Dependency) ([]string, map[string]database.Dependency) {
+	var purls []string
+	purlToDep := make(map[string]database.Dependency)
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		purlStr := provenancePURLForDependency(dep)
+		if purlStr == "" || seen[purlStr] {
+			continue
+		}
+		seen[purlStr] = true
+		purls = append(purls, purlStr)
+		purlToDep[purlStr] = dep
+	}
+	return purls, purlToDep
+}
+
+func provenancePURLForDependency(dep database.Dependency) string {
+	if dep.PURL != "" {
+		parsed, err := purl.Parse(dep.PURL)
+		if err == nil && parsed.Version != "" {
+			return parsed.String()
+		}
+	}
+	return purl.MakePURLString(dep.Ecosystem, dep.Name, dep.Requirement)
+}
+
+func lookupProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
+	switch dep.Ecosystem {
+	case "npm":
+		return lookupNPMProvenance(ctx, client, dep)
+	case "pypi":
+		return lookupPyPIProvenance(ctx, client, dep)
+	case "rubygems":
+		return lookupRubyGemsProvenance(ctx, client, dep)
+	default:
+		return provenanceLookupData{
+			Status: provenanceStatusUnsupported,
+			Error:  "provenance lookup is only supported for npm, pypi, and rubygems",
+		}
+	}
+}
+
+func lookupNPMProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
+	endpoint := "https://registry.npmjs.org/" + url.PathEscape(dep.Name) + "/" + url.PathEscape(dep.Requirement)
+	var body map[string]any
+	if err := fetchJSON(ctx, client, endpoint, nil, &body); err != nil {
+		return provenanceLookupData{Status: provenanceStatusError, Error: err.Error()}
+	}
+
+	dist, _ := body["dist"].(map[string]any)
+	evidence := provenanceEvidence(dist)
+	signatures := countJSONList(dist["signatures"])
+
+	if len(evidence) > 0 {
+		return provenanceLookupData{
+			Status:             provenanceStatusTrustedPublishing,
+			TrustedPublishing:  true,
+			RegistrySignatures: signatures,
+			Evidence:           evidence,
+		}
+	}
+	if signatures > 0 {
+		return provenanceLookupData{
+			Status:             provenanceStatusSigned,
+			RegistrySignatures: signatures,
+			Evidence:           []string{"npm registry signature"},
+		}
+	}
+	return provenanceLookupData{Status: provenanceStatusMissing}
+}
+
+func lookupPyPIProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
+	endpoint := "https://pypi.org/pypi/" + pathEscape(dep.Name) + "/" + pathEscape(dep.Requirement) + "/json"
+	var body map[string]any
+	if err := fetchJSON(ctx, client, endpoint, nil, &body); err != nil {
+		return provenanceLookupData{Status: provenanceStatusError, Error: err.Error()}
+	}
+
+	evidence := provenanceEvidence(body)
+	if urls, ok := body["urls"].([]any); ok {
+		for _, raw := range urls {
+			if file, ok := raw.(map[string]any); ok {
+				evidence = append(evidence, provenanceEvidence(file)...)
+			}
+		}
+	}
+	evidence = uniqueStrings(evidence)
+	if len(evidence) > 0 {
+		return provenanceLookupData{
+			Status:            provenanceStatusTrustedPublishing,
+			TrustedPublishing: true,
+			Evidence:          evidence,
+		}
+	}
+	return provenanceLookupData{Status: provenanceStatusMissing}
+}
+
+func lookupRubyGemsProvenance(ctx context.Context, client provenanceHTTPClient, dep database.Dependency) provenanceLookupData {
+	endpoint := "https://rubygems.org/api/v2/rubygems/" + pathEscape(dep.Name) + "/versions/" + pathEscape(dep.Requirement) + ".json"
+	var body map[string]any
+	if err := fetchJSON(ctx, client, endpoint, nil, &body); err != nil {
+		return provenanceLookupData{Status: provenanceStatusError, Error: err.Error()}
+	}
+
+	evidence := uniqueStrings(provenanceEvidence(body))
+	if len(evidence) > 0 {
+		return provenanceLookupData{
+			Status:            provenanceStatusTrustedPublishing,
+			TrustedPublishing: true,
+			Evidence:          evidence,
+		}
+	}
+	return provenanceLookupData{Status: provenanceStatusMissing}
+}
+
+func fetchJSON(ctx context.Context, client provenanceHTTPClient, endpoint string, headers map[string]string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Accept", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return errors.New("package version not found")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("registry returned HTTP %d", resp.StatusCode)
+	}
+
+	limited := io.LimitReader(resp.Body, 10<<20)
+	if err := json.NewDecoder(limited).Decode(target); err != nil {
+		return fmt.Errorf("decoding registry response: %w", err)
+	}
+	return nil
+}
+
+func provenanceEvidence(value any) []string {
+	object, ok := value.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	var evidence []string
+	for _, key := range []string{"attestations", "attestation", "provenance", "provenances", "trusted_publishing", "trustedPublishing"} {
+		if hasJSONValue(object[key]) {
+			evidence = append(evidence, key)
+		}
+	}
+	if dist, ok := object["dist"].(map[string]any); ok {
+		evidence = append(evidence, provenanceEvidence(dist)...)
+	}
+	return evidence
+}
+
+func hasJSONValue(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case string:
+		return v != ""
+	case bool:
+		return v
+	case []any:
+		return len(v) > 0
+	case map[string]any:
+		return len(v) > 0
+	default:
+		return true
+	}
+}
+
+func countJSONList(value any) int {
+	switch v := value.(type) {
+	case []any:
+		return len(v)
+	default:
+		return 0
+	}
+}
+
+func buildProvenanceResult(
+	deps []database.Dependency,
+	unresolved int,
+	lookupData map[string]provenanceLookupData,
+	showMissing bool,
+) *ProvenanceResult {
+	result := emptyProvenanceResult()
+	result.Summary.TotalDependencies = len(deps)
+	result.Summary.UnresolvedDependencies = unresolved
+
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		purlStr := provenancePURLForDependency(dep)
+		key := purlStr + "\x00" + dep.ManifestPath
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		data, ok := lookupData[purlStr]
+		if !ok {
+			data = provenanceLookupData{Status: provenanceStatusError, Error: "provenance lookup missing"}
+		}
+		result.Summary.CheckedDependencies++
+
+		switch data.Status {
+		case provenanceStatusTrustedPublishing:
+			result.Summary.TrustedPublishing++
+		case provenanceStatusSigned:
+			result.Summary.RegistrySignatures++
+			result.Summary.WithoutProvenance++
+		case provenanceStatusMissing:
+			result.Summary.WithoutProvenance++
+		case provenanceStatusUnsupported:
+			result.Summary.UnsupportedEcosystems++
+		case provenanceStatusError:
+			result.Summary.LookupErrors++
+		}
+
+		if showMissing && data.Status == provenanceStatusTrustedPublishing {
+			continue
+		}
+
+		result.Dependencies = append(result.Dependencies, ProvenanceEntry{
+			Name:               dep.Name,
+			Ecosystem:          dep.Ecosystem,
+			Version:            dep.Requirement,
+			ManifestPath:       dep.ManifestPath,
+			PURL:               purlStr,
+			Status:             string(data.Status),
+			TrustedPublishing:  data.TrustedPublishing,
+			RegistrySignatures: data.RegistrySignatures,
+			Evidence:           uniqueStrings(data.Evidence),
+			Error:              data.Error,
+		})
+	}
+
+	sort.Slice(result.Dependencies, func(i, j int) bool {
+		if result.Dependencies[i].Status != result.Dependencies[j].Status {
+			return result.Dependencies[i].Status < result.Dependencies[j].Status
+		}
+		if result.Dependencies[i].Ecosystem != result.Dependencies[j].Ecosystem {
+			return result.Dependencies[i].Ecosystem < result.Dependencies[j].Ecosystem
+		}
+		if result.Dependencies[i].Name != result.Dependencies[j].Name {
+			return result.Dependencies[i].Name < result.Dependencies[j].Name
+		}
+		return result.Dependencies[i].Version < result.Dependencies[j].Version
+	})
+
+	return result
+}
+
+func emptyProvenanceResult() *ProvenanceResult {
+	return &ProvenanceResult{Dependencies: []ProvenanceEntry{}}
+}
+
+func outputProvenanceJSON(cmd *cobra.Command, result *ProvenanceResult) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func outputProvenanceText(cmd *cobra.Command, result *ProvenanceResult, showMissing bool) {
+	if len(result.Dependencies) == 0 {
+		if showMissing {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "All checked dependencies have trusted-publishing provenance.")
+		} else {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No provenance metadata found.")
+		}
+		return
+	}
+
+	if showMissing {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Found %d dependencies without trusted-publishing provenance:\n\n", len(result.Dependencies))
+	} else {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Provenance results for %d dependencies:\n\n", len(result.Dependencies))
+	}
+
+	maxNameLen := 0
+	for _, dep := range result.Dependencies {
+		if len(dep.Name) > maxNameLen {
+			maxNameLen = len(dep.Name)
+		}
+	}
+
+	for _, dep := range result.Dependencies {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%-*s  %s  %s  %s\n",
+			maxNameLen,
+			dep.Name,
+			dep.Version,
+			dep.Status,
+			Dim("("+dep.ManifestPath+")"))
+		for _, evidence := range dep.Evidence {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  evidence: %s\n", evidence)
+		}
+		if dep.Error != "" {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  error: %s\n", dep.Error)
+		}
+	}
+
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
+		"Checked: %d, trusted publishing: %d, registry signatures: %d, without provenance: %d, unsupported: %d, errors: %d\n",
+		result.Summary.CheckedDependencies,
+		result.Summary.TrustedPublishing,
+		result.Summary.RegistrySignatures,
+		result.Summary.WithoutProvenance,
+		result.Summary.UnsupportedEcosystems,
+		result.Summary.LookupErrors)
+}
+
+func pathEscape(value string) string {
+	return strings.ReplaceAll(url.PathEscape(value), "%2F", "/")
+}

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -279,7 +279,7 @@ func buildProvenanceResult(
 			result.Summary.LookupErrors++
 		}
 
-		if showMissing && data.Status == provenanceStatusTrustedPublishing {
+		if showMissing && (data.Status == provenanceStatusTrustedPublishing || data.Status == provenanceStatusAttested) {
 			continue
 		}
 

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -20,6 +20,7 @@ const provenanceLookupConcurrency = 8
 
 const (
 	provenanceStatusTrustedPublishing = provenance.StatusTrustedPublishing
+	provenanceStatusAttested          = provenance.StatusAttested
 	provenanceStatusSigned            = provenance.StatusSigned
 	provenanceStatusMissing           = provenance.StatusMissing
 	provenanceStatusUnsupported       = provenance.StatusUnsupported
@@ -32,9 +33,10 @@ func addProvenanceCmd(parent *cobra.Command) {
 		Short: "Check dependency provenance metadata",
 		Long: `Check resolved dependencies for registry provenance and attestation metadata.
 
-The command reports trusted-publishing attestations where registry APIs expose
-them, registry signatures as a weaker integrity signal, and unsupported
-ecosystems explicitly instead of treating missing metadata as verified.`,
+The command reports verified trusted-publishing signals where registry APIs
+expose them, registry attestations and signatures as weaker integrity signals,
+and unsupported ecosystems explicitly instead of treating missing metadata as
+verified.`,
 		RunE: runProvenance,
 	}
 
@@ -50,6 +52,7 @@ type ProvenanceSummary struct {
 	TotalDependencies      int `json:"total_dependencies"`
 	CheckedDependencies    int `json:"checked_dependencies"`
 	TrustedPublishing      int `json:"trusted_publishing"`
+	AttestedDependencies   int `json:"attested_dependencies"`
 	RegistrySignatures     int `json:"registry_signatures"`
 	WithoutProvenance      int `json:"without_provenance"`
 	UnsupportedEcosystems  int `json:"unsupported_ecosystems"`
@@ -258,11 +261,15 @@ func buildProvenanceResult(
 		}
 		result.Summary.CheckedDependencies++
 
+		if data.RegistrySignatures > 0 {
+			result.Summary.RegistrySignatures++
+		}
 		switch data.Status {
 		case provenanceStatusTrustedPublishing:
 			result.Summary.TrustedPublishing++
+		case provenanceStatusAttested:
+			result.Summary.AttestedDependencies++
 		case provenanceStatusSigned:
-			result.Summary.RegistrySignatures++
 			result.Summary.WithoutProvenance++
 		case provenanceStatusMissing:
 			result.Summary.WithoutProvenance++
@@ -356,9 +363,10 @@ func outputProvenanceText(cmd *cobra.Command, result *ProvenanceResult, showMiss
 
 	_, _ = fmt.Fprintln(cmd.OutOrStdout())
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(),
-		"Checked: %d, trusted publishing: %d, registry signatures: %d, without provenance: %d, unsupported: %d, errors: %d\n",
+		"Checked: %d, trusted publishing: %d, attested: %d, registry signatures: %d, without provenance: %d, unsupported: %d, errors: %d\n",
 		result.Summary.CheckedDependencies,
 		result.Summary.TrustedPublishing,
+		result.Summary.AttestedDependencies,
 		result.Summary.RegistrySignatures,
 		result.Summary.WithoutProvenance,
 		result.Summary.UnsupportedEcosystems,

--- a/cmd/provenance_test.go
+++ b/cmd/provenance_test.go
@@ -54,6 +54,13 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 			ManifestKind: manifestKindLockfile,
 		},
 		{
+			Name:         "attested",
+			Ecosystem:    "npm",
+			Requirement:  "1.0.0",
+			ManifestPath: "package-lock.json",
+			ManifestKind: manifestKindLockfile,
+		},
+		{
 			Name:         "serde",
 			Ecosystem:    "cargo",
 			Requirement:  "1.0.0",
@@ -71,6 +78,11 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 			Status:             provenanceStatusSigned,
 			RegistrySignatures: 1,
 		},
+		"pkg:npm/attested@1.0.0": {
+			Status:             provenanceStatusAttested,
+			RegistrySignatures: 1,
+			Evidence:           []string{"npm registry attestation; publishing authentication is not verifiable"},
+		},
 		"pkg:cargo/serde@1.0.0": {
 			Status:   provenanceStatusUnsupported,
 			Evidence: []string{"provenance lookup is only supported for npm, pypi, and rubygems"},
@@ -78,14 +90,17 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 	}
 
 	result := buildProvenanceResult(deps, 1, lookupData, true)
-	if result.Summary.TotalDependencies != 3 {
-		t.Fatalf("total dependencies = %d, want 3", result.Summary.TotalDependencies)
+	if result.Summary.TotalDependencies != 4 {
+		t.Fatalf("total dependencies = %d, want 4", result.Summary.TotalDependencies)
 	}
 	if result.Summary.TrustedPublishing != 1 {
 		t.Fatalf("trusted publishing = %d, want 1", result.Summary.TrustedPublishing)
 	}
-	if result.Summary.RegistrySignatures != 1 {
-		t.Fatalf("registry signatures = %d, want 1", result.Summary.RegistrySignatures)
+	if result.Summary.AttestedDependencies != 1 {
+		t.Fatalf("attested dependencies = %d, want 1", result.Summary.AttestedDependencies)
+	}
+	if result.Summary.RegistrySignatures != 2 {
+		t.Fatalf("registry signatures = %d, want 2", result.Summary.RegistrySignatures)
 	}
 	if result.Summary.WithoutProvenance != 1 {
 		t.Fatalf("without provenance = %d, want 1", result.Summary.WithoutProvenance)
@@ -96,8 +111,8 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 	if result.Summary.UnresolvedDependencies != 1 {
 		t.Fatalf("unresolved dependencies = %d, want 1", result.Summary.UnresolvedDependencies)
 	}
-	if len(result.Dependencies) != 2 {
-		t.Fatalf("dependencies length = %d, want 2", len(result.Dependencies))
+	if len(result.Dependencies) != 3 {
+		t.Fatalf("dependencies length = %d, want 3", len(result.Dependencies))
 	}
 	for _, dep := range result.Dependencies {
 		if dep.TrustedPublishing {
@@ -105,6 +120,9 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 		}
 		if dep.Status == string(provenanceStatusUnsupported) && dep.Error != "" {
 			t.Fatalf("unsupported dependency should not be reported as error: %#v", dep)
+		}
+		if dep.Name == "attested" && dep.Status != string(provenanceStatusAttested) {
+			t.Fatalf("attested dependency = %#v, want attested status", dep)
 		}
 	}
 }

--- a/cmd/provenance_test.go
+++ b/cmd/provenance_test.go
@@ -1,95 +1,10 @@
 package cmd
 
 import (
-	"context"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 )
-
-type fakeProvenanceHTTPClient struct {
-	responses map[string]string
-	requests  []string
-}
-
-func (f *fakeProvenanceHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	f.requests = append(f.requests, req.URL.String())
-	body, ok := f.responses[req.URL.String()]
-	if !ok {
-		return &http.Response{
-			StatusCode: http.StatusNotFound,
-			Body:       io.NopCloser(strings.NewReader(req.URL.String())),
-		}, nil
-	}
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}, nil
-}
-
-func TestLookupNPMProvenanceTrustedPublishing(t *testing.T) {
-	dep := database.Dependency{
-		Name:        "@scope/pkg",
-		Ecosystem:   "npm",
-		Requirement: "1.2.3",
-	}
-	client := &fakeProvenanceHTTPClient{
-		responses: map[string]string{
-			"https://registry.npmjs.org/@scope%2Fpkg/1.2.3": `{
-				"dist": {
-					"attestations": {"provenance": {"url": "https://registry.npmjs.org/-/npm/v1/attestations/%40scope/pkg@1.2.3"}},
-					"signatures": [{"keyid": "SHA256:test", "sig": "abc"}]
-				}
-			}`,
-		},
-	}
-
-	got := lookupNPMProvenance(context.Background(), client, dep)
-	if got.Status != provenanceStatusTrustedPublishing {
-		t.Fatalf("status = %q, want %q; error = %q; requests = %#v",
-			got.Status, provenanceStatusTrustedPublishing, got.Error, client.requests)
-	}
-	if !got.TrustedPublishing {
-		t.Fatal("trusted publishing = false, want true")
-	}
-	if got.RegistrySignatures != 1 {
-		t.Fatalf("registry signatures = %d, want 1", got.RegistrySignatures)
-	}
-	if len(got.Evidence) == 0 {
-		t.Fatal("expected provenance evidence")
-	}
-}
-
-func TestLookupNPMProvenanceSignedOnly(t *testing.T) {
-	dep := database.Dependency{
-		Name:        "lodash",
-		Ecosystem:   "npm",
-		Requirement: "4.17.21",
-	}
-	client := &fakeProvenanceHTTPClient{
-		responses: map[string]string{
-			"https://registry.npmjs.org/lodash/4.17.21": `{
-				"dist": {
-					"signatures": [{"keyid": "SHA256:test", "sig": "abc"}]
-				}
-			}`,
-		},
-	}
-
-	got := lookupNPMProvenance(context.Background(), client, dep)
-	if got.Status != provenanceStatusSigned {
-		t.Fatalf("status = %q, want %q", got.Status, provenanceStatusSigned)
-	}
-	if got.TrustedPublishing {
-		t.Fatal("trusted publishing = true, want false")
-	}
-	if got.RegistrySignatures != 1 {
-		t.Fatalf("registry signatures = %d, want 1", got.RegistrySignatures)
-	}
-}
 
 func TestSelectProvenanceDependencies(t *testing.T) {
 	deps := []database.Dependency{
@@ -191,22 +106,5 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 		if dep.Status == string(provenanceStatusUnsupported) && dep.Error != "" {
 			t.Fatalf("unsupported dependency should not be reported as error: %#v", dep)
 		}
-	}
-}
-
-func TestLookupProvenanceUnsupportedUsesEvidence(t *testing.T) {
-	got := lookupProvenance(context.Background(), &fakeProvenanceHTTPClient{}, database.Dependency{
-		Name:        "serde",
-		Ecosystem:   "cargo",
-		Requirement: "1.0.0",
-	})
-	if got.Status != provenanceStatusUnsupported {
-		t.Fatalf("status = %q, want %q", got.Status, provenanceStatusUnsupported)
-	}
-	if got.Error != "" {
-		t.Fatalf("error = %q, want empty", got.Error)
-	}
-	if len(got.Evidence) == 0 {
-		t.Fatal("expected explanatory evidence for unsupported ecosystem")
 	}
 }

--- a/cmd/provenance_test.go
+++ b/cmd/provenance_test.go
@@ -111,8 +111,8 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 	if result.Summary.UnresolvedDependencies != 1 {
 		t.Fatalf("unresolved dependencies = %d, want 1", result.Summary.UnresolvedDependencies)
 	}
-	if len(result.Dependencies) != 3 {
-		t.Fatalf("dependencies length = %d, want 3", len(result.Dependencies))
+	if len(result.Dependencies) != 2 {
+		t.Fatalf("dependencies length = %d, want 2", len(result.Dependencies))
 	}
 	for _, dep := range result.Dependencies {
 		if dep.TrustedPublishing {
@@ -121,8 +121,8 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 		if dep.Status == string(provenanceStatusUnsupported) && dep.Error != "" {
 			t.Fatalf("unsupported dependency should not be reported as error: %#v", dep)
 		}
-		if dep.Name == "attested" && dep.Status != string(provenanceStatusAttested) {
-			t.Fatalf("attested dependency = %#v, want attested status", dep)
+		if dep.Name == "attested" {
+			t.Fatalf("attested dependency should be filtered from --missing result: %#v", dep)
 		}
 	}
 }

--- a/cmd/provenance_test.go
+++ b/cmd/provenance_test.go
@@ -157,8 +157,8 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 			RegistrySignatures: 1,
 		},
 		"pkg:cargo/serde@1.0.0": {
-			Status: provenanceStatusUnsupported,
-			Error:  "unsupported",
+			Status:   provenanceStatusUnsupported,
+			Evidence: []string{"provenance lookup is only supported for npm, pypi, and rubygems"},
 		},
 	}
 
@@ -188,5 +188,25 @@ func TestBuildProvenanceResultMissingFilter(t *testing.T) {
 		if dep.TrustedPublishing {
 			t.Fatalf("trusted dependency should be filtered from --missing result: %#v", dep)
 		}
+		if dep.Status == string(provenanceStatusUnsupported) && dep.Error != "" {
+			t.Fatalf("unsupported dependency should not be reported as error: %#v", dep)
+		}
+	}
+}
+
+func TestLookupProvenanceUnsupportedUsesEvidence(t *testing.T) {
+	got := lookupProvenance(context.Background(), &fakeProvenanceHTTPClient{}, database.Dependency{
+		Name:        "serde",
+		Ecosystem:   "cargo",
+		Requirement: "1.0.0",
+	})
+	if got.Status != provenanceStatusUnsupported {
+		t.Fatalf("status = %q, want %q", got.Status, provenanceStatusUnsupported)
+	}
+	if got.Error != "" {
+		t.Fatalf("error = %q, want empty", got.Error)
+	}
+	if len(got.Evidence) == 0 {
+		t.Fatal("expected explanatory evidence for unsupported ecosystem")
 	}
 }

--- a/cmd/provenance_test.go
+++ b/cmd/provenance_test.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+type fakeProvenanceHTTPClient struct {
+	responses map[string]string
+	requests  []string
+}
+
+func (f *fakeProvenanceHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.requests = append(f.requests, req.URL.String())
+	body, ok := f.responses[req.URL.String()]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader(req.URL.String())),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func TestLookupNPMProvenanceTrustedPublishing(t *testing.T) {
+	dep := database.Dependency{
+		Name:        "@scope/pkg",
+		Ecosystem:   "npm",
+		Requirement: "1.2.3",
+	}
+	client := &fakeProvenanceHTTPClient{
+		responses: map[string]string{
+			"https://registry.npmjs.org/@scope%2Fpkg/1.2.3": `{
+				"dist": {
+					"attestations": {"provenance": {"url": "https://registry.npmjs.org/-/npm/v1/attestations/%40scope/pkg@1.2.3"}},
+					"signatures": [{"keyid": "SHA256:test", "sig": "abc"}]
+				}
+			}`,
+		},
+	}
+
+	got := lookupNPMProvenance(context.Background(), client, dep)
+	if got.Status != provenanceStatusTrustedPublishing {
+		t.Fatalf("status = %q, want %q; error = %q; requests = %#v",
+			got.Status, provenanceStatusTrustedPublishing, got.Error, client.requests)
+	}
+	if !got.TrustedPublishing {
+		t.Fatal("trusted publishing = false, want true")
+	}
+	if got.RegistrySignatures != 1 {
+		t.Fatalf("registry signatures = %d, want 1", got.RegistrySignatures)
+	}
+	if len(got.Evidence) == 0 {
+		t.Fatal("expected provenance evidence")
+	}
+}
+
+func TestLookupNPMProvenanceSignedOnly(t *testing.T) {
+	dep := database.Dependency{
+		Name:        "lodash",
+		Ecosystem:   "npm",
+		Requirement: "4.17.21",
+	}
+	client := &fakeProvenanceHTTPClient{
+		responses: map[string]string{
+			"https://registry.npmjs.org/lodash/4.17.21": `{
+				"dist": {
+					"signatures": [{"keyid": "SHA256:test", "sig": "abc"}]
+				}
+			}`,
+		},
+	}
+
+	got := lookupNPMProvenance(context.Background(), client, dep)
+	if got.Status != provenanceStatusSigned {
+		t.Fatalf("status = %q, want %q", got.Status, provenanceStatusSigned)
+	}
+	if got.TrustedPublishing {
+		t.Fatal("trusted publishing = true, want false")
+	}
+	if got.RegistrySignatures != 1 {
+		t.Fatalf("registry signatures = %d, want 1", got.RegistrySignatures)
+	}
+}
+
+func TestSelectProvenanceDependencies(t *testing.T) {
+	deps := []database.Dependency{
+		{
+			Name:         "lodash",
+			Ecosystem:    "npm",
+			Requirement:  "^4.17.21",
+			ManifestKind: "manifest",
+		},
+		{
+			Name:         "lodash",
+			Ecosystem:    "npm",
+			Requirement:  "4.17.21",
+			ManifestKind: manifestKindLockfile,
+		},
+		{
+			Name:         "golang.org/x/mod",
+			Ecosystem:    "golang",
+			Requirement:  "v0.32.0",
+			ManifestKind: "manifest",
+		},
+	}
+
+	resolved, unresolved := selectProvenanceDependencies(deps)
+	if len(resolved) != 2 {
+		t.Fatalf("resolved length = %d, want 2", len(resolved))
+	}
+	if unresolved != 1 {
+		t.Fatalf("unresolved = %d, want 1", unresolved)
+	}
+}
+
+func TestBuildProvenanceResultMissingFilter(t *testing.T) {
+	deps := []database.Dependency{
+		{
+			Name:         "trusted",
+			Ecosystem:    "npm",
+			Requirement:  "1.0.0",
+			ManifestPath: "package-lock.json",
+			ManifestKind: manifestKindLockfile,
+		},
+		{
+			Name:         "signed",
+			Ecosystem:    "npm",
+			Requirement:  "1.0.0",
+			ManifestPath: "package-lock.json",
+			ManifestKind: manifestKindLockfile,
+		},
+		{
+			Name:         "serde",
+			Ecosystem:    "cargo",
+			Requirement:  "1.0.0",
+			ManifestPath: "Cargo.lock",
+			ManifestKind: manifestKindLockfile,
+		},
+	}
+	lookupData := map[string]provenanceLookupData{
+		"pkg:npm/trusted@1.0.0": {
+			Status:            provenanceStatusTrustedPublishing,
+			TrustedPublishing: true,
+			Evidence:          []string{"attestations"},
+		},
+		"pkg:npm/signed@1.0.0": {
+			Status:             provenanceStatusSigned,
+			RegistrySignatures: 1,
+		},
+		"pkg:cargo/serde@1.0.0": {
+			Status: provenanceStatusUnsupported,
+			Error:  "unsupported",
+		},
+	}
+
+	result := buildProvenanceResult(deps, 1, lookupData, true)
+	if result.Summary.TotalDependencies != 3 {
+		t.Fatalf("total dependencies = %d, want 3", result.Summary.TotalDependencies)
+	}
+	if result.Summary.TrustedPublishing != 1 {
+		t.Fatalf("trusted publishing = %d, want 1", result.Summary.TrustedPublishing)
+	}
+	if result.Summary.RegistrySignatures != 1 {
+		t.Fatalf("registry signatures = %d, want 1", result.Summary.RegistrySignatures)
+	}
+	if result.Summary.WithoutProvenance != 1 {
+		t.Fatalf("without provenance = %d, want 1", result.Summary.WithoutProvenance)
+	}
+	if result.Summary.UnsupportedEcosystems != 1 {
+		t.Fatalf("unsupported ecosystems = %d, want 1", result.Summary.UnsupportedEcosystems)
+	}
+	if result.Summary.UnresolvedDependencies != 1 {
+		t.Fatalf("unresolved dependencies = %d, want 1", result.Summary.UnresolvedDependencies)
+	}
+	if len(result.Dependencies) != 2 {
+		t.Fatalf("dependencies length = %d, want 2", len(result.Dependencies))
+	}
+	for _, dep := range result.Dependencies {
+		if dep.TrustedPublishing {
+			t.Fatalf("trusted dependency should be filtered from --missing result: %#v", dep)
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,6 +82,7 @@ func NewRootCmd() *cobra.Command {
 	addFundingCmd(cmd)
 	addMaintainersCmd(cmd)
 	addHealthCmd(cmd)
+	addProvenanceCmd(cmd)
 	addChangelogCmd(cmd)
 	addLicensesCmd(cmd)
 	addIntegrityCmd(cmd)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -2,7 +2,7 @@
 
 git-pkgs walks a repository's commit history, parses manifest files at each commit, and stores dependency changes in a SQLite database. This lets you query what changed, when, and who did it.
 
-The tool works with two types of data. Intrinsic data comes from your git history: dependency names, versions from manifests, who added them, when, and why. Commands like `list`, `history`, `blame`, `diff`, and `stale` use only intrinsic data and require no network access. Extrinsic data comes from external sources: vulnerability info from [OSV](https://osv.dev), and registry metadata (latest versions, licenses, funding links, maintainer data, deprecation status, maintenance health signals) from [ecosyste.ms](https://packages.ecosyste.ms/) and package registries. Commands like `vulns`, `outdated`, `freshness`, `licenses`, `deprecated`, `funding`, `maintainers`, and `health` fetch and cache this external data.
+The tool works with two types of data. Intrinsic data comes from your git history: dependency names, versions from manifests, who added them, when, and why. Commands like `list`, `history`, `blame`, `diff`, and `stale` use only intrinsic data and require no network access. Extrinsic data comes from external sources: vulnerability info from [OSV](https://osv.dev), and registry metadata (latest versions, licenses, funding links, maintainer data, deprecation status, maintenance health signals, provenance attestations) from [ecosyste.ms](https://packages.ecosyste.ms/) and package registries. Commands like `vulns`, `outdated`, `freshness`, `licenses`, `deprecated`, `funding`, `maintainers`, `health`, and `provenance` fetch external data; most enrichment-backed commands cache it.
 
 ## Package Structure
 
@@ -150,7 +150,7 @@ See [vulns.md](vulns.md) for command documentation.
 
 ## Package Enrichment
 
-The `outdated`, `freshness`, `deprecated`, `funding`, `maintainers`, `health`, `changelog`, `licenses`, `sbom`, and `integrity --registry` commands fetch metadata from external sources. The [`github.com/git-pkgs/enrichment`](https://github.com/git-pkgs/enrichment) library provides a unified interface with two backends:
+The `outdated`, `freshness`, `deprecated`, `funding`, `maintainers`, `health`, `changelog`, `licenses`, `sbom`, `provenance`, and `integrity --registry` commands fetch metadata from external sources. The [`github.com/git-pkgs/enrichment`](https://github.com/git-pkgs/enrichment) library provides a unified interface with two backends:
 
 - **ecosyste.ms** - Bulk API queries via [ecosyste-ms/ecosystems-go](https://github.com/ecosyste-ms/ecosystems-go). Efficient for public packages.
 - **registries** - Direct queries to package registries via [git-pkgs/registries](https://github.com/git-pkgs/registries). Required for private registries.
@@ -161,6 +161,8 @@ Data is cached in the `packages` and `versions` tables with a 24-hour TTL. The `
 
 The `licenses --drift` check reads per-version license data from the `versions` cache and falls back to enrichment version lookups for uncached installed versions.
 `licenses --offline` disables enrichment requests and permits cached package and version metadata past the normal TTL. It returns an error when required metadata is absent from the cache.
+
+The `provenance` command checks exact installed versions directly against registry APIs for attestation or signature metadata and reports unsupported ecosystems explicitly. It does not currently cache provenance responses because registry support is still uneven and the command is intended for occasional review.
 
 ## Package Management
 

--- a/internal/provenance/client.go
+++ b/internal/provenance/client.go
@@ -1,0 +1,86 @@
+package provenance
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const maxResponseBytes = 10 << 20
+
+// HTTPClient is the subset of http.Client used for registry requests.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Client dispatches provenance lookups to ecosystem-specific checkers.
+type Client struct {
+	httpClient HTTPClient
+	userAgent  string
+}
+
+// NewClient creates a provenance client with a bounded request timeout.
+func NewClient(userAgent string) *Client {
+	return NewClientWithHTTPClient(userAgent, &http.Client{Timeout: 30 * time.Second})
+}
+
+// NewClientWithHTTPClient creates a provenance client using the provided HTTP client.
+func NewClientWithHTTPClient(userAgent string, httpClient HTTPClient) *Client {
+	return &Client{httpClient: httpClient, userAgent: userAgent}
+}
+
+// Lookup retrieves the available provenance signal for a dependency release.
+func (c *Client) Lookup(ctx context.Context, dep Dependency) Result {
+	switch dep.Ecosystem {
+	case "npm":
+		return c.lookupNPM(ctx, dep)
+	case "pypi":
+		return c.lookupPyPI(ctx, dep)
+	case "rubygems":
+		return c.lookupRubyGems(ctx, dep)
+	default:
+		return Result{
+			Status:   StatusUnsupported,
+			Evidence: []string{"provenance lookup is only supported for npm and pypi"},
+		}
+	}
+}
+
+type notFoundError struct{}
+
+func (notFoundError) Error() string { return "registry resource not found" }
+
+func isNotFound(err error) bool {
+	var target notFoundError
+	return errors.As(err, &target)
+}
+
+func (c *Client) fetchJSON(ctx context.Context, endpoint, accept string, target any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Accept", accept)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return notFoundError{}
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("registry returned HTTP %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(target); err != nil {
+		return fmt.Errorf("decoding registry response: %w", err)
+	}
+	return nil
+}

--- a/internal/provenance/client_test.go
+++ b/internal/provenance/client_test.go
@@ -35,7 +35,7 @@ func newFakeClient(responses map[string]fakeResponse) (*Client, *fakeHTTPClient)
 	return NewClientWithHTTPClient("git-pkgs/test", fake), fake
 }
 
-func TestLookupNPMTrustedPublishing(t *testing.T) {
+func TestLookupNPMRegistryAttestationIsNotTrustedPublishing(t *testing.T) {
 	client, _ := newFakeClient(map[string]fakeResponse{
 		"https://registry.npmjs.org/@scope%2Fpkg/1.2.3": {
 			status: http.StatusOK,
@@ -44,11 +44,14 @@ func TestLookupNPMTrustedPublishing(t *testing.T) {
 	})
 
 	got := client.Lookup(context.Background(), Dependency{Ecosystem: "npm", Name: "@scope/pkg", Version: "1.2.3"})
-	if got.Status != StatusTrustedPublishing || !got.TrustedPublishing {
-		t.Fatalf("result = %#v, want trusted publishing", got)
+	if got.Status != StatusAttested || got.TrustedPublishing {
+		t.Fatalf("result = %#v, want attested without trusted publishing", got)
 	}
 	if got.RegistrySignatures != 1 {
 		t.Fatalf("registry signatures = %d, want 1", got.RegistrySignatures)
+	}
+	if len(got.Evidence) != 1 || got.Evidence[0] != "npm registry attestation; publishing authentication is not verifiable" {
+		t.Fatalf("evidence = %#v, want authentication caveat", got.Evidence)
 	}
 }
 

--- a/internal/provenance/client_test.go
+++ b/internal/provenance/client_test.go
@@ -1,0 +1,67 @@
+package provenance
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type fakeHTTPClient struct {
+	responses map[string]fakeResponse
+	requests  []*http.Request
+}
+
+type fakeResponse struct {
+	status int
+	body   string
+}
+
+func (f *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.requests = append(f.requests, req)
+	response, ok := f.responses[req.URL.String()]
+	if !ok {
+		response = fakeResponse{status: http.StatusNotFound}
+	}
+	return &http.Response{
+		StatusCode: response.status,
+		Body:       io.NopCloser(strings.NewReader(response.body)),
+	}, nil
+}
+
+func newFakeClient(responses map[string]fakeResponse) (*Client, *fakeHTTPClient) {
+	fake := &fakeHTTPClient{responses: responses}
+	return NewClientWithHTTPClient("git-pkgs/test", fake), fake
+}
+
+func TestLookupNPMTrustedPublishing(t *testing.T) {
+	client, _ := newFakeClient(map[string]fakeResponse{
+		"https://registry.npmjs.org/@scope%2Fpkg/1.2.3": {
+			status: http.StatusOK,
+			body:   `{"dist":{"attestations":{"provenance":{}},"signatures":[{}]}}`,
+		},
+	})
+
+	got := client.Lookup(context.Background(), Dependency{Ecosystem: "npm", Name: "@scope/pkg", Version: "1.2.3"})
+	if got.Status != StatusTrustedPublishing || !got.TrustedPublishing {
+		t.Fatalf("result = %#v, want trusted publishing", got)
+	}
+	if got.RegistrySignatures != 1 {
+		t.Fatalf("registry signatures = %d, want 1", got.RegistrySignatures)
+	}
+}
+
+func TestLookupNPMSignedOnly(t *testing.T) {
+	client, _ := newFakeClient(map[string]fakeResponse{
+		"https://registry.npmjs.org/lodash/4.17.21": {
+			status: http.StatusOK,
+			body:   `{"dist":{"signatures":[{}]}}`,
+		},
+	})
+
+	got := client.Lookup(context.Background(), Dependency{Ecosystem: "npm", Name: "lodash", Version: "4.17.21"})
+	if got.Status != StatusSigned || got.TrustedPublishing {
+		t.Fatalf("result = %#v, want signed only", got)
+	}
+}

--- a/internal/provenance/npm.go
+++ b/internal/provenance/npm.go
@@ -20,10 +20,9 @@ func (c *Client) lookupNPM(ctx context.Context, dep Dependency) Result {
 
 	if hasValue(body.Dist.Attestations) || hasValue(body.Dist.Provenance) {
 		return Result{
-			Status:             StatusTrustedPublishing,
-			TrustedPublishing:  true,
+			Status:             StatusAttested,
 			RegistrySignatures: len(body.Dist.Signatures),
-			Evidence:           []string{"npm registry attestation"},
+			Evidence:           []string{"npm registry attestation; publishing authentication is not verifiable"},
 		}
 	}
 	if len(body.Dist.Signatures) > 0 {

--- a/internal/provenance/npm.go
+++ b/internal/provenance/npm.go
@@ -1,0 +1,54 @@
+package provenance
+
+import (
+	"context"
+	"net/url"
+)
+
+func (c *Client) lookupNPM(ctx context.Context, dep Dependency) Result {
+	endpoint := "https://registry.npmjs.org/" + url.PathEscape(dep.Name) + "/" + url.PathEscape(dep.Version)
+	var body struct {
+		Dist struct {
+			Attestations any   `json:"attestations"`
+			Provenance   any   `json:"provenance"`
+			Signatures   []any `json:"signatures"`
+		} `json:"dist"`
+	}
+	if err := c.fetchJSON(ctx, endpoint, "application/json", &body); err != nil {
+		return Result{Status: StatusError, Error: err.Error()}
+	}
+
+	if hasValue(body.Dist.Attestations) || hasValue(body.Dist.Provenance) {
+		return Result{
+			Status:             StatusTrustedPublishing,
+			TrustedPublishing:  true,
+			RegistrySignatures: len(body.Dist.Signatures),
+			Evidence:           []string{"npm registry attestation"},
+		}
+	}
+	if len(body.Dist.Signatures) > 0 {
+		return Result{
+			Status:             StatusSigned,
+			RegistrySignatures: len(body.Dist.Signatures),
+			Evidence:           []string{"npm registry signature"},
+		}
+	}
+	return Result{Status: StatusMissing}
+}
+
+func hasValue(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case string:
+		return v != ""
+	case bool:
+		return v
+	case []any:
+		return len(v) > 0
+	case map[string]any:
+		return len(v) > 0
+	default:
+		return true
+	}
+}

--- a/internal/provenance/pypi.go
+++ b/internal/provenance/pypi.go
@@ -1,0 +1,71 @@
+package provenance
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+const pypiIntegrityAccept = "application/vnd.pypi.integrity.v1+json"
+
+type pypiRelease struct {
+	URLs []struct {
+		Filename string `json:"filename"`
+	} `json:"urls"`
+}
+
+type pypiProvenance struct {
+	AttestationBundles []any `json:"attestation_bundles"`
+}
+
+func (c *Client) lookupPyPI(ctx context.Context, dep Dependency) Result {
+	// The release JSON is used only to enumerate the release artifacts. Attestation
+	// data itself is retrieved from PyPI's per-file Integrity API.
+	releaseEndpoint := "https://pypi.org/pypi/" + url.PathEscape(dep.Name) + "/" + url.PathEscape(dep.Version) + "/json"
+	var release pypiRelease
+	if err := c.fetchJSON(ctx, releaseEndpoint, "application/json", &release); err != nil {
+		return Result{Status: StatusError, Error: err.Error()}
+	}
+	if len(release.URLs) == 0 {
+		return Result{Status: StatusError, Error: "PyPI release has no files"}
+	}
+
+	attested := 0
+	lookupFailures := 0
+	for _, file := range release.URLs {
+		if file.Filename == "" {
+			lookupFailures++
+			continue
+		}
+		endpoint := "https://pypi.org/integrity/" + url.PathEscape(dep.Name) + "/" + url.PathEscape(dep.Version) + "/" + url.PathEscape(file.Filename) + "/provenance"
+		var provenance pypiProvenance
+		err := c.fetchJSON(ctx, endpoint, pypiIntegrityAccept, &provenance)
+		switch {
+		case err == nil && len(provenance.AttestationBundles) > 0:
+			attested++
+		case err == nil || isNotFound(err):
+			// A missing provenance resource means this release file is unattested.
+		default:
+			lookupFailures++
+		}
+	}
+
+	if lookupFailures > 0 {
+		return Result{
+			Status:   StatusError,
+			Evidence: []string{fmt.Sprintf("PyPI attestations found for %d/%d release files", attested, len(release.URLs))},
+			Error:    fmt.Sprintf("could not check provenance for %d release files", lookupFailures),
+		}
+	}
+	if attested == len(release.URLs) {
+		return Result{
+			Status:            StatusTrustedPublishing,
+			TrustedPublishing: true,
+			Evidence:          []string{fmt.Sprintf("PyPI attestations for all %d release files", attested)},
+		}
+	}
+	return Result{
+		Status:   StatusMissing,
+		Evidence: []string{fmt.Sprintf("PyPI attestations found for %d/%d release files", attested, len(release.URLs))},
+	}
+}

--- a/internal/provenance/pypi_test.go
+++ b/internal/provenance/pypi_test.go
@@ -1,0 +1,58 @@
+package provenance
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestLookupPyPIUsesIntegrityAPIForEveryReleaseFile(t *testing.T) {
+	client, fake := newFakeClient(map[string]fakeResponse{
+		"https://pypi.org/pypi/sampleproject/4.0.0/json": {
+			status: http.StatusOK,
+			body:   `{"urls":[{"filename":"sampleproject-4.0.0.tar.gz"},{"filename":"sampleproject-4.0.0-py3-none-any.whl"}]}`,
+		},
+		"https://pypi.org/integrity/sampleproject/4.0.0/sampleproject-4.0.0.tar.gz/provenance": {
+			status: http.StatusOK,
+			body:   `{"attestation_bundles":[{}]}`,
+		},
+		"https://pypi.org/integrity/sampleproject/4.0.0/sampleproject-4.0.0-py3-none-any.whl/provenance": {
+			status: http.StatusOK,
+			body:   `{"attestation_bundles":[{}]}`,
+		},
+	})
+
+	got := client.Lookup(context.Background(), Dependency{Ecosystem: "pypi", Name: "sampleproject", Version: "4.0.0"})
+	if got.Status != StatusTrustedPublishing || !got.TrustedPublishing {
+		t.Fatalf("result = %#v, want trusted publishing", got)
+	}
+	if len(fake.requests) != 3 {
+		t.Fatalf("requests = %d, want release metadata plus two file provenance requests", len(fake.requests))
+	}
+	for _, request := range fake.requests[1:] {
+		if got := request.Header.Get("Accept"); got != pypiIntegrityAccept {
+			t.Fatalf("Integrity API Accept = %q, want %q", got, pypiIntegrityAccept)
+		}
+	}
+}
+
+func TestLookupPyPIMissingWhenAnyReleaseFileIsUnattested(t *testing.T) {
+	client, _ := newFakeClient(map[string]fakeResponse{
+		"https://pypi.org/pypi/sampleproject/4.0.0/json": {
+			status: http.StatusOK,
+			body:   `{"urls":[{"filename":"sampleproject-4.0.0.tar.gz"},{"filename":"sampleproject-4.0.0-py3-none-any.whl"}]}`,
+		},
+		"https://pypi.org/integrity/sampleproject/4.0.0/sampleproject-4.0.0.tar.gz/provenance": {
+			status: http.StatusOK,
+			body:   `{"attestation_bundles":[{}]}`,
+		},
+		"https://pypi.org/integrity/sampleproject/4.0.0/sampleproject-4.0.0-py3-none-any.whl/provenance": {
+			status: http.StatusNotFound,
+		},
+	})
+
+	got := client.Lookup(context.Background(), Dependency{Ecosystem: "pypi", Name: "sampleproject", Version: "4.0.0"})
+	if got.Status != StatusMissing || got.TrustedPublishing {
+		t.Fatalf("result = %#v, want missing provenance", got)
+	}
+}

--- a/internal/provenance/rubygems.go
+++ b/internal/provenance/rubygems.go
@@ -1,0 +1,10 @@
+package provenance
+
+import "context"
+
+func (c *Client) lookupRubyGems(_ context.Context, _ Dependency) Result {
+	return Result{
+		Status:   StatusUnsupported,
+		Evidence: []string{"RubyGems does not expose per-release provenance through its V2 API"},
+	}
+}

--- a/internal/provenance/rubygems_test.go
+++ b/internal/provenance/rubygems_test.go
@@ -1,0 +1,18 @@
+package provenance
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLookupRubyGemsIsUnsupportedWithoutNetworkRequest(t *testing.T) {
+	client, fake := newFakeClient(nil)
+	got := client.Lookup(context.Background(), Dependency{Ecosystem: "rubygems", Name: "rails", Version: "8.0.0"})
+
+	if got.Status != StatusUnsupported {
+		t.Fatalf("status = %q, want %q", got.Status, StatusUnsupported)
+	}
+	if len(fake.requests) != 0 {
+		t.Fatalf("requests = %d, want 0", len(fake.requests))
+	}
+}

--- a/internal/provenance/types.go
+++ b/internal/provenance/types.go
@@ -1,0 +1,37 @@
+// Package provenance checks registry-provided provenance signals for exact
+// package versions without depending on CLI or database concerns.
+package provenance
+
+import "context"
+
+// Status describes the provenance signal available for a dependency release.
+type Status string
+
+const (
+	StatusTrustedPublishing Status = "trusted_publishing"
+	StatusSigned            Status = "signed"
+	StatusMissing           Status = "missing"
+	StatusUnsupported       Status = "unsupported"
+	StatusError             Status = "error"
+)
+
+// Dependency identifies one exact package version to inspect.
+type Dependency struct {
+	Ecosystem string
+	Name      string
+	Version   string
+}
+
+// Result contains the registry signal and any supporting evidence.
+type Result struct {
+	Status             Status
+	TrustedPublishing  bool
+	RegistrySignatures int
+	Evidence           []string
+	Error              string
+}
+
+// Checker checks provenance for exact dependency versions.
+type Checker interface {
+	Lookup(context.Context, Dependency) Result
+}

--- a/internal/provenance/types.go
+++ b/internal/provenance/types.go
@@ -9,6 +9,7 @@ type Status string
 
 const (
 	StatusTrustedPublishing Status = "trusted_publishing"
+	StatusAttested          Status = "attested"
 	StatusSigned            Status = "signed"
 	StatusMissing           Status = "missing"
 	StatusUnsupported       Status = "unsupported"


### PR DESCRIPTION
Closes #110.

## Summary

Adds a new `git pkgs provenance` command for checking resolved dependency versions against registry provenance and attestation metadata.

The command reports:
- trusted-publishing attestation metadata when exposed by registry APIs
- npm registry signatures as a weaker integrity signal
- missing provenance metadata
- unsupported ecosystems
- lookup errors

## Details

- Adds `--commit`, `--branch`, `--ecosystem`, `--format=json`, and `--missing`
- Uses an 8-worker lookup pool with a shared 5-minute timeout
- Keeps unsupported ecosystems explicit instead of treating missing metadata as verified
- Documents the new command in the README and internals docs
- Adds focused unit tests for npm provenance/signature parsing, resolved dependency selection and missing-only filtering

## Tests

```bash
GOCACHE=/tmp/git-pkgs-gocache go test ./cmd -run Provenance
GOCACHE=/tmp/git-pkgs-gocache go test ./...
GOCACHE=/tmp/git-pkgs-gocache GOLANGCI_LINT_CACHE=/tmp/git-pkgs-golangci-cache go tool golangci-lint run ./...
GOCACHE=/tmp/git-pkgs-gocache go build ./...
git diff --check
```