### PR TITLE
Add configurable ecosystem allow/deny filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,8 +763,11 @@ git pkgs where lodash --include-submodules
 ```bash
 git config --add pkgs.ecosystems rubygems
 git config --add pkgs.ecosystems npm
+git config --add pkgs.ignoredEcosystems github-actions
 git pkgs info --ecosystems  # show enabled/disabled ecosystems
 ```
+
+`pkgs.ecosystems` is an allow-list. `pkgs.ignoredEcosystems` is a deny-list and takes precedence when both are configured. Re-run `git pkgs init --force` after changing these settings to rebuild an existing database with the new filter.
 
 **Ignored paths** let you skip directories or files from analysis:
 

--- a/cmd/analysis_test.go
+++ b/cmd/analysis_test.go
@@ -501,6 +501,38 @@ func TestSearchCommand(t *testing.T) {
 			t.Error("expected 'express' in search results")
 		}
 	})
+
+	t.Run("applies ignored ecosystems to existing database", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add deps")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+		setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "npm")
+
+		var stdout bytes.Buffer
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"search", "express", "--format", "json"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("search failed: %v", err)
+		}
+
+		var result []map[string]interface{}
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("failed to parse JSON output: %v", err)
+		}
+		if len(result) != 0 {
+			t.Fatalf("expected ignored npm search results to be hidden, got: %#v", result)
+		}
+	})
 }
 
 func TestTreeCommand(t *testing.T) {

--- a/cmd/bisect.go
+++ b/cmd/bisect.go
@@ -665,6 +665,10 @@ func checkBisectComplete(repo *git.Repository, mgr *bisect.Manager, state *bisec
 
 func printCulprit(cmd *cobra.Command, repo *git.Repository, sha string) error {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s is the first bad commit\n", sha)
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	// Get commit details
 	hash, err := repo.ResolveRevision(sha)
@@ -702,6 +706,9 @@ func printCulprit(cmd *cobra.Command, repo *git.Repository, sha string) error {
 		defer func() { _ = db.Close() }()
 
 		changes, err := db.GetChangesForCommit(sha)
+		if err == nil {
+			changes = filterChangesByEcosystemConfig(changes, ecosystemFilter.Allows)
+		}
 		if err == nil && len(changes) > 0 {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dependencies changed:")
 			for _, c := range changes {

--- a/cmd/bisect.go
+++ b/cmd/bisect.go
@@ -497,6 +497,12 @@ func doBisectStep(cmd *cobra.Command, repo *git.Repository, mgr *bisect.Manager,
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		_ = db.Close()
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+	filterOptions := databaseEcosystemFilterOptions(ecosystemFilter)
 
 	branchInfo, err := resolveBranch(db, "")
 	if err != nil {
@@ -511,10 +517,11 @@ func doBisectStep(cmd *cobra.Command, repo *git.Repository, mgr *bisect.Manager,
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Commits not indexed, running reindex...")
 
 		idx := indexer.New(repo, db, indexer.Options{
-			Branch:      branchInfo.Name,
-			Output:      io.Discard,
-			Quiet:       true,
-			Incremental: true,
+			Branch:          branchInfo.Name,
+			Output:          io.Discard,
+			Quiet:           true,
+			Incremental:     true,
+			EcosystemFilter: ecosystemFilter,
 		})
 		if _, err := idx.Run(); err != nil {
 			_ = db.Close()
@@ -542,12 +549,13 @@ func doBisectStep(cmd *cobra.Command, repo *git.Repository, mgr *bisect.Manager,
 	}
 
 	candidates, err := db.GetBisectCandidates(database.BisectOptions{
-		BranchID:     branchInfo.ID,
-		StartSHA:     oldestGood,
-		EndSHA:       state.BadRev,
-		Ecosystem:    state.Ecosystem,
-		PackageName:  state.Package,
-		ManifestPath: state.Manifest,
+		EcosystemFilterOptions: filterOptions,
+		BranchID:               branchInfo.ID,
+		StartSHA:               oldestGood,
+		EndSHA:                 state.BadRev,
+		Ecosystem:              state.Ecosystem,
+		PackageName:            state.Package,
+		ManifestPath:           state.Manifest,
 	})
 	if err != nil {
 		return fmt.Errorf("getting bisect candidates: %w", err)
@@ -613,6 +621,10 @@ func checkBisectComplete(repo *git.Repository, mgr *bisect.Manager, state *bisec
 	if err != nil {
 		return false, "", err
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return false, "", fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	oldestGood := state.GoodRevs[0]
 	for _, g := range state.GoodRevs[1:] {
@@ -624,12 +636,13 @@ func checkBisectComplete(repo *git.Repository, mgr *bisect.Manager, state *bisec
 	}
 
 	candidates, err := db.GetBisectCandidates(database.BisectOptions{
-		BranchID:     branchInfo.ID,
-		StartSHA:     oldestGood,
-		EndSHA:       state.BadRev,
-		Ecosystem:    state.Ecosystem,
-		PackageName:  state.Package,
-		ManifestPath: state.Manifest,
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		StartSHA:               oldestGood,
+		EndSHA:                 state.BadRev,
+		Ecosystem:              state.Ecosystem,
+		PackageName:            state.Package,
+		ManifestPath:           state.Manifest,
 	})
 	if err != nil {
 		return false, "", err

--- a/cmd/bisect_test.go
+++ b/cmd/bisect_test.go
@@ -547,6 +547,7 @@ func TestBisectDatabaseQueries(t *testing.T) {
 		if err := rootCmd.Execute(); err != nil {
 			t.Fatalf("failed to init git-pkgs: %v", err)
 		}
+		setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "npm")
 
 		// Start bisect with first and last dependency commit
 		firstSHA := getGitSHA(t, repoDir, "HEAD~2") // First dep commit
@@ -569,6 +570,9 @@ func TestBisectDatabaseQueries(t *testing.T) {
 		}
 		if !strings.Contains(stdout, "canonical@example.com") {
 			t.Errorf("expected canonical email from mailmap, got: %s", stdout)
+		}
+		if strings.Contains(stdout, "Dependencies changed:") {
+			t.Errorf("expected ignored npm changes to be hidden, got: %s", stdout)
 		}
 
 		// Clean up

--- a/cmd/bisect_test.go
+++ b/cmd/bisect_test.go
@@ -491,6 +491,19 @@ func TestBisectDatabaseQueries(t *testing.T) {
 		if len(candidates) != 0 {
 			t.Errorf("expected no rubygems candidates, got %d", len(candidates))
 		}
+
+		candidates, err = db.GetBisectCandidates(database.BisectOptions{
+			EcosystemFilterOptions: database.EcosystemFilterOptions{IgnoredEcosystems: []string{"npm"}},
+			BranchID:               branchInfo.ID,
+			StartSHA:               firstSHA,
+			EndSHA:                 headSHA,
+		})
+		if err != nil {
+			t.Fatalf("GetBisectCandidates failed: %v", err)
+		}
+		if len(candidates) != 0 {
+			t.Errorf("expected ignored npm candidates to be excluded, got %d", len(candidates))
+		}
 	})
 
 	t.Run("printCulprit resolves author via mailmap", func(t *testing.T) {

--- a/cmd/blame.go
+++ b/cmd/blame.go
@@ -33,7 +33,7 @@ func runBlame(cmd *cobra.Command, args []string) error {
 	}
 	excludeBots, _ := cmd.Flags().GetBool("exclude-bots")
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
@@ -43,11 +43,16 @@ func runBlame(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	entries, err := db.GetBlame(database.BlameOptions{
-		BranchID:    branchInfo.ID,
-		Ecosystem:   ecosystem,
-		ExcludeBots: excludeBots,
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		Ecosystem:              ecosystem,
+		ExcludeBots:            excludeBots,
 	})
 	if err != nil {
 		return fmt.Errorf("getting blame: %w", err)

--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -252,6 +252,47 @@ func TestInfoCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("ecosystems flag respects configured filter on existing database", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		addFileAndCommit(t, repoDir, "Gemfile", "source \"https://rubygems.org\"\ngem \"rails\", \"~> 7.0\"\n", "Add Gemfile")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "npm")
+
+		stdout, _, err := runCmd(t, "info", "--ecosystems")
+		if err != nil {
+			t.Fatalf("info --ecosystems failed: %v", err)
+		}
+		if strings.Contains(stdout, "npm") {
+			t.Fatalf("expected ignored npm ecosystem to be hidden, got: %s", stdout)
+		}
+		if !strings.Contains(stdout, "gem") && !strings.Contains(stdout, "rubygems") {
+			t.Fatalf("expected RubyGems ecosystem to remain visible, got: %s", stdout)
+		}
+
+		stdout, _, err = runCmd(t, "info", "--ecosystems", "-f", "json")
+		if err != nil {
+			t.Fatalf("info --ecosystems json failed: %v", err)
+		}
+		var ecosystems []map[string]interface{}
+		if err := json.Unmarshal([]byte(stdout), &ecosystems); err != nil {
+			t.Fatalf("failed to parse JSON: %v", err)
+		}
+		for _, ecosystem := range ecosystems {
+			if ecosystem["name"] == "npm" {
+				t.Fatalf("expected ignored npm ecosystem to be hidden from JSON, got: %#v", ecosystems)
+			}
+		}
+	})
+
 	t.Run("outputs json format", func(t *testing.T) {
 		repoDir := createTestRepo(t)
 		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -163,7 +163,12 @@ func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules
 	}
 
 	// Parse working tree directly
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return nil, fmt.Errorf("loading ecosystem config: %w", err)
+	}
 	a := analyzer.New()
+	a.SetEcosystemFilter(ecosystemFilter)
 	toChanges, err := a.DependenciesInWorkingDir(repo.WorkDir(), includeSubmodules)
 	if err != nil {
 		return nil, fmt.Errorf("reading working tree: %w", err)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -124,3 +124,16 @@ func filterByEcosystem(deps []database.Dependency, ecosystem string) []database.
 	}
 	return filtered
 }
+
+func filterDependenciesByConfig(deps []database.Dependency, allows func(string) bool) []database.Dependency {
+	if len(deps) == 0 {
+		return deps
+	}
+	filtered := make([]database.Dependency, 0, len(deps))
+	for _, d := range deps {
+		if allows(d.Ecosystem) {
+			filtered = append(filtered, d)
+		}
+	}
+	return filtered
+}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -125,19 +125,6 @@ func filterByEcosystem(deps []database.Dependency, ecosystem string) []database.
 	return filtered
 }
 
-func filterDependenciesByConfig(deps []database.Dependency, allows func(string) bool) []database.Dependency {
-	if len(deps) == 0 {
-		return deps
-	}
-	filtered := make([]database.Dependency, 0, len(deps))
-	for _, d := range deps {
-		if allows(d.Ecosystem) {
-			filtered = append(filtered, d)
-		}
-	}
-	return filtered
-}
-
 func filterSearchResultsByConfig(results []database.SearchResult, allows func(string) bool) []database.SearchResult {
 	if len(results) == 0 {
 		return results

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -140,7 +140,7 @@ func filterSearchResultsByConfig(results []database.SearchResult, allows func(st
 }
 
 func databaseEcosystemFilterOptions(filter config.EcosystemFilter) database.EcosystemFilterOptions {
-	allowed, ignored := filter.Values()
+	allowed, ignored := filter.StoredValues()
 	return database.EcosystemFilterOptions{
 		AllowedEcosystems: allowed,
 		IgnoredEcosystems: ignored,

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
@@ -136,4 +137,12 @@ func filterSearchResultsByConfig(results []database.SearchResult, allows func(st
 		}
 	}
 	return filtered
+}
+
+func databaseEcosystemFilterOptions(filter config.EcosystemFilter) database.EcosystemFilterOptions {
+	allowed, ignored := filter.Values()
+	return database.EcosystemFilterOptions{
+		AllowedEcosystems: allowed,
+		IgnoredEcosystems: ignored,
+	}
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -137,3 +137,16 @@ func filterDependenciesByConfig(deps []database.Dependency, allows func(string) 
 	}
 	return filtered
 }
+
+func filterSearchResultsByConfig(results []database.SearchResult, allows func(string) bool) []database.SearchResult {
+	if len(results) == 0 {
+		return results
+	}
+	filtered := make([]database.SearchResult, 0, len(results))
+	for _, r := range results {
+		if allows(r.Ecosystem) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
+}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -71,15 +71,20 @@ func runHistory(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting branch: %w", err)
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	entries, err := db.GetPackageHistory(database.HistoryOptions{
-		BranchID:    branchInfo.ID,
-		PackageName: packageName,
-		Ecosystem:   ecosystem,
-		Author:      author,
-		Since:       since,
-		Until:       until,
-		ExcludeBots: excludeBots,
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		PackageName:            packageName,
+		Ecosystem:              ecosystem,
+		Author:                 author,
+		Since:                  since,
+		Until:                  until,
+		ExcludeBots:            excludeBots,
 	})
 	if err != nil {
 		return fmt.Errorf("getting history: %w", err)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/spf13/cobra"
@@ -52,6 +53,12 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting info: %w", err)
 	}
 
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+	info.Ecosystems = filterEcosystemCountsByConfig(info.Ecosystems, ecosystemFilter)
+
 	// Get file size
 	if stat, err := os.Stat(dbPath); err == nil {
 		info.SizeBytes = stat.Size()
@@ -83,6 +90,19 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		outputInfoText(cmd, info)
 		return nil
 	}
+}
+
+func filterEcosystemCountsByConfig(ecosystems []database.EcosystemCount, filter config.EcosystemFilter) []database.EcosystemCount {
+	if filter.Empty() || len(ecosystems) == 0 {
+		return ecosystems
+	}
+	filtered := make([]database.EcosystemCount, 0, len(ecosystems))
+	for _, ecosystem := range ecosystems {
+		if filter.Allows(ecosystem.Name) {
+			filtered = append(filtered, ecosystem)
+		}
+	}
+	return filtered
 }
 
 func outputInfoJSON(cmd *cobra.Command, info *database.DatabaseInfo) error {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -77,6 +77,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = db.Close() }()
 
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+
 	idx := indexer.New(repo, db, indexer.Options{
 		Branch:           branch,
 		Since:            since,
@@ -84,6 +89,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		Quiet:            quiet,
 		BatchSize:        batchSize,
 		SnapshotInterval: snapshotInterval,
+		EcosystemFilter:  ecosystemFilter,
 	})
 
 	result, err := idx.Run()

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -73,6 +73,15 @@ func setGitUser(t *testing.T, repoDir, name, email string) {
 	}
 }
 
+func setGitConfig(t *testing.T, repoDir, key, value string) {
+	t.Helper()
+	gitCmd := exec.Command("git", "config", key, value)
+	gitCmd.Dir = repoDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("failed to set git config %s: %v", key, err)
+	}
+}
+
 func chdir(t *testing.T, dir string) func() {
 	t.Helper()
 	oldWd, err := os.Getwd()

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -261,6 +261,33 @@ func TestInitCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("normalizes go ecosystem alias in config", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "go.mod", "module example.com/test\n\ngo 1.23\n\nrequire github.com/stretchr/testify v1.9.0\n", "Add Go module")
+		setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "go")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		if _, _, err := runCmd(t, "init", "--no-hooks"); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+		if err != nil {
+			t.Fatalf("failed to open db: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		var count int
+		if err := db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem = 'golang'").Scan(&count); err != nil {
+			t.Fatalf("failed to count Go snapshots: %v", err)
+		}
+		if count != 0 {
+			t.Fatalf("expected go alias to exclude golang snapshots, got %d", count)
+		}
+	})
+
 	t.Run("fails outside git repo", func(t *testing.T) {
 		tmpDir := t.TempDir()
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -211,6 +211,47 @@ func TestInitCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("respects ignored ecosystem config", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+		addFileAndCommit(t, repoDir, "Gemfile", "source \"https://rubygems.org\"\ngem \"rails\", \"~> 7.0\"\n", "Add Gemfile")
+
+		gitCmd := exec.Command("git", "config", "--add", "pkgs.ignoredEcosystems", "npm")
+		gitCmd.Dir = repoDir
+		if err := gitCmd.Run(); err != nil {
+			t.Fatalf("failed to configure ignored ecosystem: %v", err)
+		}
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		if _, _, err := runCmd(t, "init", "--no-hooks"); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+		if err != nil {
+			t.Fatalf("failed to open db: %v", err)
+		}
+		defer func() { _ = db.Close() }()
+
+		var npmCount int
+		if err := db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem = 'npm'").Scan(&npmCount); err != nil {
+			t.Fatalf("failed to count npm snapshots: %v", err)
+		}
+		if npmCount != 0 {
+			t.Fatalf("expected no npm snapshots, got %d", npmCount)
+		}
+
+		var rubygemsCount int
+		if err := db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem = 'gem'").Scan(&rubygemsCount); err != nil {
+			t.Fatalf("failed to count gem snapshots: %v", err)
+		}
+		if rubygemsCount == 0 {
+			t.Fatal("expected gem snapshots to remain indexed")
+		}
+	})
+
 	t.Run("fails outside git repo", func(t *testing.T) {
 		tmpDir := t.TempDir()
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -252,12 +252,12 @@ func TestInitCommand(t *testing.T) {
 			t.Fatalf("expected no npm snapshots, got %d", npmCount)
 		}
 
-		var rubygemsCount int
-		if err := db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem = 'gem'").Scan(&rubygemsCount); err != nil {
-			t.Fatalf("failed to count gem snapshots: %v", err)
+		var rubyCount int
+		if err := db.QueryRow("SELECT COUNT(*) FROM dependency_snapshots WHERE ecosystem IN ('gem', 'rubygems')").Scan(&rubyCount); err != nil {
+			t.Fatalf("failed to count RubyGems snapshots: %v", err)
 		}
-		if rubygemsCount == 0 {
-			t.Fatal("expected gem snapshots to remain indexed")
+		if rubyCount == 0 {
+			t.Fatal("expected RubyGems snapshots to remain indexed")
 		}
 	})
 

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -61,15 +61,20 @@ func runLog(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting branch: %w", err)
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	commits, err := db.GetCommitsWithChanges(database.LogOptions{
-		BranchID:    branchInfo.ID,
-		Ecosystem:   ecosystem,
-		Author:      author,
-		Since:       since,
-		Until:       until,
-		Limit:       limit,
-		ExcludeBots: excludeBots,
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		Ecosystem:              ecosystem,
+		Author:                 author,
+		Since:                  since,
+		Until:                  until,
+		Limit:                  limit,
+		ExcludeBots:            excludeBots,
 	})
 	if err != nil {
 		return fmt.Errorf("getting commits: %w", err)

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -278,6 +278,47 @@ func TestHistoricalCommandsRespectIgnoredEcosystems(t *testing.T) {
 	}
 }
 
+func TestHistoricalCommandsRespectRubyGemsEcosystemAlias(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "Gemfile", "source \"https://rubygems.org\"\ngem \"rails\", \"~> 7.0\"\n", "Add Rails")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "rubygems")
+
+	stdout, stderr, err := runCmd(t, "log", "--format", "json")
+	if err != nil {
+		t.Fatalf("log failed: %v\nstderr: %s", err, stderr)
+	}
+	var logEntries []any
+	if err := json.Unmarshal([]byte(stdout), &logEntries); err != nil {
+		t.Fatalf("decode log JSON: %v\noutput: %s", err, stdout)
+	}
+	if len(logEntries) != 0 {
+		t.Fatalf("log exposed ignored RubyGems changes: %s", stdout)
+	}
+
+	stdout, stderr, err = runCmd(t, "stats", "--format", "json")
+	if err != nil {
+		t.Fatalf("stats failed: %v\nstderr: %s", err, stderr)
+	}
+	var stats struct {
+		CurrentDeps  int            `json:"current_deps"`
+		TotalChanges int            `json:"total_changes"`
+		DepsBySystem map[string]int `json:"deps_by_ecosystem"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &stats); err != nil {
+		t.Fatalf("decode stats JSON: %v\noutput: %s", err, stdout)
+	}
+	if stats.CurrentDeps != 0 || stats.TotalChanges != 0 || len(stats.DepsBySystem) != 0 {
+		t.Fatalf("stats exposed ignored RubyGems data: %s", stdout)
+	}
+}
+
 func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 	repoDir := createTestRepo(t)
 	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -239,6 +239,45 @@ func TestListCommand(t *testing.T) {
 	})
 }
 
+func TestHistoricalCommandsRespectIgnoredEcosystems(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "Gemfile", "source \"https://rubygems.org\"\ngem \"rails\", \"~> 7.0\"\n", "Add Rails")
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add npm dependencies")
+	addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Lock npm dependencies")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "npm")
+
+	for _, args := range [][]string{
+		{"log", "--limit", "1", "--format", "json"},
+		{"history", "--format", "json"},
+		{"stats", "--format", "json"},
+		{"blame", "--format", "json"},
+		{"stale", "--format", "json"},
+	} {
+		stdout, stderr, err := runCmd(t, args...)
+		if err != nil {
+			t.Fatalf("%s failed: %v\nstderr: %s", strings.Join(args, " "), err, stderr)
+		}
+		if strings.Contains(stdout, "express") || strings.Contains(stdout, "\"npm\"") {
+			t.Fatalf("%s exposed ignored npm data: %s", strings.Join(args, " "), stdout)
+		}
+	}
+
+	stdout, stderr, err := runCmd(t, "why", "express")
+	if err != nil {
+		t.Fatalf("why failed: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(stdout, "not found") {
+		t.Fatalf("why should hide ignored npm data, got: %s", stdout)
+	}
+}
+
 func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 	repoDir := createTestRepo(t)
 	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -71,11 +71,17 @@ func reindexBranch(cmd *cobra.Command, repo *git.Repository, db *database.DB, br
 	_, branchErr := db.GetBranch(branch)
 	incremental := branchErr == nil
 
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+
 	idx := indexer.New(repo, db, indexer.Options{
-		Branch:      branch,
-		Output:      cmd.OutOrStdout(),
-		Quiet:       quiet,
-		Incremental: incremental,
+		Branch:          branch,
+		Output:          cmd.OutOrStdout(),
+		Quiet:           quiet,
+		Incremental:     incremental,
+		EcosystemFilter: ecosystemFilter,
 	})
 
 	result, err := idx.Run()

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -33,11 +33,16 @@ func runSearch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branchInfo, err := db.GetDefaultBranch()
 	if err != nil {
@@ -48,6 +53,7 @@ func runSearch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("searching: %w", err)
 	}
+	results = filterSearchResultsByConfig(results, ecosystemFilter.Allows)
 
 	switch format {
 	case formatJSON:

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -48,6 +48,12 @@ func runShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+	changes = filterChangesByEcosystemConfig(changes, ecosystemFilter.Allows)
+
 	// Apply ecosystem filter
 	if ecosystem != "" {
 		var filtered []database.Change
@@ -70,6 +76,19 @@ func runShow(cmd *cobra.Command, args []string) error {
 		}
 		return outputShowText(cmd, changes)
 	}
+}
+
+func filterChangesByEcosystemConfig(changes []database.Change, allows func(string) bool) []database.Change {
+	if len(changes) == 0 {
+		return changes
+	}
+	filtered := make([]database.Change, 0, len(changes))
+	for _, c := range changes {
+		if allows(c.Ecosystem) {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
 }
 
 // getChangesForCommit returns the dependency changes introduced in a specific commit.

--- a/cmd/stale.go
+++ b/cmd/stale.go
@@ -33,7 +33,7 @@ func runStale(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
@@ -43,8 +43,17 @@ func runStale(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
-	entries, err := db.GetStaleDependencies(branchInfo.ID, ecosystem, days)
+	entries, err := db.GetStaleDependencies(database.StaleOptions{
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		Ecosystem:              ecosystem,
+		Days:                   days,
+	})
 	if err != nil {
 		return fmt.Errorf("getting stale dependencies: %w", err)
 	}

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -42,7 +42,7 @@ func runStats(cmd *cobra.Command, args []string) error {
 	byAuthor, _ := cmd.Flags().GetBool("by-author")
 	excludeBots, _ := cmd.Flags().GetBool("exclude-bots")
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
@@ -52,14 +52,19 @@ func runStats(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	opts := database.StatsOptions{
-		BranchID:    branchInfo.ID,
-		Ecosystem:   ecosystem,
-		Since:       since,
-		Until:       until,
-		Limit:       limit,
-		ExcludeBots: excludeBots,
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		Ecosystem:              ecosystem,
+		Since:                  since,
+		Until:                  until,
+		Limit:                  limit,
+		ExcludeBots:            excludeBots,
 	}
 
 	if byAuthor {

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +70,7 @@ func runTree(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("loading ecosystem config: %w", err)
 	}
-	deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
+	deps = git.FilterDependenciesByEcosystemConfig(deps, ecosystemFilter)
 
 	tree := buildTree(deps)
 

--- a/cmd/tree.go
+++ b/cmd/tree.go
@@ -65,6 +65,11 @@ func runTree(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, ecosystem)
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+	deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
 
 	tree := buildTree(deps)
 

--- a/cmd/urls.go
+++ b/cmd/urls.go
@@ -93,11 +93,16 @@ func outputUrlsText(cmd *cobra.Command, urls map[string]string) error {
 }
 
 func lookupPackage(name, ecosystem string) (purlType, pkgName, version string, err error) {
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return "", "", "", err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return "", "", "", fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branchInfo, err := db.GetDefaultBranch()
 	if err != nil {
@@ -108,6 +113,7 @@ func lookupPackage(name, ecosystem string) (purlType, pkgName, version string, e
 	if err != nil {
 		return "", "", "", fmt.Errorf("searching dependencies: %w", err)
 	}
+	results = filterSearchResultsByConfig(results, ecosystemFilter.Allows)
 
 	if len(results) == 0 {
 		if ecosystem != "" {

--- a/cmd/urls_test.go
+++ b/cmd/urls_test.go
@@ -180,6 +180,25 @@ func TestUrlsNameLookup(t *testing.T) {
 		}
 	})
 
+	t.Run("plain name lookup ignores configured ecosystems from existing database", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", `{"dependencies":{"lodash":"^4.17.21"}}`, "Add package.json")
+		addFileAndCommit(t, repoDir, "Gemfile", "source \"https://rubygems.org\"\ngem \"lodash\", \"~> 1.0\"\n", "Add Gemfile")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		if _, _, err := runCmd(t, "init"); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+		setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "npm")
+
+		urls := runUrlsJSON(t, "lodash")
+		if urls["purl"] != "pkg:gem/lodash" {
+			t.Errorf("expected ignored npm lookup to select rubygems purl, got: %q", urls["purl"])
+		}
+	})
+
 	t.Run("errors when package not found", func(t *testing.T) {
 		initRepoWithFiles(t, map[string]string{"package.json": packageJSON})
 

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -272,11 +272,16 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
 	quiet, _ := cmd.Flags().GetBool("quiet")
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -290,6 +295,7 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Filter to resolved lockfile deps
+	deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
 	deps = filterByEcosystem(deps, ecosystem)
 	var lockfileDeps []database.Dependency
 	for _, d := range deps {
@@ -1060,11 +1066,16 @@ func runVulnsShow(cmd *cobra.Command, args []string) error {
 }
 
 func analyzeVulnExposure(vuln *vulns.Vulnerability, ref, branchName string) (*VulnShowExposure, error) {
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return nil, fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -1076,6 +1087,7 @@ func analyzeVulnExposure(vuln *vulns.Vulnerability, ref, branchName string) (*Vu
 	if err != nil {
 		return nil, fmt.Errorf("getting dependencies: %w", err)
 	}
+	deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
 
 	// Check if any dependency is affected by this vulnerability
 	for _, dep := range deps {
@@ -1181,11 +1193,16 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 		toRef = args[1]
 	}
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -1193,12 +1210,12 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get vulnerabilities at both refs
-	fromVulns, err := getVulnsAtRef(db, branch.ID, fromRef, ecosystem)
+	fromVulns, err := getVulnsAtRef(db, branch.ID, fromRef, ecosystem, ecosystemFilter.Allows)
 	if err != nil {
 		return fmt.Errorf("getting vulns at %s: %w", fromRef, err)
 	}
 
-	toVulns, err := getVulnsAtRef(db, branch.ID, toRef, ecosystem)
+	toVulns, err := getVulnsAtRef(db, branch.ID, toRef, ecosystem, ecosystemFilter.Allows)
 	if err != nil {
 		return fmt.Errorf("getting vulns at %s: %w", toRef, err)
 	}
@@ -1271,12 +1288,15 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string) ([]VulnResult, error) {
+func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string, allows func(string) bool) ([]VulnResult, error) {
 	deps, err := db.GetDependenciesAtRef(ref, branchID)
 	if err != nil {
 		return nil, err
 	}
 
+	if allows != nil {
+		deps = filterDependenciesByConfig(deps, allows)
+	}
 	deps = filterByEcosystem(deps, ecosystem)
 
 	var lockfileDeps []database.Dependency
@@ -1296,7 +1316,7 @@ func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string) ([]Vu
 
 // getAllTimeVulns gets all vulnerabilities that have ever affected the codebase
 // by scanning commit history and collecting any vulnerability that was present.
-func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string) ([]VulnResult, error) {
+func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string, allows func(string) bool) ([]VulnResult, error) {
 	// Get recent commits with changes
 	const allTimeVulnsLimit = 100
 	commits, err := db.GetCommitsWithChanges(database.LogOptions{
@@ -1312,7 +1332,7 @@ func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string) ([]VulnR
 	seen := make(map[string]VulnResult) // key: vulnID:package:version
 
 	for _, c := range commits {
-		vulns, err := getVulnsAtRef(db, branchID, c.SHA, ecosystem)
+		vulns, err := getVulnsAtRef(db, branchID, c.SHA, ecosystem, allows)
 		if err != nil {
 			continue
 		}
@@ -1373,11 +1393,16 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	}
 	allTime, _ := cmd.Flags().GetBool("all-time")
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -1387,9 +1412,9 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	// Get vulnerabilities
 	var vulns []VulnResult
 	if allTime {
-		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem)
+		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter.Allows)
 	} else {
-		vulns, err = getVulnsAtRef(db, branch.ID, refHEAD, ecosystem)
+		vulns, err = getVulnsAtRef(db, branch.ID, refHEAD, ecosystem, ecosystemFilter.Allows)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)
@@ -1546,11 +1571,16 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -1592,7 +1622,7 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 
 	for i, c := range commits {
 		// Get vulns at this commit
-		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem)
+		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter.Allows)
 		if err != nil {
 			continue
 		}
@@ -1722,11 +1752,16 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -1750,6 +1785,7 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			continue
 		}
+		deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
 
 		// Find the package in deps
 		var pkgDep *database.Dependency
@@ -1872,11 +1908,16 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 	summary, _ := cmd.Flags().GetBool("summary")
 	allTime, _ := cmd.Flags().GetBool("all-time")
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -1892,9 +1933,9 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 	var vulns []VulnResult
 	if allTime {
 		// Get all historical vulnerabilities by scanning commit history
-		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem)
+		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter.Allows)
 	} else {
-		vulns, err = getVulnsAtRef(db, branch.ID, targetRef, ecosystem)
+		vulns, err = getVulnsAtRef(db, branch.ID, targetRef, ecosystem, ecosystemFilter.Allows)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)
@@ -2101,11 +2142,16 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	}
 	summary, _ := cmd.Flags().GetBool("summary")
 
-	_, db, err := openDatabase()
+	repo, db, err := openDatabase()
 	if err != nil {
 		return err
 	}
 	defer func() { _ = db.Close() }()
+
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	branch, err := resolveBranch(db, branchName)
 	if err != nil {
@@ -2143,7 +2189,7 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	var prevVulns []VulnResult
 
 	for i, c := range commits {
-		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem)
+		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter.Allows)
 		if err != nil {
 			continue
 		}

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
@@ -295,7 +296,7 @@ func runVulnsSync(cmd *cobra.Command, args []string) error {
 	}
 
 	// Filter to resolved lockfile deps
-	deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
+	deps = git.FilterDependenciesByEcosystemConfig(deps, ecosystemFilter)
 	deps = filterByEcosystem(deps, ecosystem)
 	var lockfileDeps []database.Dependency
 	for _, d := range deps {
@@ -1087,7 +1088,7 @@ func analyzeVulnExposure(vuln *vulns.Vulnerability, ref, branchName string) (*Vu
 	if err != nil {
 		return nil, fmt.Errorf("getting dependencies: %w", err)
 	}
-	deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
+	deps = git.FilterDependenciesByEcosystemConfig(deps, ecosystemFilter)
 
 	// Check if any dependency is affected by this vulnerability
 	for _, dep := range deps {
@@ -1210,12 +1211,12 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get vulnerabilities at both refs
-	fromVulns, err := getVulnsAtRef(db, branch.ID, fromRef, ecosystem, ecosystemFilter.Allows)
+	fromVulns, err := getVulnsAtRef(db, branch.ID, fromRef, ecosystem, ecosystemFilter)
 	if err != nil {
 		return fmt.Errorf("getting vulns at %s: %w", fromRef, err)
 	}
 
-	toVulns, err := getVulnsAtRef(db, branch.ID, toRef, ecosystem, ecosystemFilter.Allows)
+	toVulns, err := getVulnsAtRef(db, branch.ID, toRef, ecosystem, ecosystemFilter)
 	if err != nil {
 		return fmt.Errorf("getting vulns at %s: %w", toRef, err)
 	}
@@ -1288,15 +1289,13 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string, allows func(string) bool) ([]VulnResult, error) {
+func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string, filter config.EcosystemFilter) ([]VulnResult, error) {
 	deps, err := db.GetDependenciesAtRef(ref, branchID)
 	if err != nil {
 		return nil, err
 	}
 
-	if allows != nil {
-		deps = filterDependenciesByConfig(deps, allows)
-	}
+	deps = git.FilterDependenciesByEcosystemConfig(deps, filter)
 	deps = filterByEcosystem(deps, ecosystem)
 
 	var lockfileDeps []database.Dependency
@@ -1316,7 +1315,7 @@ func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string, allow
 
 // getAllTimeVulns gets all vulnerabilities that have ever affected the codebase
 // by scanning commit history and collecting any vulnerability that was present.
-func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string, allows func(string) bool) ([]VulnResult, error) {
+func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string, filter config.EcosystemFilter) ([]VulnResult, error) {
 	// Get recent commits with changes
 	const allTimeVulnsLimit = 100
 	commits, err := db.GetCommitsWithChanges(database.LogOptions{
@@ -1332,7 +1331,7 @@ func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string, allows f
 	seen := make(map[string]VulnResult) // key: vulnID:package:version
 
 	for _, c := range commits {
-		vulns, err := getVulnsAtRef(db, branchID, c.SHA, ecosystem, allows)
+		vulns, err := getVulnsAtRef(db, branchID, c.SHA, ecosystem, filter)
 		if err != nil {
 			continue
 		}
@@ -1412,9 +1411,9 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	// Get vulnerabilities
 	var vulns []VulnResult
 	if allTime {
-		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter.Allows)
+		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter)
 	} else {
-		vulns, err = getVulnsAtRef(db, branch.ID, refHEAD, ecosystem, ecosystemFilter.Allows)
+		vulns, err = getVulnsAtRef(db, branch.ID, refHEAD, ecosystem, ecosystemFilter)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)
@@ -1622,7 +1621,7 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 
 	for i, c := range commits {
 		// Get vulns at this commit
-		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter.Allows)
+		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter)
 		if err != nil {
 			continue
 		}
@@ -1785,7 +1784,7 @@ func runVulnsHistory(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			continue
 		}
-		deps = filterDependenciesByConfig(deps, ecosystemFilter.Allows)
+		deps = git.FilterDependenciesByEcosystemConfig(deps, ecosystemFilter)
 
 		// Find the package in deps
 		var pkgDep *database.Dependency
@@ -1933,9 +1932,9 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 	var vulns []VulnResult
 	if allTime {
 		// Get all historical vulnerabilities by scanning commit history
-		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter.Allows)
+		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter)
 	} else {
-		vulns, err = getVulnsAtRef(db, branch.ID, targetRef, ecosystem, ecosystemFilter.Allows)
+		vulns, err = getVulnsAtRef(db, branch.ID, targetRef, ecosystem, ecosystemFilter)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)
@@ -2189,7 +2188,7 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	var prevVulns []VulnResult
 
 	for i, c := range commits {
-		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter.Allows)
+		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter)
 		if err != nil {
 			continue
 		}

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/sarif"
@@ -400,6 +401,82 @@ func TestScanLiveWithSourceBatchErrorIdentifiesDependency(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q does not include %q", err, want)
 		}
+	}
+}
+
+func TestGetVulnsAtRefAppliesEcosystemConfig(t *testing.T) {
+	db := newTestDB(t)
+	branch, err := db.GetOrCreateBranch("main")
+	if err != nil {
+		t.Fatalf("GetOrCreateBranch: %v", err)
+	}
+
+	commitSHA := strings.Repeat("a", shaHashLen)
+	commit := database.CommitInfo{
+		SHA:         commitSHA,
+		Message:     "add deps",
+		AuthorName:  "Test User",
+		AuthorEmail: "test@example.com",
+		CommittedAt: time.Now(),
+	}
+	snapshots := []database.SnapshotInfo{
+		{
+			ManifestPath:   "package-lock.json",
+			Name:           "foo",
+			Ecosystem:      "npm",
+			PURL:           "pkg:npm/foo@1.0.0",
+			Requirement:    "1.0.0",
+			DependencyType: "runtime",
+			Integrity:      "sha512-test",
+		},
+		{
+			ManifestPath:   "Gemfile.lock",
+			Name:           "bar",
+			Ecosystem:      "rubygems",
+			PURL:           "pkg:gem/bar@1.0.0",
+			Requirement:    "1.0.0",
+			DependencyType: "runtime",
+			Integrity:      "sha256-test",
+		},
+	}
+	if err := db.StoreSnapshot(branch.ID, commit, snapshots); err != nil {
+		t.Fatalf("StoreSnapshot: %v", err)
+	}
+
+	vuln := database.Vulnerability{
+		ID:        "GHSA-ignored",
+		Severity:  "high",
+		Summary:   "ignored ecosystem vuln",
+		FetchedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := db.InsertVulnerability(vuln); err != nil {
+		t.Fatalf("InsertVulnerability: %v", err)
+	}
+	if err := db.InsertVulnerabilityPackage(database.VulnerabilityPackage{
+		VulnerabilityID:  vuln.ID,
+		Ecosystem:        "npm",
+		PackageName:      "foo",
+		AffectedVersions: "vers:npm/>=1.0.0|<2.0.0",
+		FixedVersions:    "2.0.0",
+	}); err != nil {
+		t.Fatalf("InsertVulnerabilityPackage: %v", err)
+	}
+
+	unfiltered, err := getVulnsAtRef(db, branch.ID, commitSHA, "", nil)
+	if err != nil {
+		t.Fatalf("getVulnsAtRef without filter: %v", err)
+	}
+	if len(unfiltered) != 1 || unfiltered[0].Package != "foo" {
+		t.Fatalf("expected seeded npm vuln before filtering, got: %#v", unfiltered)
+	}
+
+	filter := config.NewEcosystemFilter(nil, []string{"npm"})
+	results, err := getVulnsAtRef(db, branch.ID, commitSHA, "", filter.Allows)
+	if err != nil {
+		t.Fatalf("getVulnsAtRef: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected ignored npm vuln to be filtered, got: %#v", results)
 	}
 }
 

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -462,7 +462,7 @@ func TestGetVulnsAtRefAppliesEcosystemConfig(t *testing.T) {
 		t.Fatalf("InsertVulnerabilityPackage: %v", err)
 	}
 
-	unfiltered, err := getVulnsAtRef(db, branch.ID, commitSHA, "", nil)
+	unfiltered, err := getVulnsAtRef(db, branch.ID, commitSHA, "", config.NewEcosystemFilter(nil, nil))
 	if err != nil {
 		t.Fatalf("getVulnsAtRef without filter: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestGetVulnsAtRefAppliesEcosystemConfig(t *testing.T) {
 	}
 
 	filter := config.NewEcosystemFilter(nil, []string{"npm"})
-	results, err := getVulnsAtRef(db, branch.ID, commitSHA, "", filter.Allows)
+	results, err := getVulnsAtRef(db, branch.ID, commitSHA, "", filter)
 	if err != nil {
 		t.Fatalf("getVulnsAtRef: %v", err)
 	}

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -61,6 +61,10 @@ func runWhere(cmd *cobra.Command, args []string) error {
 	}
 
 	workDir := repo.WorkDir()
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	matcher := gitignore.New(workDir)
 
@@ -135,6 +139,9 @@ func runWhere(cmd *cobra.Command, args []string) error {
 
 		// Filter by ecosystem if specified
 		if ecosystem != "" && !strings.EqualFold(eco, ecosystem) {
+			return nil
+		}
+		if !ecosystemFilter.Allows(eco) {
 			return nil
 		}
 		fileMatches, err := searchFileForPackage(osRoot, osRel, relPath, packageName, eco, context)

--- a/cmd/why.go
+++ b/cmd/why.go
@@ -56,8 +56,17 @@ func runWhy(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("getting branch: %w", err)
 	}
+	ecosystemFilter, err := repo.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
-	result, err := db.GetWhy(branchInfo.ID, packageName, ecosystem)
+	result, err := db.GetWhy(database.WhyOptions{
+		EcosystemFilterOptions: databaseEcosystemFilterOptions(ecosystemFilter),
+		BranchID:               branchInfo.ID,
+		PackageName:            packageName,
+		Ecosystem:              ecosystem,
+	})
 	if err != nil {
 		return fmt.Errorf("getting why: %w", err)
 	}

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -67,6 +67,8 @@ For large repositories, the analyzer prefetches diffs using a single `git log` s
 
 `internal/analyzer` detects and parses manifest files using [git-pkgs/manifests](https://github.com/git-pkgs/manifests), which supports 35+ ecosystems including npm, RubyGems, PyPI, Cargo, Go modules, and more.
 
+Repository config can constrain analysis by ecosystem. `pkgs.ecosystems` acts as an allow-list, while `pkgs.ignoredEcosystems` acts as a deny-list that wins over the allow-list. Fresh indexing skips filtered ecosystems before writing changes or snapshots to SQLite.
+
 The analyzer maintains caches to avoid redundant work:
 
 - `blobCache` - parsed manifest contents keyed by git blob OID. If two commits have the same OID for a file, we parse it once.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/gitignore"
 	"github.com/git-pkgs/manifests"
 	"github.com/go-git/go-git/v5"
@@ -66,10 +67,11 @@ type cachedDiff struct {
 }
 
 type Analyzer struct {
-	blobCache map[string]*manifests.ParseResult
-	diffCache map[string]*cachedDiff
-	diffMu    sync.RWMutex
-	repoPath  string
+	blobCache       map[string]*manifests.ParseResult
+	diffCache       map[string]*cachedDiff
+	diffMu          sync.RWMutex
+	repoPath        string
+	ecosystemFilter config.EcosystemFilter
 }
 
 func New() *Analyzer {
@@ -82,6 +84,15 @@ func New() *Analyzer {
 // SetRepoPath sets the repository path for git shell commands.
 func (a *Analyzer) SetRepoPath(path string) {
 	a.repoPath = path
+}
+
+// SetEcosystemFilter limits which ecosystems are analyzed.
+func (a *Analyzer) SetEcosystemFilter(filter config.EcosystemFilter) {
+	a.ecosystemFilter = filter
+}
+
+func (a *Analyzer) allowsEcosystem(ecosystem string) bool {
+	return a.ecosystemFilter.Allows(ecosystem)
 }
 
 // ClearBlobCache replaces the blobCache with a fresh empty map,
@@ -296,6 +307,9 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 		if err != nil || deps == nil {
 			continue
 		}
+		if !a.allowsEcosystem(deps.Ecosystem) {
+			continue
+		}
 
 		// Merge integrity hashes from supplement files in same directory
 		supHashes := a.parseSupplementsInDir(tree, filepath.Dir(path))
@@ -342,6 +356,14 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 		}
 		afterDeps, err := a.parseManifestInTree(tree, path)
 		if err != nil || afterDeps == nil {
+			continue
+		}
+		if !a.allowsEcosystem(afterDeps.Ecosystem) {
+			for key := range result.Snapshot {
+				if key.ManifestPath == path {
+					delete(result.Snapshot, key)
+				}
+			}
 			continue
 		}
 
@@ -518,6 +540,9 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 		if deps == nil {
 			continue
 		}
+		if !a.allowsEcosystem(deps.Ecosystem) {
+			continue
+		}
 
 		for _, dep := range deps.Dependencies {
 			result.Changes = append(result.Changes, Change{
@@ -585,6 +610,9 @@ func (a *Analyzer) DependenciesAtCommit(commit *object.Commit) ([]Change, error)
 
 		result, err := a.parseManifestInTree(tree, f.Name)
 		if err != nil || result == nil {
+			return nil
+		}
+		if !a.allowsEcosystem(result.Ecosystem) {
 			return nil
 		}
 
@@ -772,6 +800,9 @@ func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool)
 
 		result, err := manifests.Parse(relPath, content)
 		if err != nil || result == nil {
+			return nil
+		}
+		if !a.allowsEcosystem(result.Ecosystem) {
 			return nil
 		}
 

--- a/internal/config/ecosystems.go
+++ b/internal/config/ecosystems.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/git-pkgs/purl"
+)
+
+const (
+	EcosystemsKey        = "pkgs.ecosystems"
+	IgnoredEcosystemsKey = "pkgs.ignoredEcosystems"
+)
+
+type EcosystemFilter struct {
+	allowed map[string]bool
+	ignored map[string]bool
+}
+
+func LoadEcosystemFilter(dir string) (EcosystemFilter, error) {
+	allowed, err := gitConfigValues(dir, EcosystemsKey)
+	if err != nil {
+		return EcosystemFilter{}, err
+	}
+	ignored, err := gitConfigValues(dir, IgnoredEcosystemsKey)
+	if err != nil {
+		return EcosystemFilter{}, err
+	}
+
+	return NewEcosystemFilter(allowed, ignored), nil
+}
+
+func NewEcosystemFilter(allowed, ignored []string) EcosystemFilter {
+	return EcosystemFilter{
+		allowed: ecosystemSet(allowed),
+		ignored: ecosystemSet(ignored),
+	}
+}
+
+func (f EcosystemFilter) Empty() bool {
+	return len(f.allowed) == 0 && len(f.ignored) == 0
+}
+
+func (f EcosystemFilter) Allows(ecosystem string) bool {
+	normalized := normalizeEcosystem(ecosystem)
+	if normalized == "" {
+		return true
+	}
+	if f.ignored[normalized] {
+		return false
+	}
+	return len(f.allowed) == 0 || f.allowed[normalized]
+}
+
+func gitConfigValues(dir, key string) ([]string, error) {
+	cmd := exec.Command("git", "config", "--get-all", key)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return splitConfigValues(string(out)), nil
+}
+
+func splitConfigValues(raw string) []string {
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == ',' || r == ' ' || r == '\t'
+	})
+	values := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if trimmed := strings.TrimSpace(field); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
+}
+
+func ecosystemSet(values []string) map[string]bool {
+	if len(values) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(values))
+	for _, value := range values {
+		if normalized := normalizeEcosystem(value); normalized != "" {
+			set[normalized] = true
+		}
+	}
+	return set
+}
+
+func normalizeEcosystem(ecosystem string) string {
+	ecosystem = strings.ToLower(strings.TrimSpace(ecosystem))
+	if ecosystem == "" {
+		return ""
+	}
+	if mapped := purl.PURLTypeToEcosystem(ecosystem); mapped != "" {
+		return strings.ToLower(mapped)
+	}
+	return ecosystem
+}

--- a/internal/config/ecosystems.go
+++ b/internal/config/ecosystems.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/git-pkgs/purl"
@@ -53,6 +54,26 @@ func (f EcosystemFilter) Allows(ecosystem string) bool {
 	return len(f.allowed) == 0 || f.allowed[normalized]
 }
 
+// Values returns the canonical ecosystem values configured for the allow and
+// ignore lists. The returned slices are sorted for deterministic query inputs.
+func (f EcosystemFilter) Values() (allowed, ignored []string) {
+	allowed = filterValues(f.allowed)
+	ignored = filterValues(f.ignored)
+	return allowed, ignored
+}
+
+func filterValues(values map[string]bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(values))
+	for value := range values {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
 func gitConfigValues(dir, key string) ([]string, error) {
 	cmd := exec.Command("git", "config", "--get-all", key)
 	cmd.Dir = dir
@@ -97,6 +118,9 @@ func normalizeEcosystem(ecosystem string) string {
 	ecosystem = strings.ToLower(strings.TrimSpace(ecosystem))
 	if ecosystem == "" {
 		return ""
+	}
+	if ecosystem == "go" {
+		return "golang"
 	}
 	if mapped := purl.PURLTypeToEcosystem(ecosystem); mapped != "" {
 		return strings.ToLower(mapped)

--- a/internal/config/ecosystems.go
+++ b/internal/config/ecosystems.go
@@ -62,6 +62,33 @@ func (f EcosystemFilter) Values() (allowed, ignored []string) {
 	return allowed, ignored
 }
 
+// StoredValues returns filter values expanded to include the PURL type aliases
+// that manifest parsers may persist in the database.
+func (f EcosystemFilter) StoredValues() (allowed, ignored []string) {
+	allowed = storedEcosystemValues(f.allowed)
+	ignored = storedEcosystemValues(f.ignored)
+	return allowed, ignored
+}
+
+func storedEcosystemValues(values map[string]bool) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	stored := make(map[string]bool, len(values)*2)
+	for ecosystem := range values {
+		stored[ecosystem] = true
+		purlType := purl.EcosystemToPURLType(ecosystem)
+		if purlType == "" {
+			continue
+		}
+		stored[purlType] = true
+		if mapped := purl.PURLTypeToEcosystem(purlType); mapped != "" {
+			stored[mapped] = true
+		}
+	}
+	return filterValues(stored)
+}
+
 func filterValues(values map[string]bool) []string {
 	if len(values) == 0 {
 		return nil

--- a/internal/config/ecosystems_test.go
+++ b/internal/config/ecosystems_test.go
@@ -60,6 +60,22 @@ func TestEcosystemFilterValues(t *testing.T) {
 	}
 }
 
+func TestEcosystemFilterStoredValuesIncludesPURLAliases(t *testing.T) {
+	filter := NewEcosystemFilter(
+		[]string{"rubygems", "packagist", "github-actions", "alpine", "arch"},
+		nil,
+	)
+	allowed, ignored := filter.StoredValues()
+
+	if len(ignored) != 0 {
+		t.Fatalf("ignored = %#v, want none", ignored)
+	}
+	want := "alpine,alpm,apk,arch,composer,gem,github-actions,githubactions,packagist,rubygems"
+	if got := strings.Join(allowed, ","); got != want {
+		t.Fatalf("allowed = %q, want %q", got, want)
+	}
+}
+
 func TestSplitConfigValues(t *testing.T) {
 	values := splitConfigValues("npm, rubygems\npypi\tgolang")
 

--- a/internal/config/ecosystems_test.go
+++ b/internal/config/ecosystems_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEcosystemFilterAllowsAllWhenUnset(t *testing.T) {
 	filter := NewEcosystemFilter(nil, nil)
@@ -34,6 +37,26 @@ func TestEcosystemFilterIgnoreListWins(t *testing.T) {
 	}
 	if !filter.Allows("rubygems") {
 		t.Fatal("expected rubygems to remain allowed")
+	}
+}
+
+func TestEcosystemFilterNormalizesGoAlias(t *testing.T) {
+	filter := NewEcosystemFilter(nil, []string{"go"})
+
+	if filter.Allows("golang") {
+		t.Fatal("expected go alias to exclude golang")
+	}
+}
+
+func TestEcosystemFilterValues(t *testing.T) {
+	filter := NewEcosystemFilter([]string{"rubygems", "npm"}, []string{"pypi", "go"})
+	allowed, ignored := filter.Values()
+
+	if got, want := strings.Join(allowed, ","), "npm,rubygems"; got != want {
+		t.Fatalf("allowed = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(ignored, ","), "golang,pypi"; got != want {
+		t.Fatalf("ignored = %q, want %q", got, want)
 	}
 }
 

--- a/internal/config/ecosystems_test.go
+++ b/internal/config/ecosystems_test.go
@@ -1,0 +1,52 @@
+package config
+
+import "testing"
+
+func TestEcosystemFilterAllowsAllWhenUnset(t *testing.T) {
+	filter := NewEcosystemFilter(nil, nil)
+
+	for _, ecosystem := range []string{"npm", "rubygems", "golang"} {
+		if !filter.Allows(ecosystem) {
+			t.Fatalf("expected unset filter to allow %s", ecosystem)
+		}
+	}
+}
+
+func TestEcosystemFilterAllowList(t *testing.T) {
+	filter := NewEcosystemFilter([]string{"npm", "gem"}, nil)
+
+	if !filter.Allows("npm") {
+		t.Fatal("expected npm to be allowed")
+	}
+	if !filter.Allows("rubygems") {
+		t.Fatal("expected gem alias to allow rubygems")
+	}
+	if filter.Allows("pypi") {
+		t.Fatal("expected pypi to be filtered")
+	}
+}
+
+func TestEcosystemFilterIgnoreListWins(t *testing.T) {
+	filter := NewEcosystemFilter([]string{"npm", "rubygems"}, []string{"npm"})
+
+	if filter.Allows("npm") {
+		t.Fatal("expected ignored npm to be filtered")
+	}
+	if !filter.Allows("rubygems") {
+		t.Fatal("expected rubygems to remain allowed")
+	}
+}
+
+func TestSplitConfigValues(t *testing.T) {
+	values := splitConfigValues("npm, rubygems\npypi\tgolang")
+
+	want := []string{"npm", "rubygems", "pypi", "golang"}
+	if len(values) != len(want) {
+		t.Fatalf("got %d values, want %d: %#v", len(values), len(want), values)
+	}
+	for i := range want {
+		if values[i] != want[i] {
+			t.Fatalf("value %d = %q, want %q", i, values[i], want[i])
+		}
+	}
+}

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -17,6 +17,53 @@ const (
 
 var knownBotAuthorNeedles = []string{"[bot]", "dependabot", "renovate", "greenkeeper"}
 
+// EcosystemFilterOptions narrows query results to ecosystems enabled for a
+// repository. An ignored ecosystem takes precedence over an allowed one.
+type EcosystemFilterOptions struct {
+	AllowedEcosystems []string
+	IgnoredEcosystems []string
+}
+
+func appendEcosystemConfigFilter(query string, args []any, column string, opts EcosystemFilterOptions) (string, []any) {
+	if len(opts.AllowedEcosystems) > 0 {
+		query += " AND (" + column + " IS NULL OR " + column + " = '' OR " + column + " IN (" + placeholders(len(opts.AllowedEcosystems)) + "))"
+		for _, ecosystem := range opts.AllowedEcosystems {
+			args = append(args, ecosystem)
+		}
+	}
+	if len(opts.IgnoredEcosystems) > 0 {
+		query += " AND (" + column + " IS NULL OR " + column + " = '' OR " + column + " NOT IN (" + placeholders(len(opts.IgnoredEcosystems)) + "))"
+		for _, ecosystem := range opts.IgnoredEcosystems {
+			args = append(args, ecosystem)
+		}
+	}
+	return query, args
+}
+
+func placeholders(count int) string {
+	return strings.TrimSuffix(strings.Repeat("?,", count), ",")
+}
+
+func ecosystemAllowed(ecosystem string, opts EcosystemFilterOptions) bool {
+	if ecosystem == "" {
+		return true
+	}
+	for _, ignored := range opts.IgnoredEcosystems {
+		if ecosystem == ignored {
+			return false
+		}
+	}
+	if len(opts.AllowedEcosystems) == 0 {
+		return true
+	}
+	for _, allowed := range opts.AllowedEcosystems {
+		if ecosystem == allowed {
+			return true
+		}
+	}
+	return false
+}
+
 // Change type values
 const (
 	changeAdded    = "added"
@@ -391,6 +438,7 @@ type CommitWithChanges struct {
 }
 
 type LogOptions struct {
+	EcosystemFilterOptions
 	BranchID    int64
 	Ecosystem   string
 	Author      string
@@ -428,6 +476,7 @@ func (db *DB) GetCommitsWithChanges(opts LogOptions) ([]CommitWithChanges, error
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.Author != "" {
 		query += " AND (c.author_name LIKE ? OR c.author_email LIKE ?)"
 		pattern := "%" + opts.Author + "%"
@@ -495,14 +544,14 @@ func (db *DB) GetCommitsWithChanges(opts LogOptions) ([]CommitWithChanges, error
 		return nil, err
 	}
 
-	// Assign changes to commits, filtering by ecosystem if needed
+	// Assign changes to commits, applying all ecosystem filters.
 	for i := range commits {
 		changes := allChanges[commits[i].SHA]
 
-		if opts.Ecosystem != "" {
+		if opts.Ecosystem != "" || len(opts.AllowedEcosystems) > 0 || len(opts.IgnoredEcosystems) > 0 {
 			var filtered []Change
 			for _, ch := range changes {
-				if ch.Ecosystem == opts.Ecosystem {
+				if (opts.Ecosystem == "" || ch.Ecosystem == opts.Ecosystem) && ecosystemAllowed(ch.Ecosystem, opts.EcosystemFilterOptions) {
 					filtered = append(filtered, ch)
 				}
 			}
@@ -531,6 +580,7 @@ type HistoryEntry struct {
 }
 
 type HistoryOptions struct {
+	EcosystemFilterOptions
 	BranchID    int64
 	PackageName string
 	Ecosystem   string
@@ -552,6 +602,7 @@ type BlameEntry struct {
 }
 
 type BlameOptions struct {
+	EcosystemFilterOptions
 	BranchID    int64
 	Ecosystem   string
 	ExcludeBots bool
@@ -604,6 +655,7 @@ type AuthorStats struct {
 }
 
 type StatsOptions struct {
+	EcosystemFilterOptions
 	BranchID    int64
 	Ecosystem   string
 	Since       string
@@ -619,6 +671,13 @@ type StaleEntry struct {
 	ManifestPath string `json:"manifest_path"`
 	LastChanged  string `json:"last_changed"`
 	DaysSince    int    `json:"days_since"`
+}
+
+type StaleOptions struct {
+	EcosystemFilterOptions
+	BranchID  int64
+	Ecosystem string
+	Days      int
 }
 
 type EcosystemCount struct {
@@ -700,7 +759,7 @@ func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
 	return info, nil
 }
 
-func (db *DB) GetStaleDependencies(branchID int64, ecosystem string, days int) ([]StaleEntry, error) {
+func (db *DB) GetStaleDependencies(opts StaleOptions) ([]StaleEntry, error) {
 	query := `
 		WITH current_deps AS (
 			SELECT DISTINCT ds.name, ds.ecosystem, ds.requirement, m.path, m.kind
@@ -726,21 +785,29 @@ func (db *DB) GetStaleDependencies(branchID int64, ecosystem string, days int) (
 		FROM current_deps cd
 		LEFT JOIN last_changed lc ON lc.name = cd.name AND lc.path = cd.path
 	`
-	args := []any{branchID, branchID, branchID}
+	args := []any{opts.BranchID, opts.BranchID, opts.BranchID}
 
-	if ecosystem != "" {
+	if opts.Ecosystem != "" {
 		query += " WHERE cd.ecosystem = ?"
-		args = append(args, ecosystem)
+		args = append(args, opts.Ecosystem)
+	}
+	whereStarted := opts.Ecosystem != ""
+	if len(opts.AllowedEcosystems) > 0 || len(opts.IgnoredEcosystems) > 0 {
+		if !whereStarted {
+			query += " WHERE 1=1"
+		}
+		query, args = appendEcosystemConfigFilter(query, args, "cd.ecosystem", opts.EcosystemFilterOptions)
+		whereStarted = true
 	}
 
-	if days > 0 {
-		if ecosystem != "" {
+	if opts.Days > 0 {
+		if whereStarted {
 			query += " AND"
 		} else {
 			query += " WHERE"
 		}
 		query += " CAST(julianday('now') - julianday(substr(COALESCE(lc.last_changed, '2000-01-01'), 1, 19)) AS INTEGER) >= ?"
-		args = append(args, days)
+		args = append(args, opts.Days)
 	}
 
 	query += " ORDER BY days_since DESC, cd.name"
@@ -825,6 +892,7 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.ExcludeBots {
 		query, args = appendExcludeBotsFilter(query, args)
 	}
@@ -855,20 +923,20 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 		`, opts.BranchID).Scan(&snapshotCommitID)
 	}
 	if snapshotCommitID.Valid {
-		err = db.QueryRow(`
-			SELECT COUNT(*) FROM dependency_snapshots WHERE commit_id = ?
-		`, snapshotCommitID.Int64).Scan(&stats.CurrentDeps)
+		query = "SELECT COUNT(*) FROM dependency_snapshots WHERE commit_id = ?"
+		args = []any{snapshotCommitID.Int64}
+		query, args = appendEcosystemConfigFilter(query, args, "ecosystem", opts.EcosystemFilterOptions)
+		err = db.QueryRow(query, args...).Scan(&stats.CurrentDeps)
 		if err != nil {
 			return nil, err
 		}
 
 		// Deps by ecosystem
-		rows, err := db.Query(`
-			SELECT ecosystem, COUNT(*)
-			FROM dependency_snapshots
-			WHERE commit_id = ?
-			GROUP BY ecosystem
-		`, snapshotCommitID.Int64)
+		query = "SELECT ecosystem, COUNT(*) FROM dependency_snapshots WHERE commit_id = ?"
+		args = []any{snapshotCommitID.Int64}
+		query, args = appendEcosystemConfigFilter(query, args, "ecosystem", opts.EcosystemFilterOptions)
+		query += " GROUP BY ecosystem"
+		rows, err := db.Query(query, args...)
 		if err != nil {
 			return nil, err
 		}
@@ -899,6 +967,7 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.ExcludeBots {
 		query, args = appendExcludeBotsFilter(query, args)
 	}
@@ -946,6 +1015,7 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.ExcludeBots {
 		query, args = appendExcludeBotsFilter(query, args)
 	}
@@ -987,6 +1057,7 @@ func (db *DB) GetStats(opts StatsOptions) (*Stats, error) {
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.ExcludeBots {
 		query, args = appendExcludeBotsFilter(query, args)
 	}
@@ -1041,6 +1112,7 @@ func (db *DB) GetAuthorStats(opts StatsOptions) ([]AuthorStats, error) {
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.ExcludeBots {
 		query, args = appendExcludeBotsFilter(query, args)
 	}
@@ -1177,7 +1249,14 @@ func (db *DB) SearchDependencies(branchID int64, pattern, ecosystem string, dire
 	return results, rows.Err()
 }
 
-func (db *DB) GetWhy(branchID int64, packageName, ecosystem string) (*WhyResult, error) {
+type WhyOptions struct {
+	EcosystemFilterOptions
+	BranchID    int64
+	PackageName string
+	Ecosystem   string
+}
+
+func (db *DB) GetWhy(opts WhyOptions) (*WhyResult, error) {
 	query := `
 		SELECT dc.name, dc.ecosystem, m.path, c.sha, c.message, c.author_name, c.author_email, c.committed_at
 		FROM dependency_changes dc
@@ -1186,12 +1265,13 @@ func (db *DB) GetWhy(branchID int64, packageName, ecosystem string) (*WhyResult,
 		JOIN manifests m ON m.id = dc.manifest_id
 		WHERE bc.branch_id = ? AND dc.change_type = 'added' AND dc.name = ?
 	`
-	args := []any{branchID, packageName}
+	args := []any{opts.BranchID, opts.PackageName}
 
-	if ecosystem != "" {
+	if opts.Ecosystem != "" {
 		query += filterEcosystem
-		args = append(args, ecosystem)
+		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 
 	query += " ORDER BY bc.position ASC LIMIT 1"
 
@@ -1267,6 +1347,7 @@ func (db *DB) GetBlame(opts BlameOptions) ([]BlameEntry, error) {
 		query += " AND cd.ecosystem = ?"
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "cd.ecosystem", opts.EcosystemFilterOptions)
 	if opts.ExcludeBots {
 		query, args = appendExcludeBotsFilter(query, args)
 	}
@@ -1328,6 +1409,7 @@ func (db *DB) GetPackageHistory(opts HistoryOptions) ([]HistoryEntry, error) {
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.Author != "" {
 		query += " AND (c.author_name LIKE ? OR c.author_email LIKE ?)"
 		pattern := "%" + opts.Author + "%"
@@ -2762,6 +2844,7 @@ type BisectCandidate struct {
 
 // BisectOptions specifies filters for finding bisect candidates.
 type BisectOptions struct {
+	EcosystemFilterOptions
 	BranchID     int64
 	StartSHA     string // good commit (older)
 	EndSHA       string // bad commit (newer)
@@ -2812,6 +2895,7 @@ func (db *DB) GetBisectCandidates(opts BisectOptions) ([]BisectCandidate, error)
 		query += filterEcosystem
 		args = append(args, opts.Ecosystem)
 	}
+	query, args = appendEcosystemConfigFilter(query, args, "dc.ecosystem", opts.EcosystemFilterOptions)
 	if opts.PackageName != "" {
 		query += " AND dc.name = ?"
 		args = append(args, opts.PackageName)

--- a/internal/git/query.go
+++ b/internal/git/query.go
@@ -90,7 +90,7 @@ func (r *Repository) GetDependenciesWithDB(commitRef, branchName string) ([]data
 		return nil, nil, fmt.Errorf("getting dependencies: %w", err)
 	}
 
-	deps = filterDependencies(deps, filter)
+	deps = FilterDependenciesByEcosystemConfig(deps, filter)
 	return deps, db, nil
 }
 
@@ -153,7 +153,7 @@ func (r *Repository) IndexCommitSnapshot(db *database.DB, branchID int64, sha st
 	return db.StoreSnapshot(branchID, commitInfo, snapshots)
 }
 
-func filterDependencies(deps []database.Dependency, filter config.EcosystemFilter) []database.Dependency {
+func FilterDependenciesByEcosystemConfig(deps []database.Dependency, filter config.EcosystemFilter) []database.Dependency {
 	if filter.Empty() || len(deps) == 0 {
 		return deps
 	}

--- a/internal/git/query.go
+++ b/internal/git/query.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/git-pkgs/git-pkgs/internal/analyzer"
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 )
 
@@ -31,6 +32,10 @@ func (r *Repository) GetDependenciesWithDB(commitRef, branchName string) ([]data
 		return nil, nil, fmt.Errorf("resolving %q: %w", commitRef, err)
 	}
 	sha := hash.String()
+	filter, err := r.EcosystemFilter()
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading ecosystem config: %w", err)
+	}
 
 	// Open or create database
 	dbPath := r.DatabasePath()
@@ -85,6 +90,7 @@ func (r *Repository) GetDependenciesWithDB(commitRef, branchName string) ([]data
 		return nil, nil, fmt.Errorf("getting dependencies: %w", err)
 	}
 
+	deps = filterDependencies(deps, filter)
 	return deps, db, nil
 }
 
@@ -107,7 +113,13 @@ func (r *Repository) IndexCommitSnapshot(db *database.DB, branchID int64, sha st
 		}
 	}
 
+	filter, err := r.EcosystemFilter()
+	if err != nil {
+		return fmt.Errorf("loading ecosystem config: %w", err)
+	}
+
 	a := analyzer.New()
+	a.SetEcosystemFilter(filter)
 	changes, err := a.DependenciesAtCommit(commit)
 	if err != nil {
 		return fmt.Errorf("analyzing commit: %w", err)
@@ -139,4 +151,17 @@ func (r *Repository) IndexCommitSnapshot(db *database.DB, branchID int64, sha st
 	}
 
 	return db.StoreSnapshot(branchID, commitInfo, snapshots)
+}
+
+func filterDependencies(deps []database.Dependency, filter config.EcosystemFilter) []database.Dependency {
+	if filter.Empty() || len(deps) == 0 {
+		return deps
+	}
+	filtered := make([]database.Dependency, 0, len(deps))
+	for _, dep := range deps {
+		if filter.Allows(dep.Ecosystem) {
+			filtered = append(filtered, dep)
+		}
+	}
+	return filtered
 }

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/mailmap"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
@@ -94,6 +95,10 @@ func (r *Repository) GitDir() string {
 
 func (r *Repository) WorkDir() string {
 	return r.workDir
+}
+
+func (r *Repository) EcosystemFilter() (config.EcosystemFilter, error) {
+	return config.LoadEcosystemFilter(r.workDir)
 }
 
 func (r *Repository) Head() (*plumbing.Reference, error) {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/mailmap"
@@ -21,10 +22,13 @@ import (
 const DatabaseFile = "pkgs.sqlite3"
 
 type Repository struct {
-	repo    *git.Repository
-	gitDir  string
-	workDir string
-	mailmap *mailmap.Mailmap
+	repo                *git.Repository
+	gitDir              string
+	workDir             string
+	mailmap             *mailmap.Mailmap
+	ecosystemFilter     config.EcosystemFilter
+	ecosystemFilterErr  error
+	ecosystemFilterOnce sync.Once
 }
 
 func OpenRepository(path string) (*Repository, error) {
@@ -98,7 +102,13 @@ func (r *Repository) WorkDir() string {
 }
 
 func (r *Repository) EcosystemFilter() (config.EcosystemFilter, error) {
-	return config.LoadEcosystemFilter(r.workDir)
+	r.ecosystemFilterOnce.Do(func() {
+		r.ecosystemFilter, r.ecosystemFilterErr = config.LoadEcosystemFilter(r.workDir)
+	})
+	if r.ecosystemFilterErr != nil {
+		return config.EcosystemFilter{}, r.ecosystemFilterErr
+	}
+	return r.ecosystemFilter, nil
 }
 
 func (r *Repository) Head() (*plumbing.Reference, error) {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/git-pkgs/git-pkgs/internal/analyzer"
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/git-pkgs/internal/progress"
@@ -21,6 +22,7 @@ type Options struct {
 	Incremental      bool // Use existing branch and continue from last SHA
 	BatchSize        int  // Commits to buffer before flushing (default 500)
 	SnapshotInterval int  // Store snapshot every N commits with changes (default 50)
+	EcosystemFilter  config.EcosystemFilter
 }
 
 type Result struct {
@@ -121,6 +123,7 @@ func (idx *Indexer) Run() (*Result, error) {
 			return nil, fmt.Errorf("getting last snapshot: %w", err)
 		}
 		snapshot = convertDBSnapshot(dbSnapshot)
+		snapshot = filterSnapshot(snapshot, idx.opts.EcosystemFilter)
 	} else {
 		if err := writer.CreateBranch(branch); err != nil {
 			return nil, fmt.Errorf("creating branch: %w", err)
@@ -140,6 +143,7 @@ func (idx *Indexer) Run() (*Result, error) {
 	idx.progress.Println("Analyzing %d commits on %s...", len(commits), branch)
 
 	idx.analyzer.SetRepoPath(idx.repo.WorkDir())
+	idx.analyzer.SetEcosystemFilter(idx.opts.EcosystemFilter)
 
 	refs := <-refCh
 	tagsBySHA := refs.tags
@@ -338,6 +342,19 @@ func (idx *Indexer) Run() (*Result, error) {
 	}
 
 	return result, nil
+}
+
+func filterSnapshot(snapshot analyzer.Snapshot, filter config.EcosystemFilter) analyzer.Snapshot {
+	if filter.Empty() {
+		return snapshot
+	}
+	filtered := make(analyzer.Snapshot, len(snapshot))
+	for key, entry := range snapshot {
+		if filter.Allows(entry.Ecosystem) {
+			filtered[key] = entry
+		}
+	}
+	return filtered
 }
 
 func convertDBSnapshot(dbSnapshot map[string]database.SnapshotInfo) analyzer.Snapshot {


### PR DESCRIPTION
Closes #256

## Summary

Adds repository-level ecosystem filtering through git config:

- `pkgs.ecosystems` acts as an allow-list
- `pkgs.ignoredEcosystems` acts as a deny-list
- deny-list entries take precedence when both are configured

The filter is applied during indexing so excluded ecosystems are not written to dependency changes/snapshots, and command-time dependency loading also filters existing database results.

## Changes

- Add ecosystem filter config loading from git config
- Apply filters in `init`, `reindex`, on-demand snapshots, working-tree diff, `where`, `show` and dependency query paths
- Document allow-list and deny-list behavior
- Add tests for config parsing and ignored ecosystem indexing behavior

## Testing

```bash
go test ./...
go tool golangci-lint run ./...
```