### PR TITLE
fix: preserve json output for empty results

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -82,19 +82,18 @@ func runHistory(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting history: %w", err)
 	}
 
-	if len(entries) == 0 {
-		if packageName != "" {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No history found for %q.\n", packageName)
-		} else {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependency changes found.")
-		}
-		return nil
-	}
-
 	switch format {
 	case formatJSON:
 		return outputHistoryJSON(cmd, entries)
 	default:
+		if len(entries) == 0 {
+			if packageName != "" {
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "No history found for %q.\n", packageName)
+			} else {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependency changes found.")
+			}
+			return nil
+		}
 		outputHistoryText(cmd, entries, packageName)
 		return nil
 	}
@@ -103,7 +102,7 @@ func runHistory(cmd *cobra.Command, args []string) error {
 func outputHistoryJSON(cmd *cobra.Command, entries []database.HistoryEntry) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(entries)
+	return enc.Encode(nonNilSlice(entries))
 }
 
 func capitalize(s string) string {

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -97,6 +97,9 @@ func runIntegrity(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
+		if format == formatJSON {
+			return outputIntegrityJSON(cmd, nil)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies with integrity hashes found.")
 		return nil
 	}
@@ -192,13 +195,13 @@ func runIntegrity(cmd *cobra.Command, args []string) error {
 func outputIntegrityJSON(cmd *cobra.Command, entries []IntegrityEntry) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(entries)
+	return enc.Encode(nonNilSlice(entries))
 }
 
 func outputDriftJSON(cmd *cobra.Command, drifts []IntegrityDrift) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(drifts)
+	return enc.Encode(nonNilSlice(drifts))
 }
 
 func outputIntegrityText(cmd *cobra.Command, entries []IntegrityEntry) {
@@ -263,6 +266,9 @@ func runRegistryCheck(cmd *cobra.Command, deps []database.Dependency, format str
 	}
 
 	if len(lockfileDeps) == 0 {
+		if format == formatJSON {
+			return outputRegistryMismatchJSON(cmd, nil, 0, 0)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No dependencies with integrity hashes found.")
 		return nil
 	}

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -124,6 +124,9 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(directDeps) == 0 {
+		if format == formatJSON {
+			return outputLicensesJSON(cmd, nil)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No direct dependencies found.")
 		return nil
 	}
@@ -758,7 +761,7 @@ func outputLicenseDriftText(cmd *cobra.Command, result *LicenseDriftResult) {
 func outputLicensesJSON(cmd *cobra.Command, infos []LicenseInfo) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(infos)
+	return enc.Encode(nonNilSlice(infos))
 }
 
 func outputLicensesCSV(cmd *cobra.Command, infos []LicenseInfo) error {

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -264,6 +264,16 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 		{name: "stale", args: []string{"stale", "--format", "json"}},
 		{name: "show", args: []string{"show", "HEAD", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "where", args: []string{"where", "definitely-not-present", "--format", "json"}},
+		{name: "history", args: []string{"history", "definitely-not-present", "--format", "json"}},
+		{name: "licenses", args: []string{"licenses", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "integrity", args: []string{"integrity", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "integrity drift", args: []string{"integrity", "--drift", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "vulns no lockfile deps", args: []string{"vulns", "scan", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "vulns no results", args: []string{"vulns", "scan", "--no-sync", "--format", "json"}},
+		{name: "vulns blame", args: []string{"vulns", "blame", "--format", "json"}},
+		{name: "vulns history", args: []string{"vulns", "history", "definitely-not-present", "--format", "json"}},
+		{name: "vulns exposure", args: []string{"vulns", "exposure", "--format", "json"}},
+		{name: "vulns praise", args: []string{"vulns", "praise", "--format", "json"}},
 	}
 
 	for _, tt := range tests {

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -415,6 +415,9 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
+		if format == formatJSON {
+			return outputVulnsJSON(cmd, nil)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found to scan.")
 		return nil
 	}
@@ -459,6 +462,9 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 	})
 
 	if len(vulnResults) == 0 {
+		if format == formatJSON {
+			return outputVulnsJSON(cmd, vulnResults)
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerabilities found.")
 		return nil
 	}
@@ -598,7 +604,7 @@ func scanCached(db *database.DB, deps []database.Dependency, minSeverity int) ([
 func outputVulnsJSON(cmd *cobra.Command, results []VulnResult) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetIndent("", "  ")
-	return enc.Encode(results)
+	return enc.Encode(nonNilSlice(results))
 }
 
 func outputVulnsText(cmd *cobra.Command, results []VulnResult) {
@@ -1249,6 +1255,11 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(filteredVulns) == 0 {
+		if format == formatJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]VulnBlameEntry{})
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerabilities found.")
 		return nil
 	}
@@ -1301,7 +1312,7 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	if format == formatJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return enc.Encode(nonNilSlice(entries))
 	}
 
 	// Group by author
@@ -1623,6 +1634,11 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(history) == 0 {
+		if format == formatJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]VulnHistoryEntry{})
+		}
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Package %q not found in commit history.\n", packageName)
 		return nil
 	}
@@ -1630,7 +1646,7 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 	if format == formatJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(history)
+		return enc.Encode(nonNilSlice(history))
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Vulnerability history for %s:\n\n", packageName)
@@ -1735,6 +1751,11 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(filteredVulns) == 0 {
+		if format == formatJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]VulnExposureEntry{})
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerabilities found.")
 		return nil
 	}
@@ -1798,7 +1819,7 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 	if format == formatJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return enc.Encode(nonNilSlice(entries))
 	}
 
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Vulnerability exposure (%d vulnerabilities):\n\n", len(entries))
@@ -1933,6 +1954,11 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(commits) < minCommitsForAnalysis {
+		if format == formatJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]VulnPraiseEntry{})
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Not enough commits to analyze vulnerability fixes.")
 		return nil
 	}
@@ -1992,6 +2018,11 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(entries) == 0 {
+		if format == formatJSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode([]VulnPraiseEntry{})
+		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerability fixes found in recent commits.")
 		return nil
 	}
@@ -2003,7 +2034,7 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	if format == formatJSON {
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(entries)
+		return enc.Encode(nonNilSlice(entries))
 	}
 
 	// Group by author


### PR DESCRIPTION
## Summary
- Return empty JSON arrays for empty-result paths in history, licenses, integrity, and vulnerability commands.
- Extend the empty-result JSON regression table to cover the remaining command branches.

## Testing
- [x] `go test ./cmd -run TestEmptyResultsRespectJSONFormat -count=1 -v`
- [x] `go test ./cmd -count=1`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go tool golangci-lint run ./...`
- [x] `git diff --check`

Closes #254
