### PR TITLE
docs: explain bare column usage in first_added CTE

### DIFF
--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1120,6 +1120,7 @@ func (db *DB) SearchDependencies(branchID int64, pattern, ecosystem string, dire
 
 	query += `
 		),
+		-- Note: c.sha alongside MIN(c.committed_at) relies on SQLite's bare-column-in-aggregate guarantee
 		first_added AS (
 			SELECT dc.name, dc.ecosystem, MIN(c.committed_at) as first_seen, c.sha as added_in
 			FROM dependency_changes dc


### PR DESCRIPTION
## Description

This PR adds a brief explanatory comment to the `first_added` CTE in `internal/database/queries.go` to clarify the behavior of selecting `c.sha` alongside the `MIN(c.committed_at)` aggregate function.

As noted in the review https://github.com/git-pkgs/git-pkgs/pull/252#pullrequestreview-4587887339, this query syntax can read like a bug to developers who are accustomed to other SQL dialects (like PostgreSQL or MySQL). The new comment explicitly documents that the query safely relies on SQLite's "bare column in aggregate" guarantee, which ensures that the bare `c.sha` column is drawn from the exact same row that produced the minimum `c.committed_at` value.

This is a documentation-only change; no query logic was modified. All tests continue to pass.