### PR TITLE
fix: preserve where context line numbers

### DIFF
--- a/cmd/where.go
+++ b/cmd/where.go
@@ -33,11 +33,12 @@ Shows the file path, line number, and content.`,
 }
 
 type WhereMatch struct {
-	FilePath   string   `json:"file_path"`
-	LineNumber int      `json:"line_number"`
-	Content    string   `json:"content"`
-	Context    []string `json:"context,omitempty"`
-	Ecosystem  string   `json:"ecosystem"`
+	FilePath         string   `json:"file_path"`
+	LineNumber       int      `json:"line_number"`
+	Content          string   `json:"content"`
+	Context          []string `json:"context,omitempty"`
+	ContextStartLine int      `json:"-"`
+	Ecosystem        string   `json:"ecosystem"`
 }
 
 func runWhere(cmd *cobra.Command, args []string) error {
@@ -197,14 +198,14 @@ func searchFileForPackage(root *os.Root, osRel, relPath, packageName, ecosystem 
 	// Add context if requested
 	if contextLines > 0 && len(matches) > 0 {
 		for i := range matches {
-			matches[i].Context = getContext(lines, matches[i].LineNumber-1, contextLines)
+			matches[i].Context, matches[i].ContextStartLine = getContext(lines, matches[i].LineNumber-1, contextLines)
 		}
 	}
 
 	return matches, scanner.Err()
 }
 
-func getContext(lines []string, lineIndex, contextLines int) []string {
+func getContext(lines []string, lineIndex, contextLines int) ([]string, int) {
 	start := lineIndex - contextLines
 	if start < 0 {
 		start = 0
@@ -215,7 +216,7 @@ func getContext(lines []string, lineIndex, contextLines int) []string {
 		end = len(lines)
 	}
 
-	return lines[start:end]
+	return lines[start:end], start + 1
 }
 
 func outputWhereJSON(cmd *cobra.Command, matches []WhereMatch) error {
@@ -228,7 +229,7 @@ func outputWhereText(cmd *cobra.Command, matches []WhereMatch, showContext bool)
 	for _, m := range matches {
 		if showContext && len(m.Context) > 0 {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", m.FilePath)
-			startLine := m.LineNumber - len(m.Context)/2
+			startLine := m.ContextStartLine
 			if startLine < 1 {
 				startLine = 1
 			}

--- a/cmd/where_test.go
+++ b/cmd/where_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestSearchFileForPackage(t *testing.T) {
@@ -93,6 +97,51 @@ func TestSearchFileForPackage(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestOutputWhereTextContextNearEOFUsesOriginalLineNumbers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "package.json")
+	content := strings.Join([]string{
+		"{",
+		`  "scripts": {},`,
+		`  "devDependencies": {},`,
+		`  "dependencies": {`,
+		`    "other": "1.0.0",`,
+		`    "left-pad": "1.3.0"`,
+	}, "\n")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = root.Close() }()
+
+	matches, err := searchFileForPackage(root, "package.json", "package.json", "left-pad", "npm", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := outputWhereText(cmd, matches, true); err != nil {
+		t.Fatal(err)
+	}
+
+	got := out.String()
+	if !strings.Contains(got, `     5:     "other": "1.0.0",`) {
+		t.Fatalf("context output did not preserve preceding line number:\n%s", got)
+	}
+	if !strings.Contains(got, `>    6:     "left-pad": "1.3.0"`) {
+		t.Fatalf("context output did not mark the matched line:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the original context start line when `where --context` builds a truncated window
- use that start line when printing text context so EOF-truncated output keeps the match marker on the correct source line
- add a regression test for a dependency match near the end of a manifest

## Testing
- [x] `go test ./cmd -run 'TestOutputWhereTextContextNearEOFUsesOriginalLineNumbers|TestSearchFileForPackage'`
- [x] `go test -v -race ./...`
- [x] `go build -v ./...`
- [x] `go tool golangci-lint run ./...`
- [x] `git diff --check`

Closes #258
