### PR TITLE
fix: avoid partial package matches in where

### DIFF
--- a/cmd/where.go
+++ b/cmd/where.go
@@ -168,10 +168,13 @@ func searchFileForPackage(root *os.Root, osRel, relPath, packageName, ecosystem 
 	var matches []WhereMatch
 	var lines []string
 
-	// Case-insensitive search with non-alphanumeric boundaries to avoid matching inside hashes.
-	// We can't use \b because package names may start/end with non-word chars (e.g. @scope/pkg).
+	// Case-insensitive search with package-token boundaries to avoid matching inside
+	// hashes or similarly named packages. We can't use \b because package names may
+	// start/end with non-word chars (e.g. @scope/pkg), and punctuation like hyphens
+	// can be part of package names. Allow @ as a boundary so GitHub Actions like
+	// actions/checkout@v4 still match actions/checkout.
 	quoted := regexp.QuoteMeta(packageName)
-	re := regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9])` + quoted + `(?:$|[^A-Za-z0-9])`)
+	re := regexp.MustCompile(`(?i)(?:^|[^A-Za-z0-9._-])` + quoted + `(?:$|[^A-Za-z0-9._-])`)
 
 	scanner := bufio.NewScanner(file)
 	lineNum := 0

--- a/cmd/where_test.go
+++ b/cmd/where_test.go
@@ -56,6 +56,12 @@ func TestSearchFileForPackage(t *testing.T) {
 			packageName: "six",
 			wantLines:   nil,
 		},
+		{
+			name:        "no match when package name is hyphenated substring",
+			content:     `    "my-left-pad": "1.0.0",`,
+			packageName: "left-pad",
+			wantLines:   nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- tighten `where` package-name matching so hyphenated substrings like `my-left-pad` do not match `left-pad`
- keep existing GitHub Actions matching such as `actions/checkout@...`
- add regression coverage for the hyphenated substring case

## Testing
- [x] `go test ./cmd -run 'TestSearchFileForPackage|TestWhereCommandWithWorkflows' -count=1`
- [x] `go test ./cmd -count=1`
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go tool golangci-lint run ./...`

Closes #242
