### PR TITLE
fix: preserve json output for empty results

### DIFF
--- a/cmd/blame.go
+++ b/cmd/blame.go
@@ -50,15 +50,14 @@ func runBlame(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting blame: %w", err)
 	}
 
-	if len(entries) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies found.")
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		return outputBlameJSON(cmd, entries)
 	default:
+		if len(entries) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies found.")
+			return nil
+		}
 		outputBlameText(cmd, entries)
 		return nil
 	}
@@ -67,7 +66,7 @@ func runBlame(cmd *cobra.Command, args []string) error {
 func outputBlameJSON(cmd *cobra.Command, entries []database.BlameEntry) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(entries)
+	return enc.Encode(nonNilSlice(entries))
 }
 
 func outputBlameText(cmd *cobra.Command, entries []database.BlameEntry) {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -124,16 +124,15 @@ func runDiff(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if len(result.Added) == 0 && len(result.Modified) == 0 && len(result.Removed) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependency changes.")
-		return nil
-	}
-
 	// Output
 	switch format {
 	case formatJSON:
 		return outputDiffJSON(cmd, result)
 	default:
+		if len(result.Added) == 0 && len(result.Modified) == 0 && len(result.Removed) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependency changes.")
+			return nil
+		}
 		return outputDiffText(cmd, result)
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -56,6 +56,13 @@ func resolveBranch(db *database.DB, branchName string) (*database.BranchInfo, er
 	return branch, nil
 }
 
+func nonNilSlice[T any](items []T) []T {
+	if items == nil {
+		return []T{}
+	}
+	return items
+}
+
 func shortSHA(sha string) string {
 	if len(sha) > shortSHALen {
 		return sha[:shortSHALen]

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -72,15 +72,14 @@ func runLog(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting commits: %w", err)
 	}
 
-	if len(commits) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No commits with dependency changes found.")
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		return outputLogJSON(cmd, commits)
 	default:
+		if len(commits) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No commits with dependency changes found.")
+			return nil
+		}
 		outputLogText(cmd, commits)
 		return nil
 	}
@@ -89,7 +88,7 @@ func runLog(cmd *cobra.Command, args []string) error {
 func outputLogJSON(cmd *cobra.Command, commits []database.CommitWithChanges) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(commits)
+	return enc.Encode(nonNilSlice(commits))
 }
 
 func outputLogText(cmd *cobra.Command, commits []database.CommitWithChanges) {

--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -296,17 +296,16 @@ func runNotesList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("listing notes: %w", err)
 	}
 
-	if len(notes) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No notes found.")
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(notes)
+		return enc.Encode(nonNilSlice(notes))
 	default:
+		if len(notes) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No notes found.")
+			return nil
+		}
 		for _, n := range notes {
 			line := n.PURL
 			if n.Namespace != "" {
@@ -361,17 +360,16 @@ func runNotesNamespaces(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("listing namespaces: %w", err)
 	}
 
-	if len(namespaces) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No notes found.")
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(namespaces)
+		return enc.Encode(nonNilSlice(namespaces))
 	default:
+		if len(namespaces) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No notes found.")
+			return nil
+		}
 		for _, ns := range namespaces {
 			name := ns.Namespace
 			if name == "" {

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -80,6 +80,9 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
+		if format == formatJSON {
+			return outputOutdatedJSON(cmd, nil)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
 		return nil
 	}
@@ -160,13 +163,12 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 		})
 	}
 
+	if format == formatJSON {
+		return outputOutdatedJSON(cmd, outdated)
+	}
 	if len(outdated) == 0 {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "All dependencies are up to date.")
 		return nil
-	}
-
-	if format == formatJSON {
-		return outputOutdatedJSON(cmd, outdated)
 	}
 	outputOutdatedText(cmd, outdated)
 	return nil
@@ -365,7 +367,7 @@ func classifyUpdate(current, latest string) string {
 func outputOutdatedJSON(cmd *cobra.Command, outdated []OutdatedPackage) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(outdated)
+	return enc.Encode(nonNilSlice(outdated))
 }
 
 func outputOutdatedText(cmd *cobra.Command, outdated []OutdatedPackage) {

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -239,6 +239,45 @@ func TestListCommand(t *testing.T) {
 	})
 }
 
+func TestEmptyResultsRespectJSONFormat(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "search", args: []string{"search", "definitely-not-present", "--format", "json"}},
+		{name: "log", args: []string{"log", "--since", "2999-01-01", "--format", "json"}},
+		{name: "notes list", args: []string{"notes", "list", "--format", "json"}},
+		{name: "notes namespaces", args: []string{"notes", "namespaces", "--format", "json"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, _, err := runCmd(t, tt.args...)
+			if err != nil {
+				t.Fatalf("command failed: %v", err)
+			}
+
+			var result []any
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("expected JSON array, got %q: %v", stdout, err)
+			}
+			if len(result) != 0 {
+				t.Fatalf("expected empty JSON array, got %v", result)
+			}
+		})
+	}
+}
+
 func TestShowCommand(t *testing.T) {
 	t.Run("shows changes in commit", func(t *testing.T) {
 		repoDir := createTestRepo(t)

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -258,6 +258,12 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 		{name: "log", args: []string{"log", "--since", "2999-01-01", "--format", "json"}},
 		{name: "notes list", args: []string{"notes", "list", "--format", "json"}},
 		{name: "notes namespaces", args: []string{"notes", "namespaces", "--format", "json"}},
+		{name: "blame", args: []string{"blame", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "tree", args: []string{"tree", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "outdated", args: []string{"outdated", "--format", "json"}},
+		{name: "stale", args: []string{"stale", "--format", "json"}},
+		{name: "show", args: []string{"show", "HEAD", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "where", args: []string{"where", "definitely-not-present", "--format", "json"}},
 	}
 
 	for _, tt := range tests {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -46,15 +46,14 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("searching: %w", err)
 	}
 
-	if len(results) == 0 {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No dependencies matching %q found.\n", pattern)
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		return outputSearchJSON(cmd, results)
 	default:
+		if len(results) == 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No dependencies matching %q found.\n", pattern)
+			return nil
+		}
 		outputSearchText(cmd, results)
 		return nil
 	}
@@ -63,7 +62,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 func outputSearchJSON(cmd *cobra.Command, results []database.SearchResult) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(results)
+	return enc.Encode(nonNilSlice(results))
 }
 
 func outputSearchText(cmd *cobra.Command, results []database.SearchResult) {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -56,16 +56,15 @@ func runShow(cmd *cobra.Command, args []string) error {
 		changes = filtered
 	}
 
-	if len(changes) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependency changes in this commit.")
-		return nil
-	}
-
 	// Output
 	switch format {
 	case formatJSON:
 		return outputShowJSON(cmd, changes)
 	default:
+		if len(changes) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependency changes in this commit.")
+			return nil
+		}
 		return outputShowText(cmd, changes)
 	}
 }
@@ -129,7 +128,7 @@ func getChangesForCommit(repo *git.Repository, commitRef string) ([]database.Cha
 func outputShowJSON(cmd *cobra.Command, changes []database.Change) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(changes)
+	return enc.Encode(nonNilSlice(changes))
 }
 
 func outputShowText(cmd *cobra.Command, changes []database.Change) error {

--- a/cmd/stale.go
+++ b/cmd/stale.go
@@ -46,19 +46,18 @@ func runStale(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting stale dependencies: %w", err)
 	}
 
-	if len(entries) == 0 {
-		if days > 0 {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No dependencies unchanged for %d+ days.\n", days)
-		} else {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
-		}
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		return outputStaleJSON(cmd, entries)
 	default:
+		if len(entries) == 0 {
+			if days > 0 {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No dependencies unchanged for %d+ days.\n", days)
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
+			}
+			return nil
+		}
 		outputStaleText(cmd, entries)
 		return nil
 	}
@@ -67,7 +66,7 @@ func runStale(cmd *cobra.Command, args []string) error {
 func outputStaleJSON(cmd *cobra.Command, entries []database.StaleEntry) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(entries)
+	return enc.Encode(nonNilSlice(entries))
 }
 
 func outputStaleText(cmd *cobra.Command, entries []database.StaleEntry) {

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -63,17 +63,16 @@ func runTree(cmd *cobra.Command, args []string) error {
 
 	deps = filterByEcosystem(deps, ecosystem)
 
-	if len(deps) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies found.")
-		return nil
-	}
-
 	tree := buildTree(deps)
 
 	switch format {
 	case formatJSON:
 		return outputTreeJSON(cmd, tree)
 	default:
+		if len(deps) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies found.")
+			return nil
+		}
 		outputTreeText(cmd, tree)
 		return nil
 	}
@@ -161,7 +160,7 @@ func buildTree(deps []database.Dependency) []*TreeNode {
 func outputTreeJSON(cmd *cobra.Command, tree []*TreeNode) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(tree)
+	return enc.Encode(nonNilSlice(tree))
 }
 
 func outputTreeText(cmd *cobra.Command, tree []*TreeNode) {

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -1400,6 +1400,11 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(commits) == 0 {
+		if format == formatJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]VulnLogEntry{})
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No commits with dependency changes found.")
 		return nil
 	}
@@ -1479,15 +1484,15 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 		prevVulns = currentVulns
 	}
 
-	if len(entries) == 0 {
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerability changes found in recent commits.")
-		return nil
-	}
-
 	if format == formatJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return enc.Encode(nonNilSlice(entries))
+	}
+
+	if len(entries) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerability changes found in recent commits.")
+		return nil
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Vulnerability changes in %d commits:\n\n", len(entries))

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -145,15 +145,14 @@ func runWhere(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("searching files: %w", err)
 	}
 
-	if len(matches) == 0 {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Package %q not found in manifest files.\n", packageName)
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		return outputWhereJSON(cmd, matches)
 	default:
+		if len(matches) == 0 {
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Package %q not found in manifest files.\n", packageName)
+			return nil
+		}
 		return outputWhereText(cmd, matches, context > 0)
 	}
 }
@@ -219,7 +218,7 @@ func getContext(lines []string, lineIndex, contextLines int) []string {
 func outputWhereJSON(cmd *cobra.Command, matches []WhereMatch) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(matches)
+	return enc.Encode(nonNilSlice(matches))
 }
 
 func outputWhereText(cmd *cobra.Command, matches []WhereMatch, showContext bool) error {


### PR DESCRIPTION
## Summary
- keep `--format=json` responses as JSON arrays when result sets are empty
- preserve the existing empty-result messages for text output
- add regression coverage for empty `search`, `log`, and notes JSON output

## Testing
- [x] `go test ./cmd`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go tool golangci-lint run ./...`
- [x] manual reproduction with `git-pkgs search definitely-not-present --format=json`

Closes #233
