### PR TITLE
Use installed version licenses for policies

### DIFF
--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -158,7 +158,13 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	}
 	resolvedVersionPURLs, resolvedDeps := resolvedLicenseVersions(purlToDep, deps)
 	// Version metadata is optional; package metadata remains the fallback.
-	versionLicenses, _ := loadLicenseVersionLicenses(db, resolvedDeps, offline)
+	versionLicenses, versionLicenseErr := loadLicenseVersionLicenses(db, resolvedDeps, offline)
+	if versionLicenseErr != nil {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"Warning: version license lookup failed; using package metadata where version data is unavailable: %v\n",
+			versionLicenseErr,
+		)
+	}
 
 	// Normalize allow/deny lists to SPDX identifiers
 	allowSet := make(map[string]bool)
@@ -644,7 +650,7 @@ func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, off
 	}
 	if offline {
 		return result, fmt.Errorf(
-			"offline mode: license metadata is not cached for %d package version(s); run 'git pkgs licenses --drift' without --offline to populate the cache",
+			"offline mode: license metadata is not cached for %d package version(s); rerun without --offline to populate the cache",
 			len(missing),
 		)
 	}

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -155,6 +156,9 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("looking up packages: %w", err)
 	}
+	resolvedVersionPURLs, resolvedDeps := resolvedLicenseVersions(purlToDep, deps)
+	// Version metadata is optional; package metadata remains the fallback.
+	versionLicenses, _ := loadLicenseVersionLicenses(db, resolvedDeps, offline)
 
 	// Normalize allow/deny lists to SPDX identifiers
 	allowSet := make(map[string]bool)
@@ -197,8 +201,12 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 			PURL:         purl,
 		}
 
-		if data.License != "" {
-			info.Licenses = []string{data.License}
+		license := data.License
+		if versionLicense := versionLicenses[resolvedVersionPURLs[purl]]; versionLicense != "" {
+			license = versionLicense
+		}
+		if license != "" {
+			info.Licenses = []string{license}
 		}
 
 		// Check for violations
@@ -417,6 +425,67 @@ func getLicenseData(
 	return result, nil
 }
 
+func resolvedLicenseVersions(
+	purlToDep map[string]database.Dependency,
+	deps []database.Dependency,
+) (map[string]string, []database.Dependency) {
+	// Manifest requirements are usually ranges, so only pair them with a
+	// lockfile when that package resolves to one version in the same directory.
+	candidatesByLocation := make(map[string]map[string]database.Dependency)
+	for _, dep := range deps {
+		if !isResolvedDependency(dep) {
+			continue
+		}
+		versionedPURL := versionedPURLForDependency(dep)
+		if versionedPURL == "" {
+			continue
+		}
+		location := licenseDependencyLocation(dep)
+		if candidatesByLocation[location] == nil {
+			candidatesByLocation[location] = make(map[string]database.Dependency)
+		}
+		candidatesByLocation[location][versionedPURL] = dep
+	}
+
+	resolvedVersionPURLs := make(map[string]string)
+	resolvedByPURL := make(map[string]database.Dependency)
+	for lookupPURL, directDep := range purlToDep {
+		if isResolvedDependency(directDep) {
+			versionedPURL := versionedPURLForDependency(directDep)
+			if versionedPURL != "" {
+				resolvedVersionPURLs[lookupPURL] = versionedPURL
+				resolvedByPURL[versionedPURL] = directDep
+			}
+			continue
+		}
+
+		candidates := candidatesByLocation[licenseDependencyLocation(directDep)]
+		if len(candidates) != 1 {
+			continue
+		}
+		for versionedPURL, dep := range candidates {
+			resolvedVersionPURLs[lookupPURL] = versionedPURL
+			resolvedByPURL[versionedPURL] = dep
+		}
+	}
+
+	versionedPURLs := make([]string, 0, len(resolvedByPURL))
+	for versionedPURL := range resolvedByPURL {
+		versionedPURLs = append(versionedPURLs, versionedPURL)
+	}
+	sort.Strings(versionedPURLs)
+
+	resolvedDeps := make([]database.Dependency, 0, len(versionedPURLs))
+	for _, versionedPURL := range versionedPURLs {
+		resolvedDeps = append(resolvedDeps, resolvedByPURL[versionedPURL])
+	}
+	return resolvedVersionPURLs, resolvedDeps
+}
+
+func licenseDependencyLocation(dep database.Dependency) string {
+	return strings.ToLower(dep.Ecosystem) + "\x00" + strings.ToLower(dep.Name) + "\x00" + path.Dir(dep.ManifestPath)
+}
+
 func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Dependency, format string, offline bool) error {
 	resolved := make([]database.Dependency, 0, len(deps))
 	for _, dep := range deps {
@@ -474,7 +543,7 @@ func computeLicenseDrift(db *database.DB, deps []database.Dependency, offline bo
 		return nil, fmt.Errorf("looking up package licenses: %w", err)
 	}
 
-	versionLicenses, err := loadLicenseDriftVersionLicenses(db, deps, offline)
+	versionLicenses, err := loadLicenseVersionLicenses(db, deps, offline)
 	if err != nil {
 		return nil, fmt.Errorf("looking up version licenses: %w", err)
 	}
@@ -542,7 +611,7 @@ func licensePackagePURLForDependency(dep database.Dependency) string {
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 }
 
-func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency, offline bool) (map[string]string, error) {
+func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, offline bool) (map[string]string, error) {
 	needed := make(map[string]map[string]bool)
 	for _, dep := range deps {
 		versionedPURL := versionedPURLForDependency(dep)
@@ -574,7 +643,7 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 		return result, nil
 	}
 	if offline {
-		return nil, fmt.Errorf(
+		return result, fmt.Errorf(
 			"offline mode: license metadata is not cached for %d package version(s); run 'git pkgs licenses --drift' without --offline to populate the cache",
 			len(missing),
 		)
@@ -582,7 +651,7 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 
 	client, err := newEnrichmentClient()
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 
 	const licenseDriftLookupTimeout = 5 * time.Minute
@@ -598,7 +667,7 @@ func loadLicenseDriftVersionLicenses(db *database.DB, deps []database.Dependency
 		result[fetchedVersion.VersionedPURL] = normalizeLicenseString(fetchedVersion.Version.License)
 	}
 	if len(fetchErrors) == len(missing) {
-		return nil, fmt.Errorf("fetching license drift metadata failed for all %d uncached versions: %w",
+		return result, fmt.Errorf("fetching license version metadata failed for all %d uncached versions: %w",
 			len(missing), wrapEcosystemsError(errors.Join(fetchErrors...)))
 	}
 

--- a/cmd/licenses_internal_test.go
+++ b/cmd/licenses_internal_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -80,5 +81,27 @@ func TestResolvedLicenseVersions(t *testing.T) {
 				t.Fatalf("resolved dependencies = %d, want %d", len(resolvedDeps), wantDeps)
 			}
 		})
+	}
+}
+
+func TestLoadLicenseVersionLicensesOfflineCacheMiss(t *testing.T) {
+	_, err := loadLicenseVersionLicenses(nil, []database.Dependency{
+		{
+			Name:         "ua-parser-js",
+			Ecosystem:    "npm",
+			PURL:         "pkg:npm/ua-parser-js@1.0.41",
+			Requirement:  "1.0.41",
+			ManifestPath: "package-lock.json",
+			ManifestKind: manifestKindLockfile,
+		},
+	}, true)
+	if err == nil {
+		t.Fatal("offline cache miss error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "rerun without --offline") {
+		t.Fatalf("offline cache miss error = %q, want generic rerun guidance", err)
+	}
+	if strings.Contains(err.Error(), "--drift") {
+		t.Fatalf("offline cache miss error = %q, should apply to both license modes", err)
 	}
 }

--- a/cmd/licenses_internal_test.go
+++ b/cmd/licenses_internal_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestResolvedLicenseVersions(t *testing.T) {
+	direct := database.Dependency{
+		Name:         "ua-parser-js",
+		Ecosystem:    "npm",
+		PURL:         "pkg:npm/ua-parser-js",
+		Requirement:  "^1.0.41",
+		ManifestPath: "app/package.json",
+		ManifestKind: "manifest",
+	}
+	resolved := database.Dependency{
+		Name:         "ua-parser-js",
+		Ecosystem:    "npm",
+		PURL:         "pkg:npm/ua-parser-js@1.0.41",
+		Requirement:  "1.0.41",
+		ManifestPath: "app/package-lock.json",
+		ManifestKind: manifestKindLockfile,
+	}
+
+	for _, tt := range []struct {
+		name     string
+		deps     []database.Dependency
+		wantPURL string
+	}{
+		{
+			name:     "one resolved version in the manifest directory",
+			deps:     []database.Dependency{direct, resolved},
+			wantPURL: "pkg:npm/ua-parser-js@1.0.41",
+		},
+		{
+			name: "multiple resolved versions are ambiguous",
+			deps: []database.Dependency{
+				direct,
+				resolved,
+				{
+					Name:         "ua-parser-js",
+					Ecosystem:    "npm",
+					PURL:         "pkg:npm/ua-parser-js@0.7.41",
+					Requirement:  "0.7.41",
+					ManifestPath: "app/package-lock.json",
+					ManifestKind: manifestKindLockfile,
+				},
+			},
+		},
+		{
+			name: "resolved version in another directory does not match",
+			deps: []database.Dependency{
+				direct,
+				{
+					Name:         resolved.Name,
+					Ecosystem:    resolved.Ecosystem,
+					PURL:         resolved.PURL,
+					Requirement:  resolved.Requirement,
+					ManifestPath: "other/package-lock.json",
+					ManifestKind: resolved.ManifestKind,
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			versions, resolvedDeps := resolvedLicenseVersions(
+				map[string]database.Dependency{direct.PURL: direct},
+				tt.deps,
+			)
+			if versions[direct.PURL] != tt.wantPURL {
+				t.Fatalf("resolved version = %q, want %q", versions[direct.PURL], tt.wantPURL)
+			}
+			wantDeps := 0
+			if tt.wantPURL != "" {
+				wantDeps = 1
+			}
+			if len(resolvedDeps) != wantDeps {
+				t.Fatalf("resolved dependencies = %d, want %d", len(resolvedDeps), wantDeps)
+			}
+		})
+	}
+}

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -25,6 +26,7 @@ type mockEnrichmentClient struct {
 	getVersionsCalls int
 	getVersionCalls  int
 	bulkLookupCalls  int
+	getVersionErr    error
 }
 
 func (m *mockEnrichmentClient) BulkLookup(_ context.Context, purls []string) (map[string]*enrichment.PackageInfo, error) {
@@ -54,6 +56,9 @@ func (m *mockEnrichmentClient) GetVersion(_ context.Context, purl string) (*enri
 	defer m.mu.Unlock()
 
 	m.getVersionCalls++
+	if m.getVersionErr != nil {
+		return nil, m.getVersionErr
+	}
 	if info, ok := m.versionInfos[purl]; ok {
 		return info, nil
 	}
@@ -203,6 +208,7 @@ func TestLicensesCommand(t *testing.T) {
 		versionLicense string
 		wantLicense    string
 		wantViolation  bool
+		wantWarning    bool
 	}{
 		{
 			name:           "license policies use installed version metadata",
@@ -213,6 +219,12 @@ func TestLicensesCommand(t *testing.T) {
 			name:          "license policies fall back to package metadata",
 			wantLicense:   "AGPL-3.0-or-later",
 			wantViolation: true,
+		},
+		{
+			name:          "license policies warn when version lookup fails",
+			wantLicense:   "AGPL-3.0-or-later",
+			wantViolation: true,
+			wantWarning:   true,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -230,15 +242,22 @@ func TestLicensesCommand(t *testing.T) {
 				},
 			)
 			defer restore()
+			if tt.wantWarning {
+				mock.getVersionErr = errors.New("enrichment unavailable")
+			}
 
 			initRepoWithFiles(t, map[string]string{
 				"package.json":      uaParserPackageJSON,
 				"package-lock.json": uaParserPackageLockJSON,
 			})
 
-			stdout, _, err := runCmd(t, "licenses", "--deny", "AGPL-3.0-or-later", "--format", "json")
+			stdout, stderr, err := runCmd(t, "licenses", "--deny", "AGPL-3.0-or-later", "--format", "json")
 			if (err != nil) != tt.wantViolation {
 				t.Fatalf("licenses error = %v, want violation %v", err, tt.wantViolation)
+			}
+			gotWarning := strings.Contains(stderr, "Warning: version license lookup failed")
+			if gotWarning != tt.wantWarning {
+				t.Fatalf("version lookup warning = %v, want %v; stderr: %s", gotWarning, tt.wantWarning, stderr)
 			}
 
 			var result []cmd.LicenseInfo

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -93,6 +93,30 @@ gem 'sidekiq'
 gem 'rails'
 `
 
+const uaParserPackageJSON = `{
+  "dependencies": {
+    "ua-parser-js": "^1.0.41"
+  }
+}
+`
+
+const uaParserPackageLockJSON = `{
+  "name": "license-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "packages": {
+    "": {
+      "dependencies": {
+        "ua-parser-js": "^1.0.41"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41"
+    }
+  }
+}
+`
+
 func TestLicensesCommand(t *testing.T) {
 	t.Setenv("GIT_PKGS_DB", "")
 
@@ -173,6 +197,72 @@ func TestLicensesCommand(t *testing.T) {
 			t.Error("expected command to return error when denied license found")
 		}
 	})
+
+	for _, tt := range []struct {
+		name           string
+		versionLicense string
+		wantLicense    string
+		wantViolation  bool
+	}{
+		{
+			name:           "license policies use installed version metadata",
+			versionLicense: "MIT",
+			wantLicense:    "MIT",
+		},
+		{
+			name:          "license policies fall back to package metadata",
+			wantLicense:   "AGPL-3.0-or-later",
+			wantViolation: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mock, restore := setMockEnrichmentWithVersionInfos(
+				map[string]*enrichment.PackageInfo{
+					"pkg:npm/ua-parser-js": {
+						Ecosystem:     "npm",
+						Name:          "ua-parser-js",
+						LatestVersion: "2.0.10",
+						License:       "AGPL-3.0-or-later",
+					},
+				},
+				map[string]*enrichment.VersionInfo{
+					"pkg:npm/ua-parser-js@1.0.41": {Number: "1.0.41", License: tt.versionLicense},
+				},
+			)
+			defer restore()
+
+			initRepoWithFiles(t, map[string]string{
+				"package.json":      uaParserPackageJSON,
+				"package-lock.json": uaParserPackageLockJSON,
+			})
+
+			stdout, _, err := runCmd(t, "licenses", "--deny", "AGPL-3.0-or-later", "--format", "json")
+			if (err != nil) != tt.wantViolation {
+				t.Fatalf("licenses error = %v, want violation %v", err, tt.wantViolation)
+			}
+
+			var result []cmd.LicenseInfo
+			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+				t.Fatalf("parse licenses output: %v\nOutput: %s", err, stdout)
+			}
+			if len(result) != 1 {
+				t.Fatalf("license entries = %d, want 1", len(result))
+			}
+			if len(result[0].Licenses) != 1 || result[0].Licenses[0] != tt.wantLicense {
+				t.Fatalf("licenses = %v, want [%s]", result[0].Licenses, tt.wantLicense)
+			}
+			if result[0].Flagged != tt.wantViolation {
+				t.Fatalf("flagged = %v, want %v", result[0].Flagged, tt.wantViolation)
+			}
+
+			mock.mu.Lock()
+			getVersionCalls := mock.getVersionCalls
+			mock.mu.Unlock()
+			if getVersionCalls != 1 {
+				t.Fatalf("GetVersion calls = %d, want 1", getVersionCalls)
+			}
+		})
+	}
 
 	t.Run("copyleft flag detects copyleft licenses", func(t *testing.T) {
 		restore := setMockEnrichment(map[string]*enrichment.PackageInfo{

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/git-pkgs/changelog v0.1.3
-	github.com/git-pkgs/enrichment v0.6.1
+	github.com/git-pkgs/enrichment v0.6.2
 	github.com/git-pkgs/gitignore v1.2.0
 	github.com/git-pkgs/managers v0.10.1
 	github.com/git-pkgs/manifests v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/git-pkgs/changelog v0.1.3 h1:iaFrl76F9lE3B9bQBZCpm0O+eB6tQ0ajMnrc5l7/EhU=
 github.com/git-pkgs/changelog v0.1.3/go.mod h1:psv6VJyJKYzDYajKdV9oPw7LUEOIqSiB0L3wcKdX6Ac=
-github.com/git-pkgs/enrichment v0.6.1 h1:hJp1TsAFBdIXPUHWp+heNAzL4SBBrlIEie3al4xPTps=
-github.com/git-pkgs/enrichment v0.6.1/go.mod h1:1w67BEH9vw30e8rDCYB+tTlnzQXybFQmL6CHtTBDJqc=
+github.com/git-pkgs/enrichment v0.6.2 h1:xu0HGsU9WJtIOb2GfKbBilAupDUfIzm98aXYWXF305o=
+github.com/git-pkgs/enrichment v0.6.2/go.mod h1:1w67BEH9vw30e8rDCYB+tTlnzQXybFQmL6CHtTBDJqc=
 github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLuFaM=
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/managers v0.10.1 h1:T877XtuXoJNweDTMGj1H6AOeVolDO44IvsgDN5jq3Ko=


### PR DESCRIPTION
Use license metadata for the installed package version when evaluating `git pkgs licenses` policies. Fall back to package metadata when version data is unavailable or lockfile resolution is ambiguous.

Update `enrichment` to v0.6.2 so version license data is available.

Fixes #283