### PR TITLE
refactor: optimize first_added CTE by leveraging SQLite bare columns

### DIFF
--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1121,13 +1121,7 @@ func (db *DB) SearchDependencies(branchID int64, pattern, ecosystem string, dire
 	query += `
 		),
 		first_added AS (
-			SELECT dc.name, dc.ecosystem, MIN(c.committed_at) as first_seen,
-			       (SELECT c2.sha FROM dependency_changes dc2
-			        JOIN commits c2 ON c2.id = dc2.commit_id
-			        JOIN branch_commits bc2 ON bc2.commit_id = c2.id
-			        WHERE bc2.branch_id = ? AND dc2.change_type = 'added'
-			              AND dc2.name = dc.name AND dc2.ecosystem = dc.ecosystem
-			        ORDER BY c2.committed_at ASC LIMIT 1) as added_in
+			SELECT dc.name, dc.ecosystem, MIN(c.committed_at) as first_seen, c.sha as added_in
 			FROM dependency_changes dc
 			JOIN commits c ON c.id = dc.commit_id
 			JOIN branch_commits bc ON bc.commit_id = c.id
@@ -1149,7 +1143,7 @@ func (db *DB) SearchDependencies(branchID int64, pattern, ecosystem string, dire
 		LEFT JOIN last_changed lc ON lc.name = cd.name AND lc.ecosystem = cd.ecosystem
 		ORDER BY cd.name
 	`
-	args = append(args, branchID, branchID, branchID)
+	args = append(args, branchID, branchID)
 
 	rows, err := db.Query(query, args...)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR is a follow-up to #250 mentioned https://github.com/git-pkgs/git-pkgs/pull/250#pullrequestreview-4587402914_ here. It optimizes the `first_added` CTE in `internal/database/queries.go` by leveraging SQLite's "bare columns in an aggregate query" guarantee.

Instead of using a correlated subquery to fetch the `added_in` commit SHA, we can directly select `c.sha` alongside the `MIN(c.committed_at)` aggregate. Since we use `modernc.org/sqlite`, it is safe to rely on SQLite's guarantee that bare columns will come from the exact row that produced the minimum aggregate value.

This simplification:
- Removes the need for a correlated subquery.
- Reduces overall query complexity.
- Removes an extraneous parameter binding (`branchID`).
- Maintains the correct behavior (verified by our existing regression guards).

## Testing
- Verified `TestSearchDependenciesCrossEcosystem` and `TestSearchDependenciesAddedInSHA` continue to pass.
- Verified all other tests pass successfully with the updated query format.