### PR TITLE
Handle withdrawn versions in dependency checks

### DIFF
--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -20,8 +20,8 @@ func addDeprecatedCmd(parent *cobra.Command) {
 	deprecatedCmd := &cobra.Command{
 		Use:     "deprecated",
 		Aliases: []string{"deprecations"},
-		Short:   "Find deprecated dependency versions",
-		Long:    `Check installed dependency versions against registries and report deprecated versions.`,
+		Short:   "Find deprecated or withdrawn dependency versions",
+		Long:    `Check installed dependency versions against registries and report deprecated, yanked, or retracted versions.`,
 		RunE:    runDeprecated,
 	}
 
@@ -36,6 +36,7 @@ type DeprecatedPackage struct {
 	Name         string `json:"name"`
 	Ecosystem    string `json:"ecosystem"`
 	Version      string `json:"version"`
+	Status       string `json:"status"`
 	Message      string `json:"message,omitempty"`
 	ManifestPath string `json:"manifest_path"`
 	PURL         string `json:"purl,omitempty"`
@@ -99,7 +100,7 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 		if format == formatJSON {
 			return outputDeprecatedJSON(cmd, []DeprecatedPackage{})
 		}
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No deprecated dependencies found.")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No deprecated or withdrawn dependencies found.")
 		return nil
 	}
 
@@ -119,10 +120,21 @@ func versionedPURLForDependency(dep database.Dependency) string {
 	if dep.PURL != "" {
 		parsed, err := purl.Parse(dep.PURL)
 		if err == nil && parsed.Version != "" {
+			if isDefaultCargoIndex(parsed.Type, parsed.RepositoryURL()) {
+				return purl.MakePURLString(dep.Ecosystem, dep.Name, dep.Requirement)
+			}
 			return dep.PURL
 		}
 	}
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, dep.Requirement)
+}
+
+func isDefaultCargoIndex(purlType, registryURL string) bool {
+	if registries.DefaultURL(purlType) != "https://crates.io" {
+		return false
+	}
+	registryURL = strings.TrimSuffix(registryURL, "/")
+	return registryURL == "https://github.com/rust-lang/crates.io-index" || registryURL == "https://index.crates.io"
 }
 
 func fetchDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[string]*registries.Version {
@@ -246,7 +258,7 @@ func deprecatedPackages(
 	var deprecated []DeprecatedPackage
 
 	for purlStr, version := range versionData {
-		if version == nil || version.Status != registries.StatusDeprecated {
+		if version == nil || !reportableVersionStatus(version.Status) {
 			continue
 		}
 		for _, dep := range purlToDeps[purlStr] {
@@ -254,6 +266,7 @@ func deprecatedPackages(
 				Name:         dep.Name,
 				Ecosystem:    dep.Ecosystem,
 				Version:      dep.Requirement,
+				Status:       string(version.Status),
 				Message:      deprecationMessage(version),
 				ManifestPath: dep.ManifestPath,
 				PURL:         purlStr,
@@ -272,6 +285,10 @@ func deprecatedPackages(
 	})
 
 	return deprecated
+}
+
+func reportableVersionStatus(status registries.VersionStatus) bool {
+	return status == registries.StatusDeprecated || isWithdrawnVersionStatus(string(status))
 }
 
 func deprecationMessage(version *registries.Version) string {
@@ -305,9 +322,9 @@ func outputDeprecatedJSON(cmd *cobra.Command, deprecated []DeprecatedPackage) er
 }
 
 func outputDeprecatedText(cmd *cobra.Command, deprecated []DeprecatedPackage) {
-	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Found %d deprecated dependencies:\n\n", len(deprecated))
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Found %d deprecated or withdrawn dependencies:\n\n", len(deprecated))
 	for _, dep := range deprecated {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %s %s\n", dep.Name, dep.Version, Dim("("+dep.ManifestPath+")"))
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s %s [%s] %s\n", dep.Name, dep.Version, dep.Status, Dim("("+dep.ManifestPath+")"))
 		if dep.Message != "" {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", dep.Message)
 		}

--- a/cmd/deprecated_test.go
+++ b/cmd/deprecated_test.go
@@ -35,6 +35,18 @@ func TestVersionedPURLForDependency(t *testing.T) {
 			t.Fatalf("versioned PURL = %q, want existing PURL", got)
 		}
 	})
+
+	t.Run("normalizes the default crates.io index URL", func(t *testing.T) {
+		got := versionedPURLForDependency(database.Dependency{
+			PURL:        "pkg:cargo/time@0.3.50?repository_url=https:%2F%2Fgithub.com%2Frust-lang%2Fcrates.io-index",
+			Name:        "time",
+			Ecosystem:   "cargo",
+			Requirement: "0.3.50",
+		})
+		if got != "pkg:cargo/time@0.3.50" {
+			t.Fatalf("versioned PURL = %q, want unqualified crates.io PURL", got)
+		}
+	})
 }
 
 func TestDeprecatedPackages(t *testing.T) {
@@ -55,6 +67,22 @@ func TestDeprecatedPackages(t *testing.T) {
 				ManifestPath: "package-lock.json",
 			},
 		},
+		"pkg:cargo/time@0.3.50": {
+			{
+				Name:         "time",
+				Ecosystem:    "cargo",
+				Requirement:  "0.3.50",
+				ManifestPath: "Cargo.lock",
+			},
+		},
+		"pkg:golang/example.com/retracted@v1.1.0": {
+			{
+				Name:         "example.com/retracted",
+				Ecosystem:    "golang",
+				Requirement:  "v1.1.0",
+				ManifestPath: "go.sum",
+			},
+		},
 	}
 	versionData := map[string]*registries.Version{
 		"pkg:npm/request@2.88.2": {
@@ -68,17 +96,35 @@ func TestDeprecatedPackages(t *testing.T) {
 			Number: "4.17.21",
 			Status: registries.StatusNone,
 		},
+		"pkg:cargo/time@0.3.50": {
+			Number: "0.3.50",
+			Status: registries.StatusYanked,
+		},
+		"pkg:golang/example.com/retracted@v1.1.0": {
+			Number: "v1.1.0",
+			Status: registries.StatusRetracted,
+		},
 	}
 
 	got := deprecatedPackages(purlToDeps, versionData)
-	if len(got) != 1 {
-		t.Fatalf("deprecated count = %d, want 1", len(got))
+	if len(got) != 3 {
+		t.Fatalf("reported count = %d, want 3", len(got))
 	}
-	if got[0].Name != "request" {
-		t.Fatalf("deprecated package = %q, want request", got[0].Name)
+	byName := make(map[string]DeprecatedPackage, len(got))
+	for _, dep := range got {
+		byName[dep.Name] = dep
 	}
-	if got[0].Message != "request has been deprecated" {
-		t.Fatalf("message = %q, want deprecation message", got[0].Message)
+	if byName["request"].Status != string(registries.StatusDeprecated) {
+		t.Fatalf("request status = %q, want deprecated", byName["request"].Status)
+	}
+	if byName["request"].Message != "request has been deprecated" {
+		t.Fatalf("message = %q, want deprecation message", byName["request"].Message)
+	}
+	if byName["time"].Status != string(registries.StatusYanked) {
+		t.Fatalf("time status = %q, want yanked", byName["time"].Status)
+	}
+	if byName["example.com/retracted"].Status != string(registries.StatusRetracted) {
+		t.Fatalf("Go module status = %q, want retracted", byName["example.com/retracted"].Status)
 	}
 }
 

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -129,7 +128,7 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 
 		// If --at is specified, find the latest version at that date
 		if !atTime.IsZero() {
-			latest = findLatestAtDateCached(db, data.Ecosystem, data.Name, purl, atTime)
+			latest = findLatestAtDateCached(db, purl, atTime)
 			if latest == "" {
 				continue
 			}
@@ -270,25 +269,12 @@ func getPackageData(db *database.DB, purls []string, purlToDep map[string]databa
 	return result, nil
 }
 
-func findLatestAtDateCached(db *database.DB, ecosystem, name, purl string, atTime time.Time) string {
+func findLatestAtDateCached(db *database.DB, purl string, atTime time.Time) string {
 	// Check cache first if DB available
 	if db != nil {
 		versions, err := db.GetCachedVersionList(purl, enrichmentCacheTTL)
-		if err == nil && len(versions) > 0 {
-			var latestVersion string
-			var latestTime time.Time
-			for _, v := range versions {
-				if !v.PublishedAt.After(atTime) {
-					if latestVersion == "" || v.PublishedAt.After(latestTime) {
-						// Extract version from PURL (pkg:type/name@version)
-						if idx := strings.LastIndex(v.PURL, "@"); idx > 0 {
-							latestVersion = v.PURL[idx+1:]
-							latestTime = v.PublishedAt
-						}
-					}
-				}
-			}
-			if latestVersion != "" {
+		if err == nil && hasCachedVersionStatuses(versions) {
+			if latestVersion := latestAvailableVersionAt(versions, atTime); latestVersion != "" {
 				return latestVersion
 			}
 		}
@@ -309,25 +295,21 @@ func findLatestAtDateCached(db *database.DB, ecosystem, name, purl string, atTim
 		return ""
 	}
 
-	var latestVersion string
-	var latestTime time.Time
 	var toCache []database.CachedVersion
+	checkedAt := time.Now()
 
 	for _, v := range apiVersions {
 		// Build version PURL
 		versionPurl := purl + "@" + v.Number
-		toCache = append(toCache, database.CachedVersion{
-			PURL:        versionPurl,
-			PackagePURL: purl,
-			PublishedAt: v.PublishedAt,
-		})
-
-		if !v.PublishedAt.IsZero() && !v.PublishedAt.After(atTime) {
-			if latestVersion == "" || v.PublishedAt.After(latestTime) {
-				latestVersion = v.Number
-				latestTime = v.PublishedAt
-			}
+		cachedVersion := database.CachedVersion{
+			PURL:            versionPurl,
+			PackagePURL:     purl,
+			PublishedAt:     v.PublishedAt,
+			Status:          enrichmentVersionStatus(v),
+			StatusCheckedAt: checkedAt,
+			Metadata:        v.Metadata,
 		}
+		toCache = append(toCache, cachedVersion)
 	}
 
 	// Save to cache if DB available
@@ -335,6 +317,21 @@ func findLatestAtDateCached(db *database.DB, ecosystem, name, purl string, atTim
 		_ = db.SaveVersionList(purl, toCache)
 	}
 
+	return latestAvailableVersionAt(toCache, atTime)
+}
+
+func latestAvailableVersionAt(versions []database.CachedVersion, atTime time.Time) string {
+	var latestVersion string
+	var latestTime time.Time
+	for _, version := range versions {
+		if version.PublishedAt.IsZero() || version.PublishedAt.After(atTime) || isWithdrawnVersionStatus(version.Status) {
+			continue
+		}
+		if latestVersion == "" || version.PublishedAt.After(latestTime) {
+			latestVersion = versionFromPURL(version.PURL)
+			latestTime = version.PublishedAt
+		}
+	}
 	return latestVersion
 }
 

--- a/cmd/version_status.go
+++ b/cmd/version_status.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+const (
+	versionStatusYanked    = "yanked"
+	versionStatusRetracted = "retracted"
+)
+
+func isWithdrawnVersionStatus(status string) bool {
+	return status == versionStatusYanked || status == versionStatusRetracted
+}
+
+func enrichmentVersionStatus(version enrichment.VersionInfo) string {
+	if version.Status != "" {
+		return version.Status
+	}
+	if version.Yanked {
+		return versionStatusYanked
+	}
+	return ""
+}
+
+func hasCachedVersionStatuses(versions []database.CachedVersion) bool {
+	if len(versions) == 0 {
+		return false
+	}
+	for _, version := range versions {
+		if version.StatusCheckedAt.IsZero() {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/version_status_test.go
+++ b/cmd/version_status_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/git-pkgs/enrichment"
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestEnrichmentVersionStatus(t *testing.T) {
+	if got := enrichmentVersionStatus(enrichment.VersionInfo{Status: versionStatusRetracted, Yanked: true}); got != versionStatusRetracted {
+		t.Fatalf("full status = %q, want retracted", got)
+	}
+	if got := enrichmentVersionStatus(enrichment.VersionInfo{Yanked: true}); got != versionStatusYanked {
+		t.Fatalf("legacy yanked status = %q, want yanked", got)
+	}
+}
+
+func TestHasCachedVersionStatuses(t *testing.T) {
+	checkedAt := time.Now()
+	if !hasCachedVersionStatuses([]database.CachedVersion{{StatusCheckedAt: checkedAt}, {StatusCheckedAt: checkedAt}}) {
+		t.Fatal("expected complete version status cache")
+	}
+	if hasCachedVersionStatuses([]database.CachedVersion{{StatusCheckedAt: checkedAt}, {}}) {
+		t.Fatal("expected incomplete version status cache")
+	}
+}
+
+func TestLatestAvailableVersionAtExcludesWithdrawnVersions(t *testing.T) {
+	atTime := time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC)
+	versions := []database.CachedVersion{
+		{PURL: "pkg:cargo/example@1.0.0", PublishedAt: time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)},
+		{PURL: "pkg:cargo/example@1.1.0", PublishedAt: time.Date(2024, time.February, 1, 0, 0, 0, 0, time.UTC), Status: versionStatusRetracted},
+		{PURL: "pkg:cargo/example@1.2.0", PublishedAt: time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC), Status: versionStatusYanked},
+	}
+
+	if got := latestAvailableVersionAt(versions, atTime); got != "1.0.0" {
+		t.Fatalf("latest available version = %q, want 1.0.0", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/git-pkgs/changelog v0.1.3
-	github.com/git-pkgs/enrichment v0.6.2
+	github.com/git-pkgs/enrichment v0.6.3
 	github.com/git-pkgs/gitignore v1.2.0
 	github.com/git-pkgs/managers v0.10.1
 	github.com/git-pkgs/manifests v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
 github.com/git-pkgs/changelog v0.1.3 h1:iaFrl76F9lE3B9bQBZCpm0O+eB6tQ0ajMnrc5l7/EhU=
 github.com/git-pkgs/changelog v0.1.3/go.mod h1:psv6VJyJKYzDYajKdV9oPw7LUEOIqSiB0L3wcKdX6Ac=
-github.com/git-pkgs/enrichment v0.6.2 h1:xu0HGsU9WJtIOb2GfKbBilAupDUfIzm98aXYWXF305o=
-github.com/git-pkgs/enrichment v0.6.2/go.mod h1:1w67BEH9vw30e8rDCYB+tTlnzQXybFQmL6CHtTBDJqc=
+github.com/git-pkgs/enrichment v0.6.3 h1:6PPYSkrWo64Yy7q5DIn+xqDyQw10AypZ9a1gLrlpXGQ=
+github.com/git-pkgs/enrichment v0.6.3/go.mod h1:1w67BEH9vw30e8rDCYB+tTlnzQXybFQmL6CHtTBDJqc=
 github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLuFaM=
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/managers v0.10.1 h1:T877XtuXoJNweDTMGj1H6AOeVolDO44IvsgDN5jq3Ko=


### PR DESCRIPTION
Report yanked and retracted installed versions from `git pkgs deprecated`.

Preserve version status and metadata from enrichment v0.6.3 when populating the historical version cache, and exclude withdrawn releases from `git pkgs outdated --at` candidates.

Addresses #287.