### PR TITLE
Use SARIF module for vulns output

### DIFF
--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -14,6 +14,7 @@ import (
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/sarif"
 	"github.com/git-pkgs/vers"
 	"github.com/git-pkgs/vulns"
 	"github.com/git-pkgs/vulns/osv"
@@ -652,68 +653,14 @@ func outputVulnsText(cmd *cobra.Command, results []VulnResult) {
 	}
 }
 
-// SARIF output for integration with CI/CD tools
-type SARIFReport struct {
-	Schema  string     `json:"$schema"`
-	Version string     `json:"version"`
-	Runs    []SARIFRun `json:"runs"`
-}
-
-type SARIFRun struct {
-	Tool    SARIFTool     `json:"tool"`
-	Results []SARIFResult `json:"results"`
-}
-
-type SARIFTool struct {
-	Driver SARIFDriver `json:"driver"`
-}
-
-type SARIFDriver struct {
-	Name           string      `json:"name"`
-	Version        string      `json:"version"`
-	InformationURI string      `json:"informationUri"`
-	Rules          []SARIFRule `json:"rules"`
-}
-
-type SARIFRule struct {
-	ID               string         `json:"id"`
-	ShortDescription SARIFMessage   `json:"shortDescription"`
-	FullDescription  SARIFMessage   `json:"fullDescription,omitempty"`
-	Help             SARIFMessage   `json:"help,omitempty"`
-	Properties       map[string]any `json:"properties,omitempty"`
-}
-
-type SARIFResult struct {
-	RuleID    string          `json:"ruleId"`
-	Level     string          `json:"level"`
-	Message   SARIFMessage    `json:"message"`
-	Locations []SARIFLocation `json:"locations,omitempty"`
-}
-
-type SARIFMessage struct {
-	Text string `json:"text"`
-}
-
-type SARIFLocation struct {
-	PhysicalLocation SARIFPhysicalLocation `json:"physicalLocation"`
-}
-
-type SARIFPhysicalLocation struct {
-	ArtifactLocation SARIFArtifactLocation `json:"artifactLocation"`
-}
-
-type SARIFArtifactLocation struct {
-	URI string `json:"uri"`
-}
-
 func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
-	report := SARIFReport{
-		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-		Version: "2.1.0",
-		Runs: []SARIFRun{
+	report := sarif.Log{
+		SchemaURI: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+		Version:   "2.1.0",
+		Runs: []sarif.Run{
 			{
-				Tool: SARIFTool{
-					Driver: SARIFDriver{
+				Tool: sarif.Tool{
+					Driver: sarif.ToolComponent{
 						Name:           "git-pkgs",
 						Version:        "1.0.0",
 						InformationURI: "https://github.com/git-pkgs/git-pkgs",
@@ -727,10 +674,10 @@ func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
 	for _, r := range results {
 		if !ruleMap[r.ID] {
 			ruleMap[r.ID] = true
-			rule := SARIFRule{
+			rule := sarif.ReportingDescriptor{
 				ID:               r.ID,
-				ShortDescription: SARIFMessage{Text: r.Summary},
-				Properties: map[string]any{
+				ShortDescription: sarif.MultiformatMessageString{Text: r.Summary},
+				Properties: sarif.PropertyBag{
 					"security-severity": severityToScore(r.Severity),
 				},
 			}
@@ -742,14 +689,14 @@ func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
 			level = "error"
 		}
 
-		result := SARIFResult{
+		result := sarif.Result{
 			RuleID:  r.ID,
 			Level:   level,
-			Message: SARIFMessage{Text: fmt.Sprintf("%s@%s is vulnerable", r.Package, r.Version)},
-			Locations: []SARIFLocation{
+			Message: sarif.Message{Text: fmt.Sprintf("%s@%s is vulnerable", r.Package, r.Version)},
+			Locations: []sarif.Location{
 				{
-					PhysicalLocation: SARIFPhysicalLocation{
-						ArtifactLocation: SARIFArtifactLocation{URI: r.ManifestPath},
+					PhysicalLocation: sarif.PhysicalLocation{
+						ArtifactLocation: sarif.ArtifactLocation{URI: r.ManifestPath},
 					},
 				},
 			},

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -654,32 +654,29 @@ func outputVulnsText(cmd *cobra.Command, results []VulnResult) {
 }
 
 func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
+	driver := sarif.NewToolComponent()
+	driver.Name = "git-pkgs"
+	driver.Version = "1.0.0"
+	driver.InformationURI = "https://github.com/git-pkgs/git-pkgs"
+	tool := sarif.NewTool()
+	tool.Driver = driver
+	run := sarif.NewRun()
+	run.Tool = tool
 	report := sarif.Log{
 		SchemaURI: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
 		Version:   "2.1.0",
-		Runs: []sarif.Run{
-			{
-				Tool: sarif.Tool{
-					Driver: sarif.ToolComponent{
-						Name:           "git-pkgs",
-						Version:        "1.0.0",
-						InformationURI: "https://github.com/git-pkgs/git-pkgs",
-					},
-				},
-			},
-		},
+		Runs:      []sarif.Run{run},
 	}
 
 	ruleMap := make(map[string]bool)
 	for _, r := range results {
 		if !ruleMap[r.ID] {
 			ruleMap[r.ID] = true
-			rule := sarif.ReportingDescriptor{
-				ID:               r.ID,
-				ShortDescription: sarif.MultiformatMessageString{Text: r.Summary},
-				Properties: sarif.PropertyBag{
-					"security-severity": severityToScore(r.Severity),
-				},
+			rule := sarif.NewReportingDescriptor()
+			rule.ID = r.ID
+			rule.ShortDescription = sarif.MultiformatMessageString{Text: r.Summary}
+			rule.Properties = sarif.PropertyBag{
+				"security-severity": severityToScore(r.Severity),
 			}
 			report.Runs[0].Tool.Driver.Rules = append(report.Runs[0].Tool.Driver.Rules, rule)
 		}
@@ -689,17 +686,16 @@ func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
 			level = "error"
 		}
 
-		result := sarif.Result{
-			RuleID:  r.ID,
-			Level:   level,
-			Message: sarif.Message{Text: fmt.Sprintf("%s@%s is vulnerable", r.Package, r.Version)},
-			Locations: []sarif.Location{
-				{
-					PhysicalLocation: sarif.PhysicalLocation{
-						ArtifactLocation: sarif.ArtifactLocation{URI: r.ManifestPath},
-					},
-				},
-			},
+		artifactLocation := sarif.NewArtifactLocation()
+		artifactLocation.URI = r.ManifestPath
+		location := sarif.NewLocation()
+		location.PhysicalLocation = sarif.PhysicalLocation{ArtifactLocation: artifactLocation}
+		result := sarif.NewResult()
+		result.RuleID = r.ID
+		result.Level = level
+		result.Message = sarif.Message{Text: fmt.Sprintf("%s@%s is vulnerable", r.Package, r.Version)}
+		result.Locations = []sarif.Location{
+			location,
 		}
 		report.Runs[0].Results = append(report.Runs[0].Results, result)
 	}

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -656,19 +656,11 @@ func outputVulnsText(cmd *cobra.Command, results []VulnResult) {
 func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
 	driver := sarif.NewToolComponent()
 	driver.Name = "git-pkgs"
-	driver.Version = "1.0.0"
+	driver.Version = version
 	driver.InformationURI = "https://github.com/git-pkgs/git-pkgs"
-	tool := sarif.NewTool()
-	tool.Driver = driver
-	run := sarif.NewRun()
-	run.Tool = tool
-	report := sarif.Log{
-		SchemaURI: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-		Version:   "2.1.0",
-		Runs:      []sarif.Run{run},
-	}
 
 	ruleMap := make(map[string]bool)
+	run := sarif.NewRun()
 	for _, r := range results {
 		if !ruleMap[r.ID] {
 			ruleMap[r.ID] = true
@@ -678,7 +670,7 @@ func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
 			rule.Properties = sarif.PropertyBag{
 				"security-severity": severityToScore(r.Severity),
 			}
-			report.Runs[0].Tool.Driver.Rules = append(report.Runs[0].Tool.Driver.Rules, rule)
+			driver.Rules = append(driver.Rules, rule)
 		}
 
 		level := "warning"
@@ -694,10 +686,17 @@ func outputVulnsSARIF(cmd *cobra.Command, results []VulnResult) error {
 		result.RuleID = r.ID
 		result.Level = level
 		result.Message = sarif.Message{Text: fmt.Sprintf("%s@%s is vulnerable", r.Package, r.Version)}
-		result.Locations = []sarif.Location{
-			location,
-		}
-		report.Runs[0].Results = append(report.Runs[0].Results, result)
+		result.Locations = []sarif.Location{location}
+		run.Results = append(run.Results, result)
+	}
+
+	tool := sarif.NewTool()
+	tool.Driver = driver
+	run.Tool = tool
+	report := sarif.Log{
+		SchemaURI: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+		Version:   "2.1.0",
+		Runs:      []sarif.Run{run},
 	}
 
 	enc := json.NewEncoder(cmd.OutOrStdout())

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -433,12 +433,12 @@ func TestOutputVulnsSARIF(t *testing.T) {
 	}
 	for i, result := range log.Runs[0].Results {
 		if result.RuleIndex != -1 || result.Rank != -1 {
-			t.Fatalf("result %d has serialized defaults: rule index %d, rank %v", i, result.RuleIndex, result.Rank)
+			t.Fatalf("result %d lost constructor defaults: ruleIndex=%d rank=%v", i, result.RuleIndex, result.Rank)
 		}
 		location := result.Locations[0]
 		if location.ID != -1 || location.PhysicalLocation.ArtifactLocation.Index != -1 {
 			t.Fatalf(
-				"result %d location has serialized defaults: location id %d, artifact index %d",
+				"result %d location lost constructor defaults: id=%d artifactIndex=%d",
 				i,
 				location.ID,
 				location.PhysicalLocation.ArtifactLocation.Index,

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/sarif"
 	"github.com/git-pkgs/vulns"
+	"github.com/spf13/cobra"
 )
 
 // mockSource implements vulns.Source for testing.
@@ -370,6 +372,50 @@ func TestBuildVersRange(t *testing.T) {
 				t.Errorf("buildVersRange() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestOutputVulnsSARIF(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+
+	results := []VulnResult{
+		{
+			ID:           "GHSA-0001",
+			Summary:      "Example vulnerability",
+			Severity:     "high",
+			Package:      "lodash",
+			Version:      "4.17.20",
+			ManifestPath: "package-lock.json",
+		},
+	}
+
+	if err := outputVulnsSARIF(cmd, results); err != nil {
+		t.Fatalf("outputVulnsSARIF() error = %v", err)
+	}
+
+	log, err := sarif.Parse(buf.Bytes())
+	if err != nil {
+		t.Fatalf("sarif.Parse() error = %v\n%s", err, buf.String())
+	}
+	if err := sarif.Validate(log); err != nil {
+		t.Fatalf("sarif.Validate() error = %v\n%s", err, buf.String())
+	}
+	if log.Version != "2.1.0" {
+		t.Fatalf("Version = %q, want 2.1.0", log.Version)
+	}
+	if got := log.Runs[0].Tool.Driver.Name; got != "git-pkgs" {
+		t.Fatalf("Tool.Driver.Name = %q, want git-pkgs", got)
+	}
+	if got := log.Runs[0].Tool.Driver.Rules[0].ID; got != "GHSA-0001" {
+		t.Fatalf("rule ID = %q, want GHSA-0001", got)
+	}
+	if got := log.Runs[0].Results[0].Level; got != "error" {
+		t.Fatalf("result level = %q, want error", got)
+	}
+	if got := log.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI; got != "package-lock.json" {
+		t.Fatalf("location URI = %q, want package-lock.json", got)
 	}
 }
 

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -389,6 +389,14 @@ func TestOutputVulnsSARIF(t *testing.T) {
 			Version:      "4.17.20",
 			ManifestPath: "package-lock.json",
 		},
+		{
+			ID:           "GHSA-0002",
+			Summary:      "Another vulnerability",
+			Severity:     "medium",
+			Package:      "express",
+			Version:      "4.18.1",
+			ManifestPath: "package-lock.json",
+		},
 	}
 
 	if err := outputVulnsSARIF(cmd, results); err != nil {
@@ -411,11 +419,31 @@ func TestOutputVulnsSARIF(t *testing.T) {
 	if got := log.Runs[0].Tool.Driver.Rules[0].ID; got != "GHSA-0001" {
 		t.Fatalf("rule ID = %q, want GHSA-0001", got)
 	}
+	if got := log.Runs[0].Tool.Driver.Rules[1].ID; got != "GHSA-0002" {
+		t.Fatalf("second rule ID = %q, want GHSA-0002", got)
+	}
 	if got := log.Runs[0].Results[0].Level; got != "error" {
 		t.Fatalf("result level = %q, want error", got)
 	}
+	if got := log.Runs[0].Results[1].Level; got != "warning" {
+		t.Fatalf("second result level = %q, want warning", got)
+	}
 	if got := log.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI; got != "package-lock.json" {
 		t.Fatalf("location URI = %q, want package-lock.json", got)
+	}
+	for i, result := range log.Runs[0].Results {
+		if result.RuleIndex != -1 || result.Rank != -1 {
+			t.Fatalf("result %d has serialized defaults: rule index %d, rank %v", i, result.RuleIndex, result.Rank)
+		}
+		location := result.Locations[0]
+		if location.ID != -1 || location.PhysicalLocation.ArtifactLocation.Index != -1 {
+			t.Fatalf(
+				"result %d location has serialized defaults: location id %d, artifact index %d",
+				i,
+				location.ID,
+				location.PhysicalLocation.ArtifactLocation.Index,
+			)
+		}
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/git-pkgs/purl v0.1.13
 	github.com/git-pkgs/registries v0.6.2
 	github.com/git-pkgs/resolve v0.2.2
+	github.com/git-pkgs/sarif v0.1.0
 	github.com/git-pkgs/sbom v0.1.2
 	github.com/git-pkgs/spdx v0.1.4
 	github.com/git-pkgs/vers v0.2.6

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/git-pkgs/purl v0.1.13
 	github.com/git-pkgs/registries v0.6.2
 	github.com/git-pkgs/resolve v0.2.2
-	github.com/git-pkgs/sarif v0.1.0
+	github.com/git-pkgs/sarif v0.1.1
 	github.com/git-pkgs/sbom v0.1.2
 	github.com/git-pkgs/spdx v0.1.4
 	github.com/git-pkgs/vers v0.2.6

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/git-pkgs/registries v0.6.2 h1:26G5zW6Q7x1CSfNkaEqEjRMJiA4JwfdKOCJ7Qm+
 github.com/git-pkgs/registries v0.6.2/go.mod h1:GR0Bu6nC3NQe6f7lfDoEVqAnoQkMocf4M98B12a7B3E=
 github.com/git-pkgs/resolve v0.2.2 h1:jjr6qa/8b/edg3tub5WYyYV04OpfWCuGZzgVYnfGl3I=
 github.com/git-pkgs/resolve v0.2.2/go.mod h1:KT894HOGMudjhSUWGHW1mC4r01eBaVaf0ujYhEHPMvo=
+github.com/git-pkgs/sarif v0.1.0 h1:ghUtzYaG/VDxBNF7aDI7EeT5mke4admqd2cqXcNzG1Q=
+github.com/git-pkgs/sarif v0.1.0/go.mod h1:NGg7Ft2+nvR0CBo+Ya9oSX+Yh/p1d7FVyhPe2/0v9V4=
 github.com/git-pkgs/sbom v0.1.2 h1:18LkdFRBG8jkWf5cclGvwam5GwM3o3lK9/qUmup15+0=
 github.com/git-pkgs/sbom v0.1.2/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/spdx v0.1.4 h1:eQ0waEV3uUeItpWAOvdN1K1rL9hTgsU7fF74r1mDXMs=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ github.com/git-pkgs/registries v0.6.2 h1:26G5zW6Q7x1CSfNkaEqEjRMJiA4JwfdKOCJ7Qm+
 github.com/git-pkgs/registries v0.6.2/go.mod h1:GR0Bu6nC3NQe6f7lfDoEVqAnoQkMocf4M98B12a7B3E=
 github.com/git-pkgs/resolve v0.2.2 h1:jjr6qa/8b/edg3tub5WYyYV04OpfWCuGZzgVYnfGl3I=
 github.com/git-pkgs/resolve v0.2.2/go.mod h1:KT894HOGMudjhSUWGHW1mC4r01eBaVaf0ujYhEHPMvo=
-github.com/git-pkgs/sarif v0.1.0 h1:ghUtzYaG/VDxBNF7aDI7EeT5mke4admqd2cqXcNzG1Q=
-github.com/git-pkgs/sarif v0.1.0/go.mod h1:NGg7Ft2+nvR0CBo+Ya9oSX+Yh/p1d7FVyhPe2/0v9V4=
 github.com/git-pkgs/sarif v0.1.1 h1:Jc5N+6ezJqbVjGZlPX9i8ar+OUsT+LX06nsM6Xjrq1c=
 github.com/git-pkgs/sarif v0.1.1/go.mod h1:NGg7Ft2+nvR0CBo+Ya9oSX+Yh/p1d7FVyhPe2/0v9V4=
 github.com/git-pkgs/sbom v0.1.2 h1:18LkdFRBG8jkWf5cclGvwam5GwM3o3lK9/qUmup15+0=

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/git-pkgs/resolve v0.2.2 h1:jjr6qa/8b/edg3tub5WYyYV04OpfWCuGZzgVYnfGl3
 github.com/git-pkgs/resolve v0.2.2/go.mod h1:KT894HOGMudjhSUWGHW1mC4r01eBaVaf0ujYhEHPMvo=
 github.com/git-pkgs/sarif v0.1.0 h1:ghUtzYaG/VDxBNF7aDI7EeT5mke4admqd2cqXcNzG1Q=
 github.com/git-pkgs/sarif v0.1.0/go.mod h1:NGg7Ft2+nvR0CBo+Ya9oSX+Yh/p1d7FVyhPe2/0v9V4=
+github.com/git-pkgs/sarif v0.1.1 h1:Jc5N+6ezJqbVjGZlPX9i8ar+OUsT+LX06nsM6Xjrq1c=
+github.com/git-pkgs/sarif v0.1.1/go.mod h1:NGg7Ft2+nvR0CBo+Ya9oSX+Yh/p1d7FVyhPe2/0v9V4=
 github.com/git-pkgs/sbom v0.1.2 h1:18LkdFRBG8jkWf5cclGvwam5GwM3o3lK9/qUmup15+0=
 github.com/git-pkgs/sbom v0.1.2/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/spdx v0.1.4 h1:eQ0waEV3uUeItpWAOvdN1K1rL9hTgsU7fF74r1mDXMs=


### PR DESCRIPTION
## Summary
- replace inline SARIF structs in the vulns command with github.com/git-pkgs/sarif v0.1.1
- build SARIF output using the generated SARIF 2.1.0 object model
- add a test that parses and validates generated SARIF output

## Tests
- go test ./cmd
- go test ./...
- go vet ./...