### PR TITLE
Fix schema SQL index output

### DIFF
--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -417,6 +417,17 @@ func TestSchemaCommand(t *testing.T) {
 		if !strings.Contains(stdout, "CREATE TABLE") {
 			t.Errorf("expected CREATE TABLE statements, got: %s", stdout)
 		}
+		if strings.Contains(stdout, "(...)") {
+			t.Errorf("expected real index columns in SQL output, got placeholder: %s", stdout)
+		}
+		for _, want := range []string{
+			"idx_branch_commits_unique ON branch_commits(branch_id, commit_id)",
+			"idx_branch_commits_position ON branch_commits(branch_id, position DESC)",
+		} {
+			if !strings.Contains(stdout, want) {
+				t.Errorf("expected index DDL containing %q, got: %s", want, stdout)
+			}
+		}
 	})
 
 	t.Run("outputs markdown format", func(t *testing.T) {

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -155,6 +155,10 @@ func getSchemaInfo(db *database.DB) ([]TableSchema, error) {
 				table.IndexSQL = append(table.IndexSQL, sql)
 			}
 		}
+		if err := idxRows.Err(); err != nil {
+			_ = idxRows.Close()
+			return nil, err
+		}
 		_ = idxRows.Close()
 
 		tables = append(tables, table)

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -23,9 +23,10 @@ func addSchemaCmd(parent *cobra.Command) {
 }
 
 type TableSchema struct {
-	Name    string         `json:"name"`
-	Columns []ColumnSchema `json:"columns"`
-	Indexes []string       `json:"indexes,omitempty"`
+	Name     string         `json:"name"`
+	Columns  []ColumnSchema `json:"columns"`
+	Indexes  []string       `json:"indexes,omitempty"`
+	IndexSQL []string       `json:"-"`
 }
 
 type ColumnSchema struct {
@@ -131,10 +132,12 @@ func getSchemaInfo(db *database.DB) ([]TableSchema, error) {
 		}
 		_ = colRows.Close()
 
-		// Get indexes
+		// Get indexes. Keep the public schema shape as index names, but retain
+		// SQLite's original DDL for SQL output.
 		idxRows, err := db.Query(`
-			SELECT name FROM sqlite_master
+			SELECT name, sql FROM sqlite_master
 			WHERE type='index' AND tbl_name=? AND name NOT LIKE 'sqlite_%'
+			ORDER BY name
 		`, tableName)
 		if err != nil {
 			return nil, err
@@ -142,11 +145,15 @@ func getSchemaInfo(db *database.DB) ([]TableSchema, error) {
 
 		for idxRows.Next() {
 			var name string
-			if err := idxRows.Scan(&name); err != nil {
+			var sql string
+			if err := idxRows.Scan(&name, &sql); err != nil {
 				_ = idxRows.Close()
 				return nil, err
 			}
 			table.Indexes = append(table.Indexes, name)
+			if sql != "" {
+				table.IndexSQL = append(table.IndexSQL, sql)
+			}
 		}
 		_ = idxRows.Close()
 
@@ -182,13 +189,21 @@ func outputSchemaSQL(cmd *cobra.Command, tables []TableSchema) {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), ");")
 		_, _ = fmt.Fprintln(cmd.OutOrStdout())
 
-		for _, idx := range table.Indexes {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "CREATE INDEX %s ON %s(...);\n", idx, table.Name)
+		for _, idxSQL := range table.IndexSQL {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), terminateSQL(idxSQL))
 		}
-		if len(table.Indexes) > 0 {
+		if len(table.IndexSQL) > 0 {
 			_, _ = fmt.Fprintln(cmd.OutOrStdout())
 		}
 	}
+}
+
+func terminateSQL(sql string) string {
+	sql = strings.TrimSpace(sql)
+	if strings.HasSuffix(sql, ";") {
+		return sql
+	}
+	return sql + ";"
 }
 
 func outputSchemaMarkdown(cmd *cobra.Command, tables []TableSchema) {


### PR DESCRIPTION
Fixes #259
## Summary

Fixes `git pkgs schema --format sql` so index definitions use real SQLite DDL instead of placeholder column lists like `(...)`.

## Changes

- Read index SQL from `sqlite_master.sql`
- Emit executable `CREATE INDEX` / `CREATE UNIQUE INDEX` statements in SQL output
- Keep JSON/text/markdown index output as index names
- Add regression coverage for real index columns in SQL output

## Testing

- `go test ./cmd -run TestSchemaCommand`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test ./...`
- `go tool golangci-lint run ./...`

