### PR TITLE
fix: include all schema tables in info counts

### DIFF
--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -220,6 +220,11 @@ func TestInfoCommand(t *testing.T) {
 		if !strings.Contains(stdout, "Branch") {
 			t.Errorf("expected 'Branch' in output, got: %s", stdout)
 		}
+		for _, tableName := range []string{"Packages", "Versions", "Vulnerabilities", "Vulnerability Packages", "Notes"} {
+			if !strings.Contains(stdout, tableName) {
+				t.Errorf("expected %q row count in output, got: %s", tableName, stdout)
+			}
+		}
 	})
 
 	t.Run("shows ecosystems flag", func(t *testing.T) {
@@ -274,6 +279,16 @@ func TestInfoCommand(t *testing.T) {
 		}
 		if _, ok := info["row_counts"]; !ok {
 			t.Error("expected 'row_counts' in JSON")
+		}
+
+		rowCounts, ok := info["row_counts"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected row_counts object, got: %#v", info["row_counts"])
+		}
+		for _, table := range []string{"packages", "versions", "vulnerabilities", "vulnerability_packages", "notes"} {
+			if _, ok := rowCounts[table]; !ok {
+				t.Errorf("expected %q row count in JSON", table)
+			}
 		}
 	})
 

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -110,14 +110,31 @@ func outputInfoText(cmd *cobra.Command, info *database.DatabaseInfo) {
 	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "----------------------------------------")
 
 	total := 0
-	order := []string{"branches", "commits", "branch_commits", "manifests", "dependency_changes", "dependency_snapshots"}
+	order := []string{
+		"branches",
+		"commits",
+		"branch_commits",
+		"manifests",
+		"dependency_changes",
+		"dependency_snapshots",
+		"packages",
+		"versions",
+		"vulnerabilities",
+		"vulnerability_packages",
+		"notes",
+	}
 	names := map[string]string{
-		"branches":             "Branches",
-		"commits":              "Commits",
-		"branch_commits":       "Branch-Commits",
-		"manifests":            "Manifests",
-		"dependency_changes":   "Dependency Changes",
-		"dependency_snapshots": "Dependency Snapshots",
+		"branches":               "Branches",
+		"commits":                "Commits",
+		"branch_commits":         "Branch-Commits",
+		"manifests":              "Manifests",
+		"dependency_changes":     "Dependency Changes",
+		"dependency_snapshots":   "Dependency Snapshots",
+		"packages":               "Packages",
+		"versions":               "Versions",
+		"vulnerabilities":        "Vulnerabilities",
+		"vulnerability_packages": "Vulnerability Packages",
+		"notes":                  "Notes",
 	}
 
 	for _, table := range order {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -74,6 +74,7 @@ func TestCreate(t *testing.T) {
 			"versions",
 			"vulnerabilities",
 			"vulnerability_packages",
+			"notes",
 		}
 
 		for _, table := range tables {

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -656,8 +656,20 @@ func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
 		info.LastAnalyzedSHA = branchInfo.LastAnalyzedSHA
 	}
 
-	// Row counts for main tables
-	tables := []string{"branches", "commits", "branch_commits", "manifests", "dependency_changes", "dependency_snapshots", "packages", "versions"}
+	// Row counts for main tables.
+	tables := []string{
+		"branches",
+		"commits",
+		"branch_commits",
+		"manifests",
+		"dependency_changes",
+		"dependency_snapshots",
+		"packages",
+		"versions",
+		"vulnerabilities",
+		"vulnerability_packages",
+		"notes",
+	}
 	for _, table := range tables {
 		var count int
 		err := db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)


### PR DESCRIPTION
## Summary
- Include all schema-backed tables in `git pkgs info` row counts.
- Add regression coverage for text and JSON info output.
- Add `notes` to schema creation table coverage.

## Testing
- [x] `go test ./cmd -run TestInfoCommand -count=1`
- [x] `go test ./internal/database -run TestCreateSchema -count=1`
- [x] `go test ./cmd ./internal/database -count=1`
- [x] `go test ./...`
- [x] `go build -v ./...`
- [x] `go tool golangci-lint run ./...`

Closes #243