### PR TITLE
Use version metadata in SBOMs

### DIFF
--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -142,6 +142,9 @@ func sbomPURLForDependency(dep database.Dependency) string {
 	if dep.PURL != "" {
 		return dep.PURL
 	}
+	if dep.Ecosystem == "" || dep.Name == "" {
+		return ""
+	}
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 }
 
@@ -159,14 +162,22 @@ func selectSBOMDependencies(deps []database.Dependency) []database.Dependency {
 		if !isResolvedDependency(dep) && resolvedLocations[sbomDependencyLocation(dep)] {
 			continue
 		}
-		key := sbomPURLForDependency(dep)
-		if key == "" || seen[key] {
+		key := sbomDependencyKey(dep)
+		if seen[key] {
 			continue
 		}
 		seen[key] = true
 		selected = append(selected, dep)
 	}
 	return selected
+}
+
+func sbomDependencyKey(dep database.Dependency) string {
+	if purlStr := sbomPURLForDependency(dep); purlStr != "" {
+		return "purl\x00" + purlStr
+	}
+	return "dependency\x00" + strings.ToLower(dep.Ecosystem) + "\x00" +
+		strings.ToLower(dep.Name) + "\x00" + dep.Requirement
 }
 
 func sbomDependencyLocation(dep database.Dependency) string {

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"path"
+	"strings"
 	"time"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -64,10 +67,21 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, ecosystem)
+	deps = selectSBOMDependencies(deps)
 
 	licenseMap := map[string]string{}
 	if !skipEnrichment {
-		licenseMap = enrichLicenses(db, deps)
+		var packageFallbacks int
+		licenseMap, packageFallbacks, err = enrichLicenses(db, deps)
+		if err != nil {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: SBOM license enrichment incomplete: %v\n", err)
+		}
+		if packageFallbacks > 0 {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"Warning: using package-level license metadata for %d SBOM component(s) without version license metadata\n",
+				packageFallbacks,
+			)
+		}
 	}
 
 	if projectName == "" {
@@ -100,10 +114,7 @@ func buildSBOM(deps []database.Dependency, licenses map[string]string, name, ver
 		Creators:  []sbom.Creator{{Type: "Tool", Name: "git-pkgs-" + version}},
 	}
 	for _, d := range deps {
-		purlStr := d.PURL
-		if purlStr == "" {
-			purlStr = purl.MakePURLString(d.Ecosystem, d.Name, d.Requirement)
-		}
+		purlStr := sbomPURLForDependency(d)
 		p := sbom.Package{
 			Name:    d.Name,
 			Version: d.Requirement,
@@ -113,8 +124,7 @@ func buildSBOM(deps []database.Dependency, licenses map[string]string, name, ver
 				Category: "PACKAGE_MANAGER", Type: "purl", Locator: purlStr,
 			}}
 		}
-		licKey := purl.MakePURLString(d.Ecosystem, d.Name, "")
-		if lic := licenses[licKey]; lic != "" {
+		if lic := licenses[purlStr]; lic != "" {
 			p.LicenseConcluded = lic
 			p.LicenseDeclared = lic
 		}
@@ -123,24 +133,100 @@ func buildSBOM(deps []database.Dependency, licenses map[string]string, name, ver
 	return s
 }
 
-func enrichLicenses(db *database.DB, deps []database.Dependency) map[string]string {
-	purls := make([]string, 0, len(deps))
-	purlToDep := make(map[string]database.Dependency)
-	for _, d := range deps {
-		purlStr := purl.MakePURLString(d.Ecosystem, d.Name, "")
-		if purlStr != "" {
-			purls = append(purls, purlStr)
-			purlToDep[purlStr] = d
+func sbomPURLForDependency(dep database.Dependency) string {
+	if isResolvedDependency(dep) {
+		if versionedPURL := versionedPURLForDependency(dep); versionedPURL != "" {
+			return versionedPURL
 		}
 	}
+	if dep.PURL != "" {
+		return dep.PURL
+	}
+	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+}
+
+func selectSBOMDependencies(deps []database.Dependency) []database.Dependency {
+	resolvedLocations := make(map[string]bool)
+	for _, dep := range deps {
+		if isResolvedDependency(dep) {
+			resolvedLocations[sbomDependencyLocation(dep)] = true
+		}
+	}
+
+	selected := make([]database.Dependency, 0, len(deps))
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		if !isResolvedDependency(dep) && resolvedLocations[sbomDependencyLocation(dep)] {
+			continue
+		}
+		key := sbomPURLForDependency(dep)
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		selected = append(selected, dep)
+	}
+	return selected
+}
+
+func sbomDependencyLocation(dep database.Dependency) string {
+	return strings.ToLower(dep.Ecosystem) + "\x00" + strings.ToLower(dep.Name) + "\x00" + path.Dir(dep.ManifestPath)
+}
+
+func enrichLicenses(db *database.DB, deps []database.Dependency) (map[string]string, int, error) {
+	purls := make([]string, 0, len(deps))
+	purlToDep := make(map[string]database.Dependency)
+	seen := make(map[string]bool)
+	for _, d := range deps {
+		purlStr := licensePackagePURLForDependency(d)
+		if purlStr == "" || seen[purlStr] {
+			continue
+		}
+		seen[purlStr] = true
+		purls = append(purls, purlStr)
+		purlToDep[purlStr] = d
+	}
 	if len(purls) == 0 {
-		return nil
+		return map[string]string{}, 0, nil
 	}
-	data, err := getSBOMLicenseData(db, purls, purlToDep)
-	if err != nil {
-		return nil
+
+	packageLicenses, packageErr := getSBOMLicenseData(db, purls, purlToDep)
+	resolved := make([]database.Dependency, 0, len(deps))
+	for _, dep := range deps {
+		if isResolvedDependency(dep) {
+			resolved = append(resolved, dep)
+		}
 	}
-	return data
+	versionLicenses, versionErr := loadLicenseVersionLicenses(db, resolved, false)
+
+	licenses, packageFallbacks := selectSBOMLicenses(deps, packageLicenses, versionLicenses)
+	return licenses, packageFallbacks, errors.Join(packageErr, versionErr)
+}
+
+func selectSBOMLicenses(
+	deps []database.Dependency,
+	packageLicenses map[string]string,
+	versionLicenses map[string]string,
+) (map[string]string, int) {
+	licenses := make(map[string]string)
+	fallbacks := make(map[string]bool)
+	for _, dep := range deps {
+		componentPURL := sbomPURLForDependency(dep)
+		if componentPURL == "" {
+			continue
+		}
+		if versionLicense := versionLicenses[versionedPURLForDependency(dep)]; versionLicense != "" {
+			licenses[componentPURL] = versionLicense
+			continue
+		}
+		packageLicense := packageLicenses[licensePackagePURLForDependency(dep)]
+		if packageLicense == "" {
+			continue
+		}
+		licenses[componentPURL] = packageLicense
+		fallbacks[componentPURL] = true
+	}
+	return licenses, len(fallbacks)
 }
 
 func getSBOMLicenseData(db *database.DB, purls []string, purlToDep map[string]database.Dependency) (map[string]string, error) {

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -121,6 +121,22 @@ func TestSelectSBOMDependenciesPrefersResolvedVersions(t *testing.T) {
 	}
 }
 
+func TestSelectSBOMDependenciesKeepsDependenciesWithoutPURL(t *testing.T) {
+	dep := database.Dependency{Name: "local-tool", Requirement: "1.0.0"}
+	otherVersion := dep
+	otherVersion.Requirement = "2.0.0"
+
+	selected := selectSBOMDependencies([]database.Dependency{dep, dep, otherVersion})
+	if len(selected) != 2 {
+		t.Fatalf("selected dependencies = %d, want 2", len(selected))
+	}
+	for _, selectedDep := range selected {
+		if got := sbomPURLForDependency(selectedDep); got != "" {
+			t.Fatalf("PURL = %q, want empty", got)
+		}
+	}
+}
+
 func TestEnrichLicensesUsesVersionMetadata(t *testing.T) {
 	for _, tt := range []struct {
 		name           string

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -2,19 +2,57 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/sbom"
 )
 
+type sbomEnrichmentClient struct {
+	packages        map[string]*enrichment.PackageInfo
+	versions        map[string]*enrichment.VersionInfo
+	getVersionCalls int
+	bulkLookupCalls int
+}
+
+func (c *sbomEnrichmentClient) BulkLookup(
+	_ context.Context,
+	purls []string,
+) (map[string]*enrichment.PackageInfo, error) {
+	c.bulkLookupCalls++
+	result := make(map[string]*enrichment.PackageInfo)
+	for _, purlStr := range purls {
+		if pkg := c.packages[purlStr]; pkg != nil {
+			result[purlStr] = pkg
+		}
+	}
+	return result, nil
+}
+
+func (c *sbomEnrichmentClient) GetVersions(_ context.Context, _ string) ([]enrichment.VersionInfo, error) {
+	return nil, nil
+}
+
+func (c *sbomEnrichmentClient) GetVersion(_ context.Context, purlStr string) (*enrichment.VersionInfo, error) {
+	c.getVersionCalls++
+	return c.versions[purlStr], nil
+}
+
 func TestBuildSBOM(t *testing.T) {
 	deps := []database.Dependency{
-		{Ecosystem: "npm", Name: "lodash", Requirement: "4.17.21", PURL: "pkg:npm/lodash@4.17.21"},
+		{
+			Ecosystem:    "npm",
+			Name:         "lodash",
+			Requirement:  "4.17.21",
+			PURL:         "pkg:npm/lodash",
+			ManifestKind: manifestKindLockfile,
+		},
 		{Ecosystem: "npm", Name: "react", Requirement: "18.2.0"},
 	}
-	licenses := map[string]string{"pkg:npm/lodash": "MIT"}
+	licenses := map[string]string{"pkg:npm/lodash@4.17.21": "MIT"}
 
 	doc := buildSBOM(deps, licenses, "demo", "1.0.0")
 
@@ -28,7 +66,7 @@ func TestBuildSBOM(t *testing.T) {
 	if lodash.PURL() != "pkg:npm/lodash@4.17.21" {
 		t.Errorf("lodash purl = %q", lodash.PURL())
 	}
-	if lodash.LicenseDeclared != licenses["pkg:npm/lodash"] {
+	if lodash.LicenseDeclared != licenses["pkg:npm/lodash@4.17.21"] {
 		t.Errorf("lodash license = %q", lodash.LicenseDeclared)
 	}
 	react := doc.Packages[1]
@@ -48,6 +86,98 @@ func TestBuildSBOM(t *testing.T) {
 		if !strings.Contains(buf.String(), "pkg:npm/lodash@4.17.21") {
 			t.Errorf("encoded output missing purl:\n%s", buf.String())
 		}
+	}
+}
+
+func TestSelectSBOMDependenciesPrefersResolvedVersions(t *testing.T) {
+	direct := database.Dependency{
+		Ecosystem:    "npm",
+		Name:         "ua-parser-js",
+		Requirement:  "^1.0.41",
+		PURL:         "pkg:npm/ua-parser-js",
+		ManifestPath: "package.json",
+		ManifestKind: "manifest",
+	}
+	resolved := database.Dependency{
+		Ecosystem:    "npm",
+		Name:         "ua-parser-js",
+		Requirement:  "1.0.41",
+		PURL:         "pkg:npm/ua-parser-js",
+		ManifestPath: "package-lock.json",
+		ManifestKind: manifestKindLockfile,
+	}
+	nested := resolved
+	nested.Requirement = "2.0.10"
+
+	selected := selectSBOMDependencies([]database.Dependency{direct, resolved, nested, resolved})
+	if len(selected) != 2 {
+		t.Fatalf("selected dependencies = %d, want 2", len(selected))
+	}
+	if got := sbomPURLForDependency(selected[0]); got != "pkg:npm/ua-parser-js@1.0.41" {
+		t.Fatalf("first PURL = %q, want version 1.0.41", got)
+	}
+	if got := sbomPURLForDependency(selected[1]); got != "pkg:npm/ua-parser-js@2.0.10" {
+		t.Fatalf("second PURL = %q, want version 2.0.10", got)
+	}
+}
+
+func TestEnrichLicensesUsesVersionMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		versionLicense string
+		wantLicense    string
+		wantFallbacks  int
+	}{
+		{
+			name:           "version license",
+			versionLicense: "MIT",
+			wantLicense:    "MIT",
+		},
+		{
+			name:          "package fallback",
+			wantLicense:   "AGPL-3.0-or-later",
+			wantFallbacks: 1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &sbomEnrichmentClient{
+				packages: map[string]*enrichment.PackageInfo{
+					"pkg:npm/ua-parser-js": {License: "AGPL-3.0-or-later"},
+				},
+				versions: map[string]*enrichment.VersionInfo{
+					"pkg:npm/ua-parser-js@1.0.41": {Number: "1.0.41", License: tt.versionLicense},
+				},
+			}
+			original := NewEnrichmentClient
+			NewEnrichmentClient = func(...enrichment.Option) (enrichment.Client, error) {
+				return client, nil
+			}
+			defer func() { NewEnrichmentClient = original }()
+
+			deps := []database.Dependency{
+				{
+					Ecosystem:    "npm",
+					Name:         "ua-parser-js",
+					Requirement:  "1.0.41",
+					PURL:         "pkg:npm/ua-parser-js",
+					ManifestKind: manifestKindLockfile,
+				},
+			}
+			licenses, fallbacks, err := enrichLicenses(nil, deps)
+			if err != nil {
+				t.Fatalf("enrich licenses: %v", err)
+			}
+			if got := licenses["pkg:npm/ua-parser-js@1.0.41"]; got != tt.wantLicense {
+				t.Fatalf("license = %q, want %q", got, tt.wantLicense)
+			}
+			if fallbacks != tt.wantFallbacks {
+				t.Fatalf("package fallbacks = %d, want %d", fallbacks, tt.wantFallbacks)
+			}
+			if client.bulkLookupCalls != 1 || client.getVersionCalls != 1 {
+				t.Fatalf("enrichment calls: BulkLookup=%d GetVersion=%d, want 1 each",
+					client.bulkLookupCalls, client.getVersionCalls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Use resolved dependency versions for SBOM component PURLs and license enrichment. Preserve distinct installed versions, prefer exact-version licenses, and warn when package-level license metadata is used as a fallback.

Closes #285