### PR TITLE
Add ecosyste.ms identity options and friendlier lookup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,6 +789,9 @@ Commands that run package managers (`install`, `add`, `remove`, `update`) delega
 - `GIT_DIR` - git directory location (standard git variable)
 - `GIT_PKGS_DB` - database path (default: `.git/pkgs.sqlite3`)
 - `GIT_PKGS_DIRECT` - set to `1` to query registries directly (skip ecosyste.ms)
+- `GIT_PKGS_ECOSYSTEMS_FROM` - email address sent as the `From` header on ecosyste.ms requests, putting you in the [polite pool](https://ecosyste.ms/api-policy) instead of the shared anonymous pool
+- `GIT_PKGS_ECOSYSTEMS_API_KEY` - ecosyste.ms API key sent as a bearer token
+- `GIT_PKGS_ECOSYSTEMS_BATCH_SIZE` - per-request batch size for ecosyste.ms bulk lookups
 
 **Author mapping** via `.mailmap` is supported. If your repository has a [`.mailmap` file](https://git-scm.com/docs/gitmailmap), author identities are resolved to their canonical names when indexing commits. This helps deduplicate contributors in `blame`, `history`, and `stats` output.
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/git-pkgs/changelog"
-	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/purl"
 	"github.com/spf13/cobra"
 )
@@ -64,14 +63,14 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), changelogTimeout)
 	defer cancel()
 
-	client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return fmt.Errorf("creating API client: %w", err)
 	}
 
 	packages, err := client.BulkLookup(ctx, []string{purlStr})
 	if err != nil {
-		return fmt.Errorf("looking up package: %w", err)
+		return fmt.Errorf("looking up package: %w", wrapEcosystemsError(err))
 	}
 	pkgInfo := packages[purlStr]
 	if pkgInfo == nil {

--- a/cmd/enrichment.go
+++ b/cmd/enrichment.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/git-pkgs/enrichment"
+)
+
+const (
+	envEcosystemsFrom      = "GIT_PKGS_ECOSYSTEMS_FROM"
+	envEcosystemsAPIKey    = "GIT_PKGS_ECOSYSTEMS_API_KEY"
+	envEcosystemsBatchSize = "GIT_PKGS_ECOSYSTEMS_BATCH_SIZE"
+)
+
+// NewEnrichmentClient is the constructor for the enrichment client.
+// Tests can replace this to avoid external API calls.
+var NewEnrichmentClient = enrichment.NewClient
+
+// newEnrichmentClient builds an enrichment client with the standard
+// git-pkgs user agent and any identity options supplied via environment
+// variables. All commands that talk to ecosyste.ms should use this so
+// that GIT_PKGS_ECOSYSTEMS_FROM and GIT_PKGS_ECOSYSTEMS_API_KEY are
+// applied consistently.
+func newEnrichmentClient() (enrichment.Client, error) {
+	return NewEnrichmentClient(enrichmentOptions()...)
+}
+
+func enrichmentOptions() []enrichment.Option {
+	opts := []enrichment.Option{
+		enrichment.WithUserAgent(userAgent),
+	}
+	if from := os.Getenv(envEcosystemsFrom); from != "" {
+		opts = append(opts, enrichment.WithFrom(from))
+	}
+	if key := os.Getenv(envEcosystemsAPIKey); key != "" {
+		opts = append(opts, enrichment.WithAPIKey(key))
+	}
+	if raw := os.Getenv(envEcosystemsBatchSize); raw != "" {
+		if size, err := strconv.Atoi(raw); err == nil && size > 0 {
+			opts = append(opts, enrichment.WithBatchSize(size))
+		}
+	}
+	return opts
+}
+
+// wrapEcosystemsError annotates ecosyste.ms request failures with a hint
+// about the polite-pool environment variables so users hitting shared-pool
+// rate limits or stream errors have a path forward. If an identity is
+// already configured the error is returned unchanged.
+func wrapEcosystemsError(err error) error {
+	if os.Getenv(envEcosystemsFrom) != "" || os.Getenv(envEcosystemsAPIKey) != "" {
+		return err
+	}
+	return fmt.Errorf(
+		"%w\n"+
+			"requests to ecosyste.ms without an identity share a common rate-limit pool; "+
+			"set %s to your email address (or %s to an API key) to use the polite pool",
+		err, envEcosystemsFrom, envEcosystemsAPIKey,
+	)
+}

--- a/cmd/enrichment_test.go
+++ b/cmd/enrichment_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEnrichmentOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want int
+	}{
+		{"user agent only", nil, 1},
+		{"from", map[string]string{envEcosystemsFrom: "user@example.com"}, 2},
+		{"api key", map[string]string{envEcosystemsAPIKey: "secret"}, 2},
+		{"from and api key", map[string]string{
+			envEcosystemsFrom:   "user@example.com",
+			envEcosystemsAPIKey: "secret",
+		}, 3},
+		{"batch size", map[string]string{envEcosystemsBatchSize: "50"}, 2},
+		{"invalid batch size ignored", map[string]string{envEcosystemsBatchSize: "abc"}, 1},
+		{"zero batch size ignored", map[string]string{envEcosystemsBatchSize: "0"}, 1},
+		{"all", map[string]string{
+			envEcosystemsFrom:      "user@example.com",
+			envEcosystemsAPIKey:    "secret",
+			envEcosystemsBatchSize: "50",
+		}, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, k := range []string{envEcosystemsFrom, envEcosystemsAPIKey, envEcosystemsBatchSize} {
+				t.Setenv(k, tt.env[k])
+			}
+			got := enrichmentOptions()
+			if len(got) != tt.want {
+				t.Errorf("enrichmentOptions() returned %d options, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapEcosystemsError(t *testing.T) {
+	base := errors.New("bulk lookup: stream error: stream ID 1; INTERNAL_ERROR")
+
+	t.Run("adds hint when no identity configured", func(t *testing.T) {
+		t.Setenv(envEcosystemsFrom, "")
+		t.Setenv(envEcosystemsAPIKey, "")
+
+		got := wrapEcosystemsError(base)
+		if !errors.Is(got, base) {
+			t.Errorf("wrapped error does not unwrap to base error")
+		}
+		msg := got.Error()
+		if !strings.Contains(msg, "INTERNAL_ERROR") {
+			t.Errorf("wrapped error lost original message: %q", msg)
+		}
+		if !strings.Contains(msg, envEcosystemsFrom) {
+			t.Errorf("wrapped error missing %s hint: %q", envEcosystemsFrom, msg)
+		}
+		if !strings.Contains(msg, envEcosystemsAPIKey) {
+			t.Errorf("wrapped error missing %s hint: %q", envEcosystemsAPIKey, msg)
+		}
+		if !strings.Contains(msg, "polite pool") {
+			t.Errorf("wrapped error missing polite pool hint: %q", msg)
+		}
+	})
+
+	t.Run("passes through when from is set", func(t *testing.T) {
+		t.Setenv(envEcosystemsFrom, "user@example.com")
+		t.Setenv(envEcosystemsAPIKey, "")
+
+		if got := wrapEcosystemsError(base); got != base {
+			t.Errorf("wrapEcosystemsError() = %v, want unchanged %v", got, base)
+		}
+	})
+
+	t.Run("passes through when api key is set", func(t *testing.T) {
+		t.Setenv(envEcosystemsFrom, "")
+		t.Setenv(envEcosystemsAPIKey, "secret")
+
+		if got := wrapEcosystemsError(base); got != base {
+			t.Errorf("wrapEcosystemsError() = %v, want unchanged %v", got, base)
+		}
+	})
+}

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -200,7 +200,7 @@ func loadFreshnessVersions(db *database.DB, deps []database.Dependency) (map[str
 		return result, nil
 	}
 
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/funding.go
+++ b/cmd/funding.go
@@ -177,7 +177,7 @@ func fetchFundingPackageData(db *database.DB, deps []database.Dependency) (map[s
 }
 
 func fetchFundingMetadata(purls []string) (map[string]*enrichment.PackageInfo, error) {
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,11 @@ func fetchFundingMetadata(purls []string) (map[string]*enrichment.PackageInfo, e
 	ctx, cancel := context.WithTimeout(context.Background(), fundingLookupTimeout)
 	defer cancel()
 
-	return client.BulkLookup(ctx, purls)
+	packages, err := client.BulkLookup(ctx, purls)
+	if err != nil {
+		return nil, wrapEcosystemsError(err)
+	}
+	return packages, nil
 }
 
 func saveFundingPackageData(

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -197,7 +197,7 @@ func fetchHealthPackageData(db *database.DB, deps []database.Dependency) (map[st
 }
 
 func fetchHealthMetadata(purls []string) (map[string]*enrichment.PackageInfo, error) {
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,11 @@ func fetchHealthMetadata(purls []string) (map[string]*enrichment.PackageInfo, er
 	ctx, cancel := context.WithTimeout(context.Background(), healthLookupTimeout)
 	defer cancel()
 
-	return client.BulkLookup(ctx, purls)
+	packages, err := client.BulkLookup(ctx, purls)
+	if err != nil {
+		return nil, wrapEcosystemsError(err)
+	}
+	return packages, nil
 }
 
 func saveHealthPackageData(

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
@@ -269,7 +268,7 @@ func runRegistryCheck(cmd *cobra.Command, deps []database.Dependency, format str
 	}
 
 	// Create enrichment client
-	client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return fmt.Errorf("creating enrichment client: %w", err)
 	}

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -19,10 +19,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewEnrichmentClient is the constructor for the enrichment client.
-// Tests can replace this to avoid external API calls.
-var NewEnrichmentClient = enrichment.NewClient
-
 func addLicensesCmd(parent *cobra.Command) {
 	licensesCmd := &cobra.Command{
 		Use:   "licenses",
@@ -354,7 +350,7 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
-		client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+		client, err := newEnrichmentClient()
 		if err != nil {
 			return nil, err
 		}
@@ -365,7 +361,7 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 
 		packages, err := client.BulkLookup(ctx, uncachedPurls)
 		if err != nil {
-			return nil, err
+			return nil, wrapEcosystemsError(err)
 		}
 
 		for purl, pkg := range packages {
@@ -553,7 +549,7 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 		return result, nil
 	}
 
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +568,7 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 	}
 	if len(fetchErrors) == len(missing) {
 		return nil, fmt.Errorf("fetching license drift metadata failed for all %d uncached versions: %w",
-			len(missing), errors.Join(fetchErrors...))
+			len(missing), wrapEcosystemsError(errors.Join(fetchErrors...)))
 	}
 
 	return result, nil

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -237,7 +237,7 @@ func fetchMaintainerDataUncached(ctx context.Context, purls []string) map[string
 		return results
 	}
 
-	client, err := NewEnrichmentClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		for _, purlStr := range purls {
 			results[purlStr] = maintainerLookupResult{Error: fmt.Sprintf("creating enrichment client: %v", err)}
@@ -247,8 +247,9 @@ func fetchMaintainerDataUncached(ctx context.Context, purls []string) map[string
 
 	packages, err := client.BulkLookup(ctx, purls)
 	if err != nil {
+		wrapped := wrapEcosystemsError(err).Error()
 		for _, purlStr := range purls {
-			results[purlStr] = maintainerLookupResult{Error: err.Error()}
+			results[purlStr] = maintainerLookupResult{Error: wrapped}
 		}
 		return results
 	}

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
@@ -212,7 +211,7 @@ func getPackageData(db *database.DB, purls []string, purlToDep map[string]databa
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
-		client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
+		client, err := newEnrichmentClient()
 		if err != nil {
 			return nil, err
 		}
@@ -223,7 +222,7 @@ func getPackageData(db *database.DB, purls []string, purlToDep map[string]databa
 
 		packages, err := client.BulkLookup(ctx, uncachedPurls)
 		if err != nil {
-			return nil, err
+			return nil, wrapEcosystemsError(err)
 		}
 
 		var toSave []database.PackageEnrichmentData
@@ -291,7 +290,7 @@ func findLatestAtDateCached(db *database.DB, ecosystem, name, purl string, atTim
 	}
 
 	// Fall back to API
-	client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
+	client, err := newEnrichmentClient()
 	if err != nil {
 		return ""
 	}

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
@@ -166,7 +165,7 @@ func getSBOMLicenseData(db *database.DB, purls []string, purlToDep map[string]da
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
-		client, err := enrichment.NewClient(enrichment.WithUserAgent(userAgent))
+		client, err := newEnrichmentClient()
 		if err != nil {
 			return nil, err
 		}
@@ -177,7 +176,7 @@ func getSBOMLicenseData(db *database.DB, purls []string, purlToDep map[string]da
 
 		packages, err := client.BulkLookup(ctx, uncachedPurls)
 		if err != nil {
-			return nil, err
+			return nil, wrapEcosystemsError(err)
 		}
 
 		for purl, pkg := range packages {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/git-pkgs/changelog v0.1.3
-	github.com/git-pkgs/enrichment v0.3.0
+	github.com/git-pkgs/enrichment v0.4.0
 	github.com/git-pkgs/gitignore v1.2.0
 	github.com/git-pkgs/managers v0.9.0
 	github.com/git-pkgs/manifests v0.5.0
@@ -19,6 +19,7 @@ require (
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/mattn/go-isatty v0.0.22
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.52.0
 )
@@ -86,7 +87,7 @@ require (
 	github.com/denis-tingaikin/go-header v0.5.0 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/ecosyste-ms/ecosystems-go v0.1.1 // indirect
+	github.com/ecosyste-ms/ecosystems-go v0.2.0 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/ettle/strcase v0.2.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
@@ -179,7 +180,7 @@ require (
 	github.com/nishanths/exhaustive v0.12.0 // indirect
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.0 // indirect
-	github.com/oapi-codegen/runtime v1.1.2 // indirect
+	github.com/oapi-codegen/runtime v1.4.1 // indirect
 	github.com/package-url/packageurl-go v0.1.6 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
@@ -216,7 +217,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZ
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
-github.com/ecosyste-ms/ecosystems-go v0.1.1 h1:YYiBK9TCCTeE+BtmpN2FssaRFcmF+T0v4LrupIOjehQ=
-github.com/ecosyste-ms/ecosystems-go v0.1.1/go.mod h1:VczXs1CO9nL8XbL1NwvgmwIaqzMsAxcsXnTpRtwi9gU=
+github.com/ecosyste-ms/ecosystems-go v0.2.0 h1:Nhpg54C+St8Sd/mf8bNJmQqx35ZgHw33TfFoxaXMQI8=
+github.com/ecosyste-ms/ecosystems-go v0.2.0/go.mod h1:CCdzT1iAZirbEZAbFSnWpK88eKKaIWex7gjtZ0UudXA=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
@@ -215,8 +215,8 @@ github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/git-pkgs/changelog v0.1.3 h1:iaFrl76F9lE3B9bQBZCpm0O+eB6tQ0ajMnrc5l7/EhU=
 github.com/git-pkgs/changelog v0.1.3/go.mod h1:psv6VJyJKYzDYajKdV9oPw7LUEOIqSiB0L3wcKdX6Ac=
-github.com/git-pkgs/enrichment v0.3.0 h1:tsATMAwR/qcSIw4JV37uH2TBgTv415RfJC7w3nzWfD4=
-github.com/git-pkgs/enrichment v0.3.0/go.mod h1:MBv5nhHzjwLxeSgx2+7waCcpReUjhCD+9B0bvufpMO0=
+github.com/git-pkgs/enrichment v0.4.0 h1:nG0EH5HrIbbmmLhKp9NcuLZ5d1DOEnRV947tg8a5mh8=
+github.com/git-pkgs/enrichment v0.4.0/go.mod h1:XFASHTtUD8SxDCe3jeObQEBlU+uaMc2oB0vt88/SLIE=
 github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLuFaM=
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/managers v0.9.0 h1:t3ZFvzvmh7Vf57tz0BSdQoOjo4DcXolUCXUiBckmn6E=
@@ -532,8 +532,10 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.23.0 h1:x3o4DGYOWbBMP/VdNQKgSj+25aJKx2Pe6lHr8gBcgf8=
 github.com/nunnatsa/ginkgolinter v0.23.0/go.mod h1:9qN1+0akwXEccwV1CAcCDfcoBlWXHB+ML9884pL4SZ4=
-github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
-github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oapi-codegen/nullable v1.1.0 h1:eAh8JVc5430VtYVnq00Hrbpag9PFRGWLjxR1/3KntMs=
+github.com/oapi-codegen/nullable v1.1.0/go.mod h1:KUZ3vUzkmEKY90ksAmit2+5juDIhIZhfDl+0PwOQlFY=
+github.com/oapi-codegen/runtime v1.4.1 h1:9nwLoI+KrWxzbBcp0jO/R8uXqbik/HUyCvPeU68Y/qo=
+github.com/oapi-codegen/runtime v1.4.1/go.mod h1:GwV7hC2hviaMzj+ITfHVRESK5J2W/GefVwIND/bMGvU=
 github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI=
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=


### PR DESCRIPTION
Fixes #231.

Bumps `github.com/git-pkgs/enrichment` to v0.4.0, which adds `WithFrom`, `WithAPIKey` and `WithBatchSize` and pulls in ecosystems-go v0.2.0 with its improved error handling and batching.

All enrichment client construction now goes through a single `newEnrichmentClient()` helper in `cmd/enrichment.go` that applies the standard user agent plus three new environment variables:

- `GIT_PKGS_ECOSYSTEMS_FROM` sets the `From` header so requests use the ecosyste.ms polite pool
- `GIT_PKGS_ECOSYSTEMS_API_KEY` sends a bearer token
- `GIT_PKGS_ECOSYSTEMS_BATCH_SIZE` overrides the bulk lookup batch size

Previously `licenses`, `funding` and `freshness` went through the swappable `NewEnrichmentClient` var while `outdated`, `sbom`, `changelog` and `integrity` called `enrichment.NewClient` directly; they're now unified so the env vars apply everywhere.

`BulkLookup` errors are wrapped with a hint pointing at `GIT_PKGS_ECOSYSTEMS_FROM` / `GIT_PKGS_ECOSYSTEMS_API_KEY` when no identity is configured, so the failure mode in #231 becomes:

```
Error: looking up packages: bulk lookup: stream error: stream ID 1; INTERNAL_ERROR; received from peer
requests to ecosyste.ms without an identity share a common rate-limit pool; set GIT_PKGS_ECOSYSTEMS_FROM to your email address (or GIT_PKGS_ECOSYSTEMS_API_KEY to an API key) to use the polite pool
```

The hint is suppressed once an identity is set. README documents the new variables alongside `GIT_PKGS_DIRECT`.