### PR TITLE
Fix vulnerability ref resolution

### DIFF
--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -1083,8 +1083,13 @@ func analyzeVulnExposure(vuln *vulns.Vulnerability, ref, branchName string) (*Vu
 		return nil, err
 	}
 
+	sha, err := resolveVulnsRef(repo, ref)
+	if err != nil {
+		return nil, err
+	}
+
 	// Get dependencies at the specified ref
-	deps, err := db.GetDependenciesAtRef(ref, branch.ID)
+	deps, err := db.GetDependenciesAtRef(sha, branch.ID)
 	if err != nil {
 		return nil, fmt.Errorf("getting dependencies: %w", err)
 	}
@@ -1211,12 +1216,12 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get vulnerabilities at both refs
-	fromVulns, err := getVulnsAtRef(db, branch.ID, fromRef, ecosystem, ecosystemFilter)
+	fromVulns, err := getVulnsAtRef(repo, db, branch.ID, fromRef, ecosystem, ecosystemFilter)
 	if err != nil {
 		return fmt.Errorf("getting vulns at %s: %w", fromRef, err)
 	}
 
-	toVulns, err := getVulnsAtRef(db, branch.ID, toRef, ecosystem, ecosystemFilter)
+	toVulns, err := getVulnsAtRef(repo, db, branch.ID, toRef, ecosystem, ecosystemFilter)
 	if err != nil {
 		return fmt.Errorf("getting vulns at %s: %w", toRef, err)
 	}
@@ -1289,8 +1294,37 @@ func runVulnsDiff(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getVulnsAtRef(db *database.DB, branchID int64, ref, ecosystem string, filter config.EcosystemFilter) ([]VulnResult, error) {
-	deps, err := db.GetDependenciesAtRef(ref, branchID)
+func getVulnsAtRef(
+	repo *git.Repository,
+	db *database.DB,
+	branchID int64,
+	ref, ecosystem string,
+	filter config.EcosystemFilter,
+) ([]VulnResult, error) {
+	sha, err := resolveVulnsRef(repo, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return getVulnsAtCommit(db, branchID, sha, ecosystem, filter)
+}
+
+func resolveVulnsRef(repo *git.Repository, ref string) (string, error) {
+	hash, err := repo.ResolveRevision(ref)
+	if err != nil {
+		return "", fmt.Errorf("resolving %q: %w", ref, err)
+	}
+
+	return hash.String(), nil
+}
+
+func getVulnsAtCommit(
+	db *database.DB,
+	branchID int64,
+	sha, ecosystem string,
+	filter config.EcosystemFilter,
+) ([]VulnResult, error) {
+	deps, err := db.GetDependenciesAtRef(sha, branchID)
 	if err != nil {
 		return nil, err
 	}
@@ -1331,7 +1365,7 @@ func getAllTimeVulns(db *database.DB, branchID int64, ecosystem string, filter c
 	seen := make(map[string]VulnResult) // key: vulnID:package:version
 
 	for _, c := range commits {
-		vulns, err := getVulnsAtRef(db, branchID, c.SHA, ecosystem, filter)
+		vulns, err := getVulnsAtCommit(db, branchID, c.SHA, ecosystem, filter)
 		if err != nil {
 			continue
 		}
@@ -1413,7 +1447,7 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	if allTime {
 		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter)
 	} else {
-		vulns, err = getVulnsAtRef(db, branch.ID, refHEAD, ecosystem, ecosystemFilter)
+		vulns, err = getVulnsAtRef(repo, db, branch.ID, refHEAD, ecosystem, ecosystemFilter)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)
@@ -1621,7 +1655,7 @@ func runVulnsLog(cmd *cobra.Command, args []string) error {
 
 	for i, c := range commits {
 		// Get vulns at this commit
-		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter)
+		currentVulns, err := getVulnsAtCommit(db, branch.ID, c.SHA, ecosystem, ecosystemFilter)
 		if err != nil {
 			continue
 		}
@@ -1934,7 +1968,7 @@ func runVulnsExposure(cmd *cobra.Command, args []string) error {
 		// Get all historical vulnerabilities by scanning commit history
 		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter)
 	} else {
-		vulns, err = getVulnsAtRef(db, branch.ID, targetRef, ecosystem, ecosystemFilter)
+		vulns, err = getVulnsAtRef(repo, db, branch.ID, targetRef, ecosystem, ecosystemFilter)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)
@@ -2188,7 +2222,7 @@ func runVulnsPraise(cmd *cobra.Command, args []string) error {
 	var prevVulns []VulnResult
 
 	for i, c := range commits {
-		currentVulns, err := getVulnsAtRef(db, branch.ID, c.SHA, ecosystem, ecosystemFilter)
+		currentVulns, err := getVulnsAtCommit(db, branch.ID, c.SHA, ecosystem, ecosystemFilter)
 		if err != nil {
 			continue
 		}

--- a/cmd/vulns_blame_test.go
+++ b/cmd/vulns_blame_test.go
@@ -1,0 +1,107 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestVulnsBlameResolvesHEAD(t *testing.T) {
+	vuln := setupVulnerableNPMRepo(t)
+
+	stdout, _, err := runCmd(t, "vulns", "blame", "--format", "json")
+	if err != nil {
+		t.Fatalf("vulns blame failed: %v", err)
+	}
+
+	var entries []struct {
+		VulnID  string `json:"vuln_id"`
+		Package string `json:"package"`
+		AddedBy string `json:"added_by"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &entries); err != nil {
+		t.Fatalf("parsing vulns blame output: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.VulnID == vuln.ID && entry.Package == "express" && entry.AddedBy == "Test User" {
+			return
+		}
+	}
+
+	t.Fatalf("expected express vulnerability blame entry, got: %#v", entries)
+}
+
+func TestVulnsExposureResolvesHEAD(t *testing.T) {
+	vuln := setupVulnerableNPMRepo(t)
+
+	stdout, _, err := runCmd(t, "vulns", "exposure", "--format", "json")
+	if err != nil {
+		t.Fatalf("vulns exposure failed: %v", err)
+	}
+
+	var entries []struct {
+		VulnID       string `json:"vuln_id"`
+		Package      string `json:"package"`
+		IntroducedBy string `json:"introduced_by"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &entries); err != nil {
+		t.Fatalf("parsing vulns exposure output: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.VulnID == vuln.ID && entry.Package == "express" && entry.IntroducedBy == "Test User" {
+			return
+		}
+	}
+
+	t.Fatalf("expected express vulnerability exposure entry, got: %#v", entries)
+}
+
+func setupVulnerableNPMRepo(t *testing.T) database.Vulnerability {
+	t.Helper()
+
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+	addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add package-lock.json")
+
+	cleanup := chdir(t, repoDir)
+	t.Cleanup(cleanup)
+
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+
+	vuln := database.Vulnerability{
+		ID:        "GHSA-issue-299",
+		Severity:  "high",
+		Summary:   "Test vulnerability",
+		FetchedAt: time.Now().Format(time.RFC3339),
+	}
+	if err := db.InsertVulnerability(vuln); err != nil {
+		_ = db.Close()
+		t.Fatalf("inserting vulnerability: %v", err)
+	}
+	if err := db.InsertVulnerabilityPackage(database.VulnerabilityPackage{
+		VulnerabilityID: vuln.ID,
+		Ecosystem:       "npm",
+		PackageName:     "express",
+		FixedVersions:   "4.19.0",
+	}); err != nil {
+		_ = db.Close()
+		t.Fatalf("inserting vulnerability package: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing database: %v", err)
+	}
+
+	return vuln
+}

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -404,7 +404,7 @@ func TestScanLiveWithSourceBatchErrorIdentifiesDependency(t *testing.T) {
 	}
 }
 
-func TestGetVulnsAtRefAppliesEcosystemConfig(t *testing.T) {
+func TestGetVulnsAtCommitAppliesEcosystemConfig(t *testing.T) {
 	db := newTestDB(t)
 	branch, err := db.GetOrCreateBranch("main")
 	if err != nil {
@@ -462,18 +462,18 @@ func TestGetVulnsAtRefAppliesEcosystemConfig(t *testing.T) {
 		t.Fatalf("InsertVulnerabilityPackage: %v", err)
 	}
 
-	unfiltered, err := getVulnsAtRef(db, branch.ID, commitSHA, "", config.NewEcosystemFilter(nil, nil))
+	unfiltered, err := getVulnsAtCommit(db, branch.ID, commitSHA, "", config.NewEcosystemFilter(nil, nil))
 	if err != nil {
-		t.Fatalf("getVulnsAtRef without filter: %v", err)
+		t.Fatalf("getVulnsAtCommit without filter: %v", err)
 	}
 	if len(unfiltered) != 1 || unfiltered[0].Package != "foo" {
 		t.Fatalf("expected seeded npm vuln before filtering, got: %#v", unfiltered)
 	}
 
 	filter := config.NewEcosystemFilter(nil, []string{"npm"})
-	results, err := getVulnsAtRef(db, branch.ID, commitSHA, "", filter)
+	results, err := getVulnsAtCommit(db, branch.ID, commitSHA, "", filter)
 	if err != nil {
-		t.Fatalf("getVulnsAtRef: %v", err)
+		t.Fatalf("getVulnsAtCommit: %v", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("expected ignored npm vuln to be filtered, got: %#v", results)


### PR DESCRIPTION
Resolve Git refs before querying cached vulnerability snapshots so `vulns blame` and other ref-based vulnerability commands use commit SHAs.

Keep history scans on their existing exact-SHA path and add regression coverage for `vulns blame` and `vulns exposure`.

Fixes #299