### PR TITLE
fix: reject unsupported output formats

### DIFF
--- a/cmd/blame.go
+++ b/cmd/blame.go
@@ -27,7 +27,10 @@ func addBlameCmd(parent *cobra.Command) {
 func runBlame(cmd *cobra.Command, args []string) error {
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	excludeBots, _ := cmd.Flags().GetBool("exclude-bots")
 
 	_, db, err := openDatabase()

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -1,7 +1,15 @@
 package cmd
 
-// Output format
-const formatJSON = "json"
+// Output formats
+const (
+	formatText     = "text"
+	formatJSON     = "json"
+	formatCSV      = "csv"
+	formatXML      = "xml"
+	formatSARIF    = "sarif"
+	formatSQL      = "sql"
+	formatMarkdown = "markdown"
+)
 
 // Git refs
 const refHEAD = "HEAD"

--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -45,7 +45,10 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -69,7 +69,10 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	toRef, _ := cmd.Flags().GetString("to")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	depType, _ := cmd.Flags().GetString("type")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	by, _ := cmd.Flags().GetString("by")
 	stat, _ := cmd.Flags().GetBool("stat")
 	summary, _ := cmd.Flags().GetBool("summary")

--- a/cmd/diff_file.go
+++ b/cmd/diff_file.go
@@ -24,7 +24,10 @@ func addDiffFileCmd(parent *cobra.Command) {
 
 func runDiffFile(cmd *cobra.Command, args []string) error {
 	defaultFilename, _ := cmd.Flags().GetString("filename")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	fromDeps, err := parseFile(args[0], defaultFilename)
 	if err != nil {

--- a/cmd/ecosystems.go
+++ b/cmd/ecosystems.go
@@ -100,7 +100,10 @@ func buildDetail(name string, cfg *ecosystemConfig, hasRegistry bool) EcosystemD
 }
 
 func runEcosystems(cmd *cobra.Command, args []string) error {
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	details := buildEcosystemDetails()
 
 	switch format {

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestUnsupportedFormatValuesAreRejected(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		formats string
+	}{
+		{name: "list", args: []string{"list", "--format", "yaml"}, formats: "text, json"},
+		{name: "search", args: []string{"search", "lodash", "--format", "yaml"}, formats: "text, json"},
+		{name: "sbom", args: []string{"sbom", "--format", "yaml"}, formats: "json, xml"},
+		{name: "licenses", args: []string{"licenses", "--format", "xml"}, formats: "text, json, csv"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := NewRootCmd()
+			var stdout, stderr bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stderr)
+			root.SetArgs(tt.args)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected unsupported format error")
+			}
+			want := "unsupported format " + quote(tt.args[len(tt.args)-1]) + "; supported formats: " + tt.formats
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), want)
+			}
+		})
+	}
+}
+
+func quote(value string) string {
+	return "\"" + value + "\""
+}

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -30,14 +31,10 @@ func TestUnsupportedFormatValuesAreRejected(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected unsupported format error")
 			}
-			want := "unsupported format " + quote(tt.args[len(tt.args)-1]) + "; supported formats: " + tt.formats
+			want := fmt.Sprintf("unsupported format %q; supported formats: %s", tt.args[len(tt.args)-1], tt.formats)
 			if !strings.Contains(err.Error(), want) {
 				t.Fatalf("error = %q, want substring %q", err.Error(), want)
 			}
 		})
 	}
-}
-
-func quote(value string) string {
-	return "\"" + value + "\""
 }

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -73,7 +73,10 @@ func runFreshness(cmd *cobra.Command, args []string) error {
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	limit, _ := cmd.Flags().GetInt("limit")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {

--- a/cmd/funding.go
+++ b/cmd/funding.go
@@ -60,7 +60,10 @@ func runFunding(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	showMissing, _ := cmd.Flags().GetBool("missing")
 
 	repo, err := git.OpenRepository(".")

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -76,7 +76,10 @@ func runHealth(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	includeAll, _ := cmd.Flags().GetBool("all")
 	threshold, _ := cmd.Flags().GetInt("threshold")
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -50,27 +50,19 @@ func addJSONHelpCommand(root *cobra.Command) {
 			if err != nil {
 				return err
 			}
-			switch format {
-			case "text", "":
-				target, err := helpTargetCommand(root, args)
-				if err != nil {
-					return err
-				}
-				target.SetOut(cmd.OutOrStdout())
-				target.SetErr(cmd.ErrOrStderr())
-				return target.Help()
-			case "json":
-				target, err := helpTargetCommand(root, args)
-				if err != nil {
-					return err
-				}
+			target, err := helpTargetCommand(root, args)
+			if err != nil {
+				return err
+			}
+			if format == formatJSON {
 				encoder := json.NewEncoder(cmd.OutOrStdout())
 				encoder.SetIndent("", "  ")
 				encoder.SetEscapeHTML(false)
 				return encoder.Encode(buildHelpCommandDoc(target))
-			default:
-				return fmt.Errorf("unsupported help format %q; supported formats: text, json", format)
 			}
+			target.SetOut(cmd.OutOrStdout())
+			target.SetErr(cmd.ErrOrStderr())
+			return target.Help()
 		},
 	}
 	helpCmd.Flags().StringP("format", "f", "text", "Output format: text, json")

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -46,7 +46,10 @@ func addJSONHelpCommand(root *cobra.Command) {
 		Short: "Help about any command",
 		Long:  "Help provides help for any command in the application.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			format, _ := cmd.Flags().GetString("format")
+			format, err := getFormatFlag(cmd, formatText, formatJSON)
+			if err != nil {
+				return err
+			}
 			switch format {
 			case "text", "":
 				target, err := helpTargetCommand(root, args)

--- a/cmd/help_test.go
+++ b/cmd/help_test.go
@@ -86,7 +86,7 @@ func TestHelpJSONRejectsUnsupportedFormat(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected unsupported format error")
 	}
-	if !strings.Contains(err.Error(), `unsupported help format "yaml"`) {
+	if !strings.Contains(err.Error(), `unsupported format "yaml"; supported formats: text, json`) {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -61,6 +62,17 @@ func nonNilSlice[T any](items []T) []T {
 		return []T{}
 	}
 	return items
+}
+
+func getFormatFlag(cmd *cobra.Command, allowed ...string) (string, error) {
+	format, _ := cmd.Flags().GetString("format")
+	for _, allowedFormat := range allowed {
+		if format == allowedFormat {
+			return format, nil
+		}
+	}
+
+	return "", fmt.Errorf("unsupported format %q; supported formats: %s", format, strings.Join(allowed, ", "))
 }
 
 func shortSHA(sha string) string {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -45,7 +45,10 @@ func runHistory(cmd *cobra.Command, args []string) error {
 	author, _ := cmd.Flags().GetString("author")
 	since, _ := cmd.Flags().GetString("since")
 	until, _ := cmd.Flags().GetString("until")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	excludeBots, _ := cmd.Flags().GetBool("exclude-bots")
 
 	repo, err := git.OpenRepository(".")

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -26,7 +26,10 @@ func addInfoCmd(parent *cobra.Command) {
 
 func runInfo(cmd *cobra.Command, args []string) error {
 	showEcosystems, _ := cmd.Flags().GetBool("ecosystems")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -64,7 +64,10 @@ func runIntegrity(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	driftOnly, _ := cmd.Flags().GetBool("drift")
 	checkRegistry, _ := cmd.Flags().GetBool("registry")
 

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -81,7 +81,10 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON, formatCSV)
+	if err != nil {
+		return err
+	}
 	allowList, _ := cmd.Flags().GetStringSlice("allow")
 	denyList, _ := cmd.Flags().GetStringSlice("deny")
 	flagPermissive, _ := cmd.Flags().GetBool("permissive")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,7 +35,10 @@ func runList(cmd *cobra.Command, args []string) error {
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	manifest, _ := cmd.Flags().GetString("manifest")
 	depType, _ := cmd.Flags().GetString("type")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -35,7 +35,10 @@ func runLog(cmd *cobra.Command, args []string) error {
 	since, _ := cmd.Flags().GetString("since")
 	until, _ := cmd.Flags().GetString("until")
 	limit, _ := cmd.Flags().GetInt("limit")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	excludeBots, _ := cmd.Flags().GetBool("exclude-bots")
 
 	repo, err := git.OpenRepository(".")

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -77,7 +77,10 @@ func runMaintainers(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	singleOnly, _ := cmd.Flags().GetBool("single")
 	includeTransitive, _ := cmd.Flags().GetBool("all")
 

--- a/cmd/notes.go
+++ b/cmd/notes.go
@@ -253,7 +253,10 @@ func loadNotesImportFile(path, defaultNamespace, defaultOrigin string) ([]databa
 func runNotesShow(cmd *cobra.Command, args []string) error {
 	purl := args[0]
 	namespace, _ := cmd.Flags().GetString("namespace")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {
@@ -283,7 +286,10 @@ func runNotesShow(cmd *cobra.Command, args []string) error {
 func runNotesList(cmd *cobra.Command, args []string) error {
 	namespace, _ := cmd.Flags().GetString("namespace")
 	purlFilter, _ := cmd.Flags().GetString("purl-filter")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {
@@ -347,7 +353,10 @@ func runNotesRemove(cmd *cobra.Command, args []string) error {
 
 func runNotesNamespaces(cmd *cobra.Command, args []string) error {
 	purlFilter, _ := cmd.Flags().GetString("purl-filter")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -50,7 +50,10 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	majorOnly, _ := cmd.Flags().GetBool("major")
 	minorUp, _ := cmd.Flags().GetBool("minor")
 	atDate, _ := cmd.Flags().GetString("at")

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -54,7 +54,10 @@ func runResolve(cmd *cobra.Command, args []string) error {
 	quiet, _ := cmd.Flags().GetBool("quiet")
 	extra, _ := cmd.Flags().GetStringArray("extra")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	dir, err := getWorkingDir()
 	if err != nil {

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -34,7 +34,10 @@ The SBOM includes all dependencies and optionally enriched license information.`
 
 func runSBOM(cmd *cobra.Command, args []string) error {
 	sbomType, _ := cmd.Flags().GetString("type")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatJSON, formatXML)
+	if err != nil {
+		return err
+	}
 	commit, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -36,7 +36,10 @@ type ColumnSchema struct {
 }
 
 func runSchema(cmd *cobra.Command, args []string) error {
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatSQL, formatJSON, formatMarkdown)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -28,7 +28,10 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	pattern := args[0]
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	directOnly, _ := cmd.Flags().GetBool("direct")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -33,7 +33,10 @@ func runShow(cmd *cobra.Command, args []string) error {
 	}
 
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {

--- a/cmd/stale.go
+++ b/cmd/stale.go
@@ -28,7 +28,10 @@ func runStale(cmd *cobra.Command, args []string) error {
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	days, _ := cmd.Flags().GetInt("days")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -35,7 +35,10 @@ func runStats(cmd *cobra.Command, args []string) error {
 	since, _ := cmd.Flags().GetString("since")
 	until, _ := cmd.Flags().GetString("until")
 	limit, _ := cmd.Flags().GetInt("limit")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	byAuthor, _ := cmd.Flags().GetBool("by-author")
 	excludeBots, _ := cmd.Flags().GetBool("exclude-bots")
 

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -34,7 +34,10 @@ func runTree(cmd *cobra.Command, args []string) error {
 	commitRef, _ := cmd.Flags().GetString("commit")
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	repo, db, err := openDatabase()
 	if err != nil {

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -39,7 +39,10 @@ Examples:
 func runUrls(cmd *cobra.Command, args []string) error {
 	pkg := args[0]
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	var purlType, name, version string
 

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -386,7 +386,10 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	severity, _ := cmd.Flags().GetString("severity")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON, formatSARIF)
+	if err != nil {
+		return err
+	}
 	live, _ := cmd.Flags().GetBool("live")
 	noSync, _ := cmd.Flags().GetBool("no-sync")
 
@@ -807,7 +810,10 @@ type VulnShowExposure struct {
 
 func runVulnsShow(cmd *cobra.Command, args []string) error {
 	vulnID := args[0]
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	ref, _ := cmd.Flags().GetString("ref")
 	branchName, _ := cmd.Flags().GetString("branch")
 
@@ -1010,7 +1016,10 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	severity, _ := cmd.Flags().GetString("severity")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	fromRef := "HEAD~1"
 	toRef := refHEAD
@@ -1207,7 +1216,10 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	branchName, _ := cmd.Flags().GetString("branch")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	severity, _ := cmd.Flags().GetString("severity")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	allTime, _ := cmd.Flags().GetBool("all-time")
 
 	_, db, err := openDatabase()
@@ -1373,7 +1385,10 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 	introducedOnly, _ := cmd.Flags().GetBool("introduced")
 	fixedOnly, _ := cmd.Flags().GetBool("fixed")
 	limit, _ := cmd.Flags().GetInt("limit")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	_, db, err := openDatabase()
 	if err != nil {
@@ -1541,7 +1556,10 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
 	branchName, _ := cmd.Flags().GetString("branch")
 	limit, _ := cmd.Flags().GetInt("limit")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	ecosystem, packageName, _, err := ParsePackageArg(args[0], ecosystemFlag)
 	if err != nil {
@@ -1686,7 +1704,10 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 	ref, _ := cmd.Flags().GetString("ref")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	severity, _ := cmd.Flags().GetString("severity")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	summary, _ := cmd.Flags().GetBool("summary")
 	allTime, _ := cmd.Flags().GetBool("all-time")
 
@@ -1908,7 +1929,10 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	severity, _ := cmd.Flags().GetString("severity")
 	limit, _ := cmd.Flags().GetInt("limit")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	summary, _ := cmd.Flags().GetBool("summary")
 
 	_, db, err := openDatabase()

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -48,7 +48,10 @@ func runWhere(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	context, _ := cmd.Flags().GetInt("context")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
 
 	repo, err := git.OpenRepository(".")

--- a/cmd/why.go
+++ b/cmd/why.go
@@ -26,7 +26,10 @@ func addWhyCmd(parent *cobra.Command) {
 
 func runWhy(cmd *cobra.Command, args []string) error {
 	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
-	format, _ := cmd.Flags().GetString("format")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	ecosystem, packageName, _, err := ParsePackageArg(args[0], ecosystemFlag)
 	if err != nil {


### PR DESCRIPTION
## Summary
- validate `--format` values before command execution
- return supported format lists for text/json, csv, XML, SARIF, SQL, and markdown outputs
- add regression coverage for unsupported format values

## Testing
- [x] `go test ./cmd -run 'TestUnsupportedFormatValuesAreRejected|TestHelpJSONRejectsUnsupportedFormat'`
- [x] `go test ./cmd`
- [x] `go test ./...`
- [x] `go build ./...`
- [x] `go tool golangci-lint run ./...`
- [x] `git diff --check`

Closes #234
