### PR TITLE
Add offline license metadata caching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,12 @@ git pkgs licenses --permissive  # flag copyleft licenses
 git pkgs licenses --allow=MIT,Apache-2.0  # explicit allow list
 git pkgs licenses --group       # group output by license
 git pkgs licenses --drift       # detect installed-to-latest license changes
+git pkgs licenses --offline     # use cached metadata without network access
 ```
 
 Fetches license information from package registries. Exits with code 1 if violations are found, making it suitable for CI.
 Use `--drift` to compare resolved dependency versions with the latest package metadata and flag changes like MIT to GPL.
+Package and version metadata is cached for 24 hours in the git-pkgs database. `--offline` accepts cached metadata regardless of age and fails if required metadata has not been cached yet. Set `GIT_PKGS_DB` to persist the database outside `.git`, including across CI runs.
 
 ### Vulnerability scanning
 

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -39,6 +39,7 @@ Licenses are normalized to SPDX identifiers when possible.`,
 	licensesCmd.Flags().Bool("unknown", false, "Flag packages with unknown licenses")
 	licensesCmd.Flags().Bool("group", false, "Group output by license")
 	licensesCmd.Flags().Bool("drift", false, "Detect dependencies whose license changed between installed and latest versions")
+	licensesCmd.Flags().Bool("offline", false, "Use cached metadata without making network requests")
 	parent.AddCommand(licensesCmd)
 }
 
@@ -92,6 +93,7 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	flagUnknown, _ := cmd.Flags().GetBool("unknown")
 	groupBy, _ := cmd.Flags().GetBool("group")
 	driftOnly, _ := cmd.Flags().GetBool("drift")
+	offline, _ := cmd.Flags().GetBool("offline")
 
 	if driftOnly {
 		if err := validateLicenseDriftFlags(allowList, denyList, flagPermissive, flagCopyleft, flagUnknown, groupBy); err != nil {
@@ -115,7 +117,7 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	deps = filterByEcosystem(deps, ecosystem)
 
 	if driftOnly {
-		return runLicenseDrift(cmd, db, deps, format)
+		return runLicenseDrift(cmd, db, deps, format, offline)
 	}
 
 	// Filter to manifest dependencies (direct deps)
@@ -149,7 +151,7 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get license data (from cache or API)
-	packageData, err := getLicenseData(db, purls, purlToDep)
+	packageData, err := getLicenseData(db, purls, purlToDep, offline)
 	if err != nil {
 		return fmt.Errorf("looking up packages: %w", err)
 	}
@@ -326,13 +328,24 @@ type licenseData struct {
 	LatestVersion string
 }
 
-func getLicenseData(db *database.DB, purls []string, purlToDep map[string]database.Dependency) (map[string]*licenseData, error) {
+func getLicenseData(
+	db *database.DB,
+	purls []string,
+	purlToDep map[string]database.Dependency,
+	offline bool,
+) (map[string]*licenseData, error) {
 	result := make(map[string]*licenseData)
 	var uncachedPurls []string
 
 	// Check cache if DB is available
 	if db != nil {
-		cached, err := db.GetCachedPackages(purls, enrichmentCacheTTL)
+		var cached map[string]*database.CachedPackage
+		var err error
+		if offline {
+			cached, err = db.GetCachedPackagesIncludingStale(purls)
+		} else {
+			cached, err = db.GetCachedPackages(purls, enrichmentCacheTTL)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -353,6 +366,12 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 	} else {
 		uncachedPurls = purls
 	}
+	if offline && len(uncachedPurls) > 0 {
+		return nil, fmt.Errorf(
+			"offline mode: license metadata is not cached for %d package(s); run 'git pkgs licenses' without --offline to populate the cache",
+			len(uncachedPurls),
+		)
+	}
 
 	// Fetch uncached from API
 	if len(uncachedPurls) > 0 {
@@ -361,7 +380,7 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 			return nil, err
 		}
 
-		const licensesTimeout = 60 * time.Second
+		const licensesTimeout = 5 * time.Minute
 		ctx, cancel := context.WithTimeout(context.Background(), licensesTimeout)
 		defer cancel()
 
@@ -398,7 +417,7 @@ func getLicenseData(db *database.DB, purls []string, purlToDep map[string]databa
 	return result, nil
 }
 
-func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Dependency, format string) error {
+func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Dependency, format string, offline bool) error {
 	resolved := make([]database.Dependency, 0, len(deps))
 	for _, dep := range deps {
 		if isResolvedDependency(dep) {
@@ -415,7 +434,7 @@ func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Depend
 		return nil
 	}
 
-	result, err := computeLicenseDrift(db, resolved)
+	result, err := computeLicenseDrift(db, resolved, offline)
 	if err != nil {
 		return err
 	}
@@ -431,7 +450,7 @@ func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Depend
 	}
 }
 
-func computeLicenseDrift(db *database.DB, deps []database.Dependency) (*LicenseDriftResult, error) {
+func computeLicenseDrift(db *database.DB, deps []database.Dependency, offline bool) (*LicenseDriftResult, error) {
 	result := emptyLicenseDriftResult()
 	result.Summary.TotalDependencies = len(deps)
 
@@ -450,12 +469,12 @@ func computeLicenseDrift(db *database.DB, deps []database.Dependency) (*LicenseD
 		}
 	}
 
-	packageLicenses, err := getLicenseData(db, packagePURLs, purlToDep)
+	packageLicenses, err := getLicenseData(db, packagePURLs, purlToDep, offline)
 	if err != nil {
 		return nil, fmt.Errorf("looking up package licenses: %w", err)
 	}
 
-	versionLicenses, err := loadLicenseDriftVersionLicenses(db, deps)
+	versionLicenses, err := loadLicenseDriftVersionLicenses(db, deps, offline)
 	if err != nil {
 		return nil, fmt.Errorf("looking up version licenses: %w", err)
 	}
@@ -523,7 +542,7 @@ func licensePackagePURLForDependency(dep database.Dependency) string {
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 }
 
-func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency) (map[string]string, error) {
+func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency, offline bool) (map[string]string, error) {
 	needed := make(map[string]map[string]bool)
 	for _, dep := range deps {
 		versionedPURL := versionedPURLForDependency(dep)
@@ -537,7 +556,7 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 		needed[packagePURL][dep.Requirement] = true
 	}
 
-	result := cachedLicenseDriftVersionLicenses(db, needed)
+	result := cachedLicenseDriftVersionLicenses(db, needed, offline)
 	var missing []licenseDriftVersionLookup
 	for packagePURL, versions := range needed {
 		for version := range versions {
@@ -553,6 +572,12 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 	}
 	if len(missing) == 0 {
 		return result, nil
+	}
+	if offline {
+		return nil, fmt.Errorf(
+			"offline mode: license metadata is not cached for %d package version(s); run 'git pkgs licenses --drift' without --offline to populate the cache",
+			len(missing),
+		)
 	}
 
 	client, err := newEnrichmentClient()
@@ -643,14 +668,24 @@ func fetchLicenseDriftVersions(
 	return fetched, fetchErrors
 }
 
-func cachedLicenseDriftVersionLicenses(db *database.DB, needed map[string]map[string]bool) map[string]string {
+func cachedLicenseDriftVersionLicenses(
+	db *database.DB,
+	needed map[string]map[string]bool,
+	includeStale bool,
+) map[string]string {
 	result := make(map[string]string)
 	if db == nil {
 		return result
 	}
 
 	for packagePURL := range needed {
-		cached, err := db.GetCachedVersions(packagePURL, enrichmentCacheTTL)
+		var cached []database.CachedVersion
+		var err error
+		if includeStale {
+			cached, err = db.GetCachedVersionsIncludingStale(packagePURL)
+		} else {
+			cached, err = db.GetCachedVersions(packagePURL, enrichmentCacheTTL)
+		}
 		if err != nil {
 			continue
 		}

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -94,6 +94,8 @@ gem 'rails'
 `
 
 func TestLicensesCommand(t *testing.T) {
+	t.Setenv("GIT_PKGS_DB", "")
+
 	t.Run("permissive flag detects non-permissive licenses", func(t *testing.T) {
 		restore := setMockEnrichment(map[string]*enrichment.PackageInfo{
 			"pkg:gem/sidekiq": {Ecosystem: "rubygems", Name: "sidekiq", License: "LGPL-3.0-or-later"},

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -389,6 +389,57 @@ func TestLicensesCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("offline treats funding-only cache rows as missing license metadata", func(t *testing.T) {
+		mock, restore := setMockEnrichmentClient(&mockEnrichmentClient{packages: map[string]*enrichment.PackageInfo{}})
+		defer restore()
+
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", `{"dependencies":{"express":"^4.18.0"}}`, "Add package.json")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+		if err != nil {
+			t.Fatalf("open database: %v", err)
+		}
+		if err := db.SavePackageFundingBatch([]database.PackageFundingData{{
+			PURL:         "pkg:npm/express",
+			Ecosystem:    "npm",
+			Name:         "express",
+			FundingLinks: []string{"https://opencollective.com/express"},
+		}}); err != nil {
+			_ = db.Close()
+			t.Fatalf("save funding metadata: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close database: %v", err)
+		}
+
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--offline"})
+		err = rootCmd.Execute()
+		if err == nil {
+			t.Fatal("expected offline lookup with funding-only cache metadata to fail")
+		}
+		if !strings.Contains(err.Error(), "license metadata is not cached") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		mock.mu.Lock()
+		calls := mock.bulkLookupCalls
+		mock.mu.Unlock()
+		if calls != 0 {
+			t.Fatalf("offline lookup made %d network call(s), want 0", calls)
+		}
+	})
+
 	t.Run("drift flag reports installed version license changes", func(t *testing.T) {
 		mock, restore := setMockEnrichmentWithVersionInfos(
 			map[string]*enrichment.PackageInfo{

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/cmd"
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/spdx"
 )
 
@@ -21,11 +24,13 @@ type mockEnrichmentClient struct {
 	versionInfos     map[string]*enrichment.VersionInfo
 	getVersionsCalls int
 	getVersionCalls  int
+	bulkLookupCalls  int
 }
 
 func (m *mockEnrichmentClient) BulkLookup(_ context.Context, purls []string) (map[string]*enrichment.PackageInfo, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.bulkLookupCalls++
 
 	result := make(map[string]*enrichment.PackageInfo)
 	for _, p := range purls {
@@ -286,6 +291,102 @@ func TestLicensesCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("offline uses stale cached metadata without a network request", func(t *testing.T) {
+		mock, restore := setMockEnrichmentClient(&mockEnrichmentClient{packages: map[string]*enrichment.PackageInfo{
+			"pkg:npm/express": {Ecosystem: "npm", Name: "express", License: "MIT"},
+			"pkg:npm/lodash":  {Ecosystem: "npm", Name: "lodash", License: "BSD-3-Clause"},
+			"pkg:npm/jest":    {Ecosystem: "npm", Name: "jest", License: "MIT"},
+		}})
+		defer restore()
+
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("initial licenses lookup failed: %v", err)
+		}
+
+		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+		if err != nil {
+			t.Fatalf("open database: %v", err)
+		}
+		staleAt := time.Now().Add(-48 * time.Hour).Format(time.RFC3339)
+		if _, err := db.Exec("UPDATE packages SET enriched_at = ?", staleAt); err != nil {
+			_ = db.Close()
+			t.Fatalf("make cache stale: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close database: %v", err)
+		}
+
+		mock.mu.Lock()
+		mock.bulkLookupCalls = 0
+		mock.mu.Unlock()
+
+		var stdout bytes.Buffer
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--offline"})
+		rootCmd.SetOut(&stdout)
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("offline licenses failed: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "MIT") || !strings.Contains(stdout.String(), "BSD-3-Clause") {
+			t.Fatalf("offline output did not use cached licenses: %s", stdout.String())
+		}
+
+		mock.mu.Lock()
+		calls := mock.bulkLookupCalls
+		mock.mu.Unlock()
+		if calls != 0 {
+			t.Fatalf("offline lookup made %d network call(s), want 0", calls)
+		}
+	})
+
+	t.Run("offline fails when metadata is not cached", func(t *testing.T) {
+		mock, restore := setMockEnrichmentClient(&mockEnrichmentClient{packages: map[string]*enrichment.PackageInfo{}})
+		defer restore()
+
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--offline"})
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatal("expected offline lookup without cached metadata to fail")
+		}
+		if !strings.Contains(err.Error(), "license metadata is not cached") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		mock.mu.Lock()
+		calls := mock.bulkLookupCalls
+		mock.mu.Unlock()
+		if calls != 0 {
+			t.Fatalf("offline lookup made %d network call(s), want 0", calls)
+		}
+	})
+
 	t.Run("drift flag reports installed version license changes", func(t *testing.T) {
 		mock, restore := setMockEnrichmentWithVersionInfos(
 			map[string]*enrichment.PackageInfo{
@@ -350,6 +451,46 @@ func TestLicensesCommand(t *testing.T) {
 		}
 		if getVersionsCalls != 0 {
 			t.Fatalf("GetVersions calls = %d, want 0", getVersionsCalls)
+		}
+
+		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+		if err != nil {
+			t.Fatalf("open database: %v", err)
+		}
+		staleAt := time.Now().Add(-48 * time.Hour).Format(time.RFC3339)
+		if _, err := db.Exec("UPDATE packages SET enriched_at = ?", staleAt); err != nil {
+			_ = db.Close()
+			t.Fatalf("make package cache stale: %v", err)
+		}
+		if _, err := db.Exec("UPDATE versions SET enriched_at = ?", staleAt); err != nil {
+			_ = db.Close()
+			t.Fatalf("make version cache stale: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close database: %v", err)
+		}
+
+		mock.mu.Lock()
+		mock.bulkLookupCalls = 0
+		mock.getVersionCalls = 0
+		mock.mu.Unlock()
+
+		stdout.Reset()
+		stderr.Reset()
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--drift", "--offline", "--format", "json"})
+		rootCmd.SetOut(&stdout)
+		rootCmd.SetErr(&stderr)
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("offline license drift failed: %v\nstderr: %s", err, stderr.String())
+		}
+
+		mock.mu.Lock()
+		bulkLookupCalls := mock.bulkLookupCalls
+		getVersionCalls = mock.getVersionCalls
+		mock.mu.Unlock()
+		if bulkLookupCalls != 0 || getVersionCalls != 0 {
+			t.Fatalf("offline drift made network calls: BulkLookup=%d GetVersion=%d", bulkLookupCalls, getVersionCalls)
 		}
 	})
 

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -296,6 +296,29 @@ Cache the git-pkgs binary to speed up workflows:
           fi
 ```
 
+Cache the SQLite database to reuse enrichment metadata, including licenses, across workflow runs. A unique primary key lets each run save refreshed data, while the restore key selects the newest earlier cache:
+
+```yaml
+env:
+  GIT_PKGS_DB: ${{ runner.temp }}/git-pkgs.sqlite3
+
+steps:
+  - uses: actions/checkout@v4
+
+  - name: Restore git-pkgs metadata cache
+    uses: actions/cache@v4
+    with:
+      path: ${{ env.GIT_PKGS_DB }}
+      key: git-pkgs-metadata-${{ runner.os }}-${{ github.run_id }}
+      restore-keys: |
+        git-pkgs-metadata-${{ runner.os }}-
+
+  - name: Check dependency licenses
+    run: git pkgs licenses --allow=MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC
+```
+
+Use `git pkgs licenses --offline` after a cache has been populated when the check must make no network requests. The command fails if metadata for a required dependency is missing from the restored cache.
+
 ## Docker
 
 Use git-pkgs in a Dockerfile:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -160,6 +160,7 @@ By default, a hybrid approach routes requests based on PURL qualifiers: packages
 Data is cached in the `packages` and `versions` tables with a 24-hour TTL. The `packages` table stores provenance: `repository_url` (the registry queried) and `source` (ecosystems or registries). The `funding` command stores package funding links in `packages`, the `maintainers` command stores package maintainer lists in `packages`, the `health` command stores package maintenance health signals in `packages`, and the `deprecated` command uses the `versions` cache and fetches exact-version status from registries when cached deprecation metadata is missing.
 
 The `licenses --drift` check reads per-version license data from the `versions` cache and falls back to enrichment version lookups for uncached installed versions.
+`licenses --offline` disables enrichment requests and permits cached package and version metadata past the normal TTL. It returns an error when required metadata is absent from the cache.
 
 ## Package Management
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	_ "modernc.org/sqlite"
 )
@@ -21,6 +22,10 @@ func Exists(path string) bool {
 }
 
 func Create(path string) (*DB, error) {
+	if err := ensureParentDir(path); err != nil {
+		return nil, err
+	}
+
 	if Exists(path) {
 		if err := os.Remove(path); err != nil {
 			return nil, fmt.Errorf("removing existing database: %w", err)
@@ -47,6 +52,9 @@ func OpenOrCreate(path string) (*DB, bool, error) {
 		db, err := Open(path)
 		return db, true, err
 	}
+	if err := ensureParentDir(path); err != nil {
+		return nil, false, err
+	}
 
 	db, err := Open(path)
 	if err != nil {
@@ -59,6 +67,13 @@ func OpenOrCreate(path string) (*DB, bool, error) {
 	}
 
 	return db, false, nil
+}
+
+func ensureParentDir(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating database directory: %w", err)
+	}
+	return nil
 }
 
 func Open(path string) (*DB, error) {

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1800,11 +1800,20 @@ type CachedVersion struct {
 
 // GetCachedPackages returns cached package data for the given PURLs that aren't stale.
 func (db *DB) GetCachedPackages(purls []string, staleDuration time.Duration) (map[string]*CachedPackage, error) {
+	staleThreshold := time.Now().Add(-staleDuration)
+	return db.getCachedPackages(purls, &staleThreshold)
+}
+
+// GetCachedPackagesIncludingStale returns cached package data regardless of age.
+func (db *DB) GetCachedPackagesIncludingStale(purls []string) (map[string]*CachedPackage, error) {
+	return db.getCachedPackages(purls, nil)
+}
+
+func (db *DB) getCachedPackages(purls []string, staleThreshold *time.Time) (map[string]*CachedPackage, error) {
 	if len(purls) == 0 {
 		return make(map[string]*CachedPackage), nil
 	}
 
-	staleThreshold := time.Now().Add(-staleDuration)
 	result := make(map[string]*CachedPackage)
 
 	// Process in batches to avoid SQLite parameter limits
@@ -1817,16 +1826,20 @@ func (db *DB) GetCachedPackages(purls []string, staleDuration time.Duration) (ma
 		batch := purls[i:end]
 
 		placeholders := make([]string, len(batch))
-		args := make([]interface{}, len(batch)+1)
-		args[0] = staleThreshold.Format(time.RFC3339)
+		args := make([]interface{}, 0, len(batch)+1)
+		freshnessFilter := ""
 		for j, purl := range batch {
 			placeholders[j] = "?"
-			args[j+1] = purl
+			args = append(args, purl)
+		}
+		if staleThreshold != nil {
+			freshnessFilter = " AND enriched_at >= ?"
+			args = append(args, staleThreshold.Format(time.RFC3339))
 		}
 
 		query := `SELECT purl, ecosystem, name, latest_version, license, enriched_at
 			FROM packages
-			WHERE enriched_at >= ? AND purl IN (` + strings.Join(placeholders, ",") + `)`
+			WHERE purl IN (` + strings.Join(placeholders, ",") + `)` + freshnessFilter
 
 		rows, err := db.Query(query, args...)
 		if err != nil {
@@ -2294,13 +2307,27 @@ func (db *DB) SavePackageHealthBatch(packages []PackageHealthData) error {
 // GetCachedVersions returns cached version data for a package that isn't stale.
 func (db *DB) GetCachedVersions(packagePurl string, staleDuration time.Duration) ([]CachedVersion, error) {
 	staleThreshold := time.Now().Add(-staleDuration)
+	return db.getCachedVersions(packagePurl, &staleThreshold)
+}
 
-	rows, err := db.Query(`
+// GetCachedVersionsIncludingStale returns cached version data regardless of age.
+func (db *DB) GetCachedVersionsIncludingStale(packagePurl string) ([]CachedVersion, error) {
+	return db.getCachedVersions(packagePurl, nil)
+}
+
+func (db *DB) getCachedVersions(packagePurl string, staleThreshold *time.Time) ([]CachedVersion, error) {
+	query := `
 		SELECT purl, package_purl, license, published_at, status, status_checked_at, metadata
 		FROM versions
-		WHERE package_purl = ? AND enriched_at >= ?
-		ORDER BY published_at DESC`,
-		packagePurl, staleThreshold.Format(time.RFC3339))
+		WHERE package_purl = ?`
+	args := []interface{}{packagePurl}
+	if staleThreshold != nil {
+		query += " AND enriched_at >= ?"
+		args = append(args, staleThreshold.Format(time.RFC3339))
+	}
+	query += " ORDER BY published_at DESC"
+
+	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1839,7 +1839,7 @@ func (db *DB) getCachedPackages(purls []string, staleThreshold *time.Time) (map[
 
 		query := `SELECT purl, ecosystem, name, latest_version, license, enriched_at
 			FROM packages
-			WHERE purl IN (` + strings.Join(placeholders, ",") + `)` + freshnessFilter
+			WHERE enriched_at IS NOT NULL AND purl IN (` + strings.Join(placeholders, ",") + `)` + freshnessFilter
 
 		rows, err := db.Query(query, args...)
 		if err != nil {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -79,6 +79,12 @@ func OpenRepository(path string) (*Repository, error) {
 }
 
 func (r *Repository) DatabasePath() string {
+	if dbPath := os.Getenv("GIT_PKGS_DB"); dbPath != "" {
+		if filepath.IsAbs(dbPath) {
+			return filepath.Clean(dbPath)
+		}
+		return filepath.Join(r.workDir, dbPath)
+	}
 	return filepath.Join(r.gitDir, DatabaseFile)
 }
 

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 )
 
@@ -226,6 +227,44 @@ func TestDatabasePath(t *testing.T) {
 		expected := filepath.Join(repoDir, ".cache", "pkgs.sqlite3")
 		if repo.DatabasePath() != expected {
 			t.Errorf("expected database path %s, got %s", expected, repo.DatabasePath())
+		}
+	})
+
+	t.Run("creates database in missing custom directory", func(t *testing.T) {
+		t.Setenv("GIT_PKGS_DB", filepath.Join(".cache", "git-pkgs", "pkgs.sqlite3"))
+		dbPath := repo.DatabasePath()
+		if _, err := os.Stat(filepath.Dir(dbPath)); !os.IsNotExist(err) {
+			t.Fatalf("expected custom database directory to be absent, got %v", err)
+		}
+
+		db, err := database.Create(dbPath)
+		if err != nil {
+			t.Fatalf("create database in custom directory: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close database: %v", err)
+		}
+		if _, err := os.Stat(dbPath); err != nil {
+			t.Fatalf("expected custom database to exist: %v", err)
+		}
+	})
+
+	t.Run("opens database in missing custom directory", func(t *testing.T) {
+		t.Setenv("GIT_PKGS_DB", filepath.Join(".cache", "on-demand", "pkgs.sqlite3"))
+		dbPath := repo.DatabasePath()
+		db, existed, err := database.OpenOrCreate(dbPath)
+		if err != nil {
+			t.Fatalf("open database in custom directory: %v", err)
+		}
+		if existed {
+			_ = db.Close()
+			t.Fatal("new custom database unexpectedly existed")
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("close database: %v", err)
+		}
+		if _, err := os.Stat(dbPath); err != nil {
+			t.Fatalf("expected on-demand custom database to exist: %v", err)
 		}
 	})
 }

--- a/internal/git/repository_test.go
+++ b/internal/git/repository_test.go
@@ -198,6 +198,7 @@ func TestOpenRepository(t *testing.T) {
 }
 
 func TestDatabasePath(t *testing.T) {
+	t.Setenv("GIT_PKGS_DB", "")
 	repoDir := createTestRepo(t)
 	addFile(t, repoDir, "README.md", "# Test")
 	commit(t, repoDir, "Initial commit")
@@ -211,6 +212,22 @@ func TestDatabasePath(t *testing.T) {
 	if repo.DatabasePath() != expected {
 		t.Errorf("expected database path %s, got %s", expected, repo.DatabasePath())
 	}
+
+	t.Run("absolute environment override", func(t *testing.T) {
+		override := filepath.Join(t.TempDir(), "cache.sqlite3")
+		t.Setenv("GIT_PKGS_DB", override)
+		if repo.DatabasePath() != override {
+			t.Errorf("expected database path %s, got %s", override, repo.DatabasePath())
+		}
+	})
+
+	t.Run("relative environment override", func(t *testing.T) {
+		t.Setenv("GIT_PKGS_DB", filepath.Join(".cache", "pkgs.sqlite3"))
+		expected := filepath.Join(repoDir, ".cache", "pkgs.sqlite3")
+		if repo.DatabasePath() != expected {
+			t.Errorf("expected database path %s, got %s", expected, repo.DatabasePath())
+		}
+	})
 }
 
 func TestCurrentBranch(t *testing.T) {


### PR DESCRIPTION
Closes #272

## Summary

Improve offline and reduced-request support for license checks by building on the existing SQLite enrichment cache.

- Add `git pkgs licenses --offline`
- Use cached package and version metadata regardless of age in offline mode
- Ensure offline mode never makes enrichment API requests
- Return a clear error when required metadata has not been cached
- Support offline operation with `licenses --drift`
- Increase the license lookup timeout from 60 seconds to 5 minutes
- Honor the documented `GIT_PKGS_DB` environment variable
- Document persisting the metadata database with GitHub Actions cache
- Add regression coverage for stale caches, missing metadata, offline drift, and database path overrides

Offline mode intentionally fails when required metadata is missing so license-policy checks cannot silently pass with incomplete data.

## Testing

- `go test ./...`
- `go tool golangci-lint run ./...`
- `git diff --check`