### PR TITLE
Resolve direct versions for license checks

### DIFF
--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -45,16 +45,22 @@ Licenses are normalized to SPDX identifiers when possible.`,
 }
 
 type LicenseInfo struct {
-	Name         string   `json:"name"`
-	Ecosystem    string   `json:"ecosystem"`
-	Version      string   `json:"version,omitempty"`
-	Licenses     []string `json:"licenses"`
-	LicenseText  string   `json:"license_text,omitempty"`
-	ManifestPath string   `json:"manifest_path"`
-	PURL         string   `json:"purl,omitempty"`
-	Flagged      bool     `json:"flagged,omitempty"`
-	FlagReason   string   `json:"flag_reason,omitempty"`
+	Name          string   `json:"name"`
+	Ecosystem     string   `json:"ecosystem"`
+	Version       string   `json:"version,omitempty"`
+	Licenses      []string `json:"licenses"`
+	LicenseText   string   `json:"license_text,omitempty"`
+	ManifestPath  string   `json:"manifest_path"`
+	PURL          string   `json:"purl,omitempty"`
+	LicenseSource string   `json:"license_source,omitempty"`
+	Flagged       bool     `json:"flagged,omitempty"`
+	FlagReason    string   `json:"flag_reason,omitempty"`
 }
+
+const (
+	licenseSourcePackage = "package"
+	licenseSourceVersion = "version"
+)
 
 type LicenseDriftSummary struct {
 	TotalDependencies      int `json:"total_dependencies"`
@@ -156,7 +162,7 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("looking up packages: %w", err)
 	}
-	resolvedVersionPURLs, resolvedDeps := resolvedLicenseVersions(purlToDep, deps)
+	resolvedVersionPURLs, resolvedDeps, ambiguousVersions := resolvedLicenseVersions(purlToDep, deps)
 	// Version metadata is optional; package metadata remains the fallback.
 	versionLicenses, versionLicenseErr := loadLicenseVersionLicenses(db, resolvedDeps, offline)
 	if versionLicenseErr != nil {
@@ -186,10 +192,11 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 
 	// Build license info
 	var licenseInfos []LicenseInfo
+	var ambiguousFallbacks []string
 	hasViolations := false
 
-	for purl, data := range packageData {
-		dep := purlToDep[purl]
+	for lookupPURL, data := range packageData {
+		dep := purlToDep[lookupPURL]
 
 		// Use API data when dep lookup failed (PURL mismatch)
 		name := dep.Name
@@ -204,12 +211,23 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 			Ecosystem:    ecosystem,
 			Version:      dep.Requirement,
 			ManifestPath: dep.ManifestPath,
-			PURL:         purl,
+			PURL:         lookupPURL,
 		}
 
 		license := data.License
-		if versionLicense := versionLicenses[resolvedVersionPURLs[purl]]; versionLicense != "" {
+		versionedPURL := resolvedVersionPURLs[lookupPURL]
+		if versionLicense := versionLicenses[versionedPURL]; versionLicense != "" {
 			license = versionLicense
+			info.LicenseSource = licenseSourceVersion
+			info.PURL = versionedPURL
+			if parsed, parseErr := purl.Parse(versionedPURL); parseErr == nil {
+				info.Version = parsed.Version
+			}
+		} else if license != "" {
+			info.LicenseSource = licenseSourcePackage
+			if ambiguousVersions[lookupPURL] {
+				ambiguousFallbacks = append(ambiguousFallbacks, lookupPURL)
+			}
 		}
 		if license != "" {
 			info.Licenses = []string{license}
@@ -276,6 +294,13 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 		}
 
 		licenseInfos = append(licenseInfos, info)
+	}
+	if len(ambiguousFallbacks) > 0 {
+		sort.Strings(ambiguousFallbacks)
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+			"Warning: could not determine installed versions for %d dependencies; using package-level license metadata: %s\n",
+			len(ambiguousFallbacks), strings.Join(ambiguousFallbacks, ", "),
+		)
 	}
 
 	// Sort by name
@@ -434,9 +459,9 @@ func getLicenseData(
 func resolvedLicenseVersions(
 	purlToDep map[string]database.Dependency,
 	deps []database.Dependency,
-) (map[string]string, []database.Dependency) {
-	// Manifest requirements are usually ranges, so only pair them with a
-	// lockfile when that package resolves to one version in the same directory.
+) (map[string]string, []database.Dependency, map[string]bool) {
+	// Manifest requirements are usually ranges. Prefer the lockfile's direct
+	// installation when it distinguishes that from other resolved versions.
 	candidatesByLocation := make(map[string]map[string]database.Dependency)
 	for _, dep := range deps {
 		if !isResolvedDependency(dep) {
@@ -450,11 +475,15 @@ func resolvedLicenseVersions(
 		if candidatesByLocation[location] == nil {
 			candidatesByLocation[location] = make(map[string]database.Dependency)
 		}
-		candidatesByLocation[location][versionedPURL] = dep
+		existing, ok := candidatesByLocation[location][versionedPURL]
+		if !ok || (dep.Direct && !existing.Direct) {
+			candidatesByLocation[location][versionedPURL] = dep
+		}
 	}
 
 	resolvedVersionPURLs := make(map[string]string)
 	resolvedByPURL := make(map[string]database.Dependency)
+	ambiguousVersions := make(map[string]bool)
 	for lookupPURL, directDep := range purlToDep {
 		if isResolvedDependency(directDep) {
 			versionedPURL := versionedPURLForDependency(directDep)
@@ -466,13 +495,15 @@ func resolvedLicenseVersions(
 		}
 
 		candidates := candidatesByLocation[licenseDependencyLocation(directDep)]
-		if len(candidates) != 1 {
+		versionedPURL, dep, ambiguous := resolvedLicenseCandidate(candidates)
+		if ambiguous {
+			ambiguousVersions[lookupPURL] = true
+		}
+		if versionedPURL == "" {
 			continue
 		}
-		for versionedPURL, dep := range candidates {
-			resolvedVersionPURLs[lookupPURL] = versionedPURL
-			resolvedByPURL[versionedPURL] = dep
-		}
+		resolvedVersionPURLs[lookupPURL] = versionedPURL
+		resolvedByPURL[versionedPURL] = dep
 	}
 
 	versionedPURLs := make([]string, 0, len(resolvedByPURL))
@@ -485,7 +516,31 @@ func resolvedLicenseVersions(
 	for _, versionedPURL := range versionedPURLs {
 		resolvedDeps = append(resolvedDeps, resolvedByPURL[versionedPURL])
 	}
-	return resolvedVersionPURLs, resolvedDeps
+	return resolvedVersionPURLs, resolvedDeps, ambiguousVersions
+}
+
+func resolvedLicenseCandidate(candidates map[string]database.Dependency) (string, database.Dependency, bool) {
+	if len(candidates) == 1 {
+		for versionedPURL, dep := range candidates {
+			return versionedPURL, dep, false
+		}
+	}
+
+	var directPURL string
+	var directDep database.Dependency
+	directCount := 0
+	for versionedPURL, dep := range candidates {
+		if !dep.Direct {
+			continue
+		}
+		directPURL = versionedPURL
+		directDep = dep
+		directCount++
+	}
+	if directCount == 1 {
+		return directPURL, directDep, false
+	}
+	return "", database.Dependency{}, len(candidates) > 1
 }
 
 func licenseDependencyLocation(dep database.Dependency) string {

--- a/cmd/licenses_internal_test.go
+++ b/cmd/licenses_internal_test.go
@@ -23,12 +23,14 @@ func TestResolvedLicenseVersions(t *testing.T) {
 		Requirement:  "1.0.41",
 		ManifestPath: "app/package-lock.json",
 		ManifestKind: manifestKindLockfile,
+		Direct:       true,
 	}
 
 	for _, tt := range []struct {
-		name     string
-		deps     []database.Dependency
-		wantPURL string
+		name          string
+		deps          []database.Dependency
+		wantPURL      string
+		wantAmbiguous bool
 	}{
 		{
 			name:     "one resolved version in the manifest directory",
@@ -36,7 +38,8 @@ func TestResolvedLicenseVersions(t *testing.T) {
 			wantPURL: "pkg:npm/ua-parser-js@1.0.41",
 		},
 		{
-			name: "multiple resolved versions are ambiguous",
+			name:     "direct resolved version disambiguates multiple versions",
+			wantPURL: "pkg:npm/ua-parser-js@1.0.41",
 			deps: []database.Dependency{
 				direct,
 				resolved,
@@ -49,6 +52,18 @@ func TestResolvedLicenseVersions(t *testing.T) {
 					ManifestKind: manifestKindLockfile,
 				},
 			},
+		},
+		{
+			name:          "multiple resolved versions without direct marker are ambiguous",
+			wantAmbiguous: true,
+			deps: func() []database.Dependency {
+				first := resolved
+				first.Direct = false
+				second := first
+				second.PURL = "pkg:npm/ua-parser-js@0.7.41"
+				second.Requirement = "0.7.41"
+				return []database.Dependency{direct, first, second}
+			}(),
 		},
 		{
 			name: "resolved version in another directory does not match",
@@ -66,7 +81,7 @@ func TestResolvedLicenseVersions(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			versions, resolvedDeps := resolvedLicenseVersions(
+			versions, resolvedDeps, ambiguous := resolvedLicenseVersions(
 				map[string]database.Dependency{direct.PURL: direct},
 				tt.deps,
 			)
@@ -79,6 +94,9 @@ func TestResolvedLicenseVersions(t *testing.T) {
 			}
 			if len(resolvedDeps) != wantDeps {
 				t.Fatalf("resolved dependencies = %d, want %d", len(resolvedDeps), wantDeps)
+			}
+			if ambiguous[direct.PURL] != tt.wantAmbiguous {
+				t.Fatalf("ambiguous = %v, want %v", ambiguous[direct.PURL], tt.wantAmbiguous)
 			}
 		})
 	}

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -117,6 +117,35 @@ const uaParserPackageLockJSON = `{
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.41"
+    },
+    "node_modules/some-parent": {
+      "version": "1.0.0",
+      "dependencies": {
+        "ua-parser-js": "2.0.10"
+      }
+    },
+    "node_modules/some-parent/node_modules/ua-parser-js": {
+      "version": "2.0.10"
+    }
+  }
+}
+`
+
+const uaParserAmbiguousPackageLockJSON = `{
+  "name": "license-test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "ua-parser-js": {
+      "version": "1.0.41"
+    },
+    "some-parent": {
+      "version": "1.0.0",
+      "dependencies": {
+        "ua-parser-js": {
+          "version": "2.0.10"
+        }
+      }
     }
   }
 }
@@ -207,6 +236,9 @@ func TestLicensesCommand(t *testing.T) {
 		name           string
 		versionLicense string
 		wantLicense    string
+		wantPURL       string
+		wantVersion    string
+		wantSource     string
 		wantViolation  bool
 		wantWarning    bool
 	}{
@@ -214,15 +246,24 @@ func TestLicensesCommand(t *testing.T) {
 			name:           "license policies use installed version metadata",
 			versionLicense: "MIT",
 			wantLicense:    "MIT",
+			wantPURL:       "pkg:npm/ua-parser-js@1.0.41",
+			wantVersion:    "1.0.41",
+			wantSource:     "version",
 		},
 		{
 			name:          "license policies fall back to package metadata",
 			wantLicense:   "AGPL-3.0-or-later",
+			wantPURL:      "pkg:npm/ua-parser-js",
+			wantVersion:   "^1.0.41",
+			wantSource:    "package",
 			wantViolation: true,
 		},
 		{
 			name:          "license policies warn when version lookup fails",
 			wantLicense:   "AGPL-3.0-or-later",
+			wantPURL:      "pkg:npm/ua-parser-js",
+			wantVersion:   "^1.0.41",
+			wantSource:    "package",
 			wantViolation: true,
 			wantWarning:   true,
 		},
@@ -273,6 +314,13 @@ func TestLicensesCommand(t *testing.T) {
 			if result[0].Flagged != tt.wantViolation {
 				t.Fatalf("flagged = %v, want %v", result[0].Flagged, tt.wantViolation)
 			}
+			if result[0].PURL != tt.wantPURL || result[0].Version != tt.wantVersion {
+				t.Fatalf("package identity = %s %s, want %s %s",
+					result[0].PURL, result[0].Version, tt.wantPURL, tt.wantVersion)
+			}
+			if result[0].LicenseSource != tt.wantSource {
+				t.Fatalf("license source = %q, want %q", result[0].LicenseSource, tt.wantSource)
+			}
 
 			mock.mu.Lock()
 			getVersionCalls := mock.getVersionCalls
@@ -282,6 +330,51 @@ func TestLicensesCommand(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ambiguous lockfile versions identify package fallback", func(t *testing.T) {
+		mock, restore := setMockEnrichmentWithVersionInfos(
+			map[string]*enrichment.PackageInfo{
+				"pkg:npm/ua-parser-js": {
+					Ecosystem: "npm",
+					Name:      "ua-parser-js",
+					License:   "AGPL-3.0-or-later",
+				},
+			},
+			nil,
+		)
+		defer restore()
+
+		initRepoWithFiles(t, map[string]string{
+			"package.json":      uaParserPackageJSON,
+			"package-lock.json": uaParserAmbiguousPackageLockJSON,
+		})
+
+		stdout, stderr, err := runCmd(t, "licenses", "--format", "json")
+		if err != nil {
+			t.Fatalf("licenses: %v", err)
+		}
+		if !strings.Contains(stderr, "could not determine installed versions") {
+			t.Fatalf("missing ambiguity warning: %s", stderr)
+		}
+
+		var result []cmd.LicenseInfo
+		if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+			t.Fatalf("parse licenses output: %v\nOutput: %s", err, stdout)
+		}
+		if len(result) != 1 {
+			t.Fatalf("license entries = %d, want 1", len(result))
+		}
+		if result[0].PURL != "pkg:npm/ua-parser-js" || result[0].LicenseSource != "package" {
+			t.Fatalf("package fallback = %+v", result[0])
+		}
+
+		mock.mu.Lock()
+		getVersionCalls := mock.getVersionCalls
+		mock.mu.Unlock()
+		if getVersionCalls != 0 {
+			t.Fatalf("GetVersion calls = %d, want 0", getVersionCalls)
+		}
+	})
 
 	t.Run("copyleft flag detects copyleft licenses", func(t *testing.T) {
 		restore := setMockEnrichment(map[string]*enrichment.PackageInfo{

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -36,6 +36,7 @@ type Change struct {
 	DependencyType         string
 	PreviousDependencyType string
 	Integrity              string
+	Direct                 bool
 }
 
 type SnapshotEntry struct {
@@ -45,6 +46,7 @@ type SnapshotEntry struct {
 	Requirement    string
 	DependencyType string
 	Integrity      string
+	Direct         bool
 }
 
 type SnapshotKey struct {
@@ -331,6 +333,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
 				Integrity:      integrity,
+				Direct:         dep.Direct,
 			}
 			result.Changes = append(result.Changes, change)
 
@@ -342,6 +345,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
 				Integrity:      integrity,
+				Direct:         dep.Direct,
 			}
 		}
 	}
@@ -431,6 +435,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 							DependencyType:         string(dep.Scope),
 							PreviousDependencyType: string(before.Scope),
 							Integrity:              integrity,
+							Direct:                 dep.Direct,
 						})
 						break
 					}
@@ -456,6 +461,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 						Requirement:    dep.Version,
 						DependencyType: string(dep.Scope),
 						Integrity:      integrity,
+						Direct:         dep.Direct,
 					})
 				} else {
 					result.Changes = append(result.Changes, Change{
@@ -469,6 +475,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 						PreviousRequirement: previousVersion,
 						DependencyType:      string(dep.Scope),
 						Integrity:           integrity,
+						Direct:              dep.Direct,
 					})
 				}
 			} else {
@@ -483,6 +490,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 					Requirement:    dep.Version,
 					DependencyType: string(dep.Scope),
 					Integrity:      integrity,
+					Direct:         dep.Direct,
 				})
 			}
 
@@ -493,6 +501,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
 				Integrity:      integrity,
+				Direct:         dep.Direct,
 			}
 		}
 
@@ -520,6 +529,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 							Requirement:    dep.Version,
 							DependencyType: string(dep.Scope),
 							Integrity:      dep.Integrity,
+							Direct:         dep.Direct,
 						})
 					}
 					key := SnapshotKey{ManifestPath: path, Name: dep.Name, Requirement: dep.Version}
@@ -555,6 +565,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
 				Integrity:      dep.Integrity,
+				Direct:         dep.Direct,
 			})
 
 			key := SnapshotKey{ManifestPath: path, Name: dep.Name, Requirement: dep.Version}
@@ -634,6 +645,7 @@ func (a *Analyzer) DependenciesAtCommit(commit *object.Commit) ([]Change, error)
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
 				Integrity:      integrity,
+				Direct:         dep.Direct,
 			})
 		}
 
@@ -825,6 +837,7 @@ func (a *Analyzer) DependenciesInWorkingDir(root string, includeSubmodules bool)
 				Requirement:    dep.Version,
 				DependencyType: string(dep.Scope),
 				Integrity:      integrity,
+				Direct:         dep.Direct,
 			})
 		}
 

--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -47,6 +47,7 @@ type SnapshotInfo struct {
 	Requirement    string
 	DependencyType string
 	Integrity      string
+	Direct         bool
 }
 
 type pendingCommit struct {
@@ -547,8 +548,8 @@ func (w *BatchWriter) insertSnapshots(tx *sql.Tx, commitIDs map[string]int64, no
 		return nil
 	}
 
-	// Snapshots have 10 columns, so max rows per batch = MaxSQLVariables / 10
-	const columnsPerRow = 10
+	// Snapshots have 11 columns, so max rows per batch = MaxSQLVariables / 11
+	const columnsPerRow = 11
 	maxRowsPerBatch := MaxSQLVariables / columnsPerRow
 
 	for start := 0; start < len(pending); start += maxRowsPerBatch {
@@ -559,14 +560,14 @@ func (w *BatchWriter) insertSnapshots(tx *sql.Tx, commitIDs map[string]int64, no
 		batch := pending[start:end]
 
 		var sb strings.Builder
-		sb.WriteString("INSERT OR IGNORE INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, created_at, updated_at) VALUES ")
+		sb.WriteString("INSERT OR IGNORE INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, direct, created_at, updated_at) VALUES ")
 
 		args := make([]any, 0, len(batch)*columnsPerRow)
 		for i, ps := range batch {
 			if i > 0 {
 				sb.WriteString(",")
 			}
-			sb.WriteString("(?,?,?,?,?,?,?,?,?,?)")
+			sb.WriteString("(?,?,?,?,?,?,?,?,?,?,?)")
 			args = append(args,
 				commitIDs[ps.sha],
 				w.manifestCache[ps.manifest.Path],
@@ -576,6 +577,7 @@ func (w *BatchWriter) insertSnapshots(tx *sql.Tx, commitIDs map[string]int64, no
 				ps.snapshot.Requirement,
 				ps.snapshot.DependencyType,
 				ps.snapshot.Integrity,
+				ps.snapshot.Direct,
 				now,
 				now,
 			)

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 14
+const SchemaVersion = 15
 
 type DB struct {
 	*sql.DB

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -238,7 +238,7 @@ func (db *DB) GetLastSnapshot(branchID int64) (map[string]SnapshotInfo, error) {
 	}
 
 	rows, err := db.Query(`
-		SELECT m.path, ds.name, ds.ecosystem, ds.purl, ds.requirement, ds.dependency_type, ds.integrity
+		SELECT m.path, ds.name, ds.ecosystem, ds.purl, ds.requirement, ds.dependency_type, ds.integrity, ds.direct
 		FROM dependency_snapshots ds
 		JOIN manifests m ON m.id = ds.manifest_id
 		WHERE ds.commit_id = ?
@@ -254,7 +254,7 @@ func (db *DB) GetLastSnapshot(branchID int64) (map[string]SnapshotInfo, error) {
 		var info SnapshotInfo
 		var ecosystem, purl, requirement, depType, integrity sql.NullString
 
-		if err := rows.Scan(&path, &name, &ecosystem, &purl, &requirement, &depType, &integrity); err != nil {
+		if err := rows.Scan(&path, &name, &ecosystem, &purl, &requirement, &depType, &integrity, &info.Direct); err != nil {
 			return nil, err
 		}
 
@@ -307,6 +307,7 @@ type Dependency struct {
 	Integrity      string `json:"integrity,omitempty"`
 	ManifestPath   string `json:"manifest_path"`
 	ManifestKind   string `json:"manifest_kind"`
+	Direct         bool   `json:"-"`
 }
 
 func (db *DB) GetDependenciesAtRef(ref string, branchID int64) ([]Dependency, error) {
@@ -371,7 +372,7 @@ func (db *DB) GetLatestDependencies(branchID int64) ([]Dependency, error) {
 
 func (db *DB) getDependenciesForCommitID(commitID int64) ([]Dependency, error) {
 	rows, err := db.Query(`
-		SELECT ds.name, ds.ecosystem, ds.purl, ds.requirement, ds.dependency_type, ds.integrity, m.path, m.kind
+		SELECT ds.name, ds.ecosystem, ds.purl, ds.requirement, ds.dependency_type, ds.integrity, ds.direct, m.path, m.kind
 		FROM dependency_snapshots ds
 		JOIN manifests m ON m.id = ds.manifest_id
 		WHERE ds.commit_id = ? AND ds.name != '_EMPTY_MARKER_'
@@ -387,7 +388,7 @@ func (db *DB) getDependenciesForCommitID(commitID int64) ([]Dependency, error) {
 		var d Dependency
 		var ecosystem, purl, requirement, depType, integrity, kind sql.NullString
 
-		if err := rows.Scan(&d.Name, &ecosystem, &purl, &requirement, &depType, &integrity, &d.ManifestPath, &kind); err != nil {
+		if err := rows.Scan(&d.Name, &ecosystem, &purl, &requirement, &depType, &integrity, &d.Direct, &d.ManifestPath, &kind); err != nil {
 			return nil, err
 		}
 
@@ -3029,9 +3030,9 @@ func (db *DB) StoreSnapshot(branchID int64, commit CommitInfo, snapshots []Snaps
 
 		// Insert snapshot (use OR IGNORE to handle duplicates within the same manifest)
 		_, err = tx.Exec(`
-			INSERT OR IGNORE INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-		`, commitID, manifestID, s.Name, s.Ecosystem, s.PURL, s.Requirement, s.DependencyType, s.Integrity, now, now)
+			INSERT OR IGNORE INTO dependency_snapshots (commit_id, manifest_id, name, ecosystem, purl, requirement, dependency_type, integrity, direct, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`, commitID, manifestID, s.Name, s.Ecosystem, s.PURL, s.Requirement, s.DependencyType, s.Integrity, s.Direct, now, now)
 		if err != nil {
 			return fmt.Errorf("inserting snapshot: %w", err)
 		}

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -83,6 +83,7 @@ func (db *DB) CreateSchema() error {
 		requirement TEXT,
 		dependency_type TEXT,
 		integrity TEXT,
+		direct INTEGER NOT NULL DEFAULT 0,
 		created_at DATETIME,
 		updated_at DATETIME
 	);

--- a/internal/git/query.go
+++ b/internal/git/query.go
@@ -136,6 +136,7 @@ func (r *Repository) IndexCommitSnapshot(db *database.DB, branchID int64, sha st
 			Requirement:    c.Requirement,
 			DependencyType: c.DependencyType,
 			Integrity:      c.Integrity,
+			Direct:         c.Direct,
 		})
 	}
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -251,6 +251,7 @@ func (idx *Indexer) Run() (*Result, error) {
 								Requirement:    entry.Requirement,
 								DependencyType: entry.DependencyType,
 								Integrity:      entry.Integrity,
+								Direct:         entry.Direct,
 							}
 							writer.AddSnapshot(sha, manifest, snapshotInfo)
 						}
@@ -277,6 +278,7 @@ func (idx *Indexer) Run() (*Result, error) {
 						Requirement:    entry.Requirement,
 						DependencyType: entry.DependencyType,
 						Integrity:      entry.Integrity,
+						Direct:         entry.Direct,
 					}
 					writer.AddSnapshot(sha, manifest, snapshotInfo)
 				}
@@ -319,6 +321,7 @@ func (idx *Indexer) Run() (*Result, error) {
 					Requirement:    entry.Requirement,
 					DependencyType: entry.DependencyType,
 					Integrity:      entry.Integrity,
+					Direct:         entry.Direct,
 				}
 				writer.AddSnapshot(lastSHAWithChanges, manifest, snapshotInfo)
 			}
@@ -371,6 +374,7 @@ func convertDBSnapshot(dbSnapshot map[string]database.SnapshotInfo) analyzer.Sna
 			Requirement:    info.Requirement,
 			DependencyType: info.DependencyType,
 			Integrity:      info.Integrity,
+			Direct:         info.Direct,
 		}
 	}
 	return result


### PR DESCRIPTION
Preserve direct lockfile relationships in dependency snapshots so `licenses` can select the installed version when multiple versions of a package exist. Version-backed results now use exact PURLs, while ambiguous package-level fallbacks are identified in JSON and produce a warning.

This bumps the database schema to version 15 so rebuilt snapshots retain direct dependency metadata.

Closes #286