### PR TITLE
Add --kind flag to diff for filtering by manifest/lockfile

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -25,7 +25,10 @@ const (
 )
 
 // Manifest kinds
-const manifestKindLockfile = "lockfile"
+const (
+	manifestKindManifest = "manifest"
+	manifestKindLockfile = "lockfile"
+)
 
 // Update severity levels
 const (

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -27,6 +27,7 @@ Supports range syntax (main..feature) or explicit --from/--to flags.`,
 	diffCmd.Flags().String("to", "", "Ending commit (default: working tree)")
 	diffCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
 	diffCmd.Flags().StringP("type", "t", "", "Filter by dependency type (runtime, development, etc.)")
+	diffCmd.Flags().String("kind", "", "Filter by manifest kind: manifest, lockfile")
 	diffCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
 	diffCmd.Flags().String("by", diffByManifest, "Match dependencies by: manifest, ecosystem")
 	diffCmd.Flags().Bool("stat", false, "Show aggregate dependency change counts")
@@ -49,6 +50,7 @@ type DiffEntry struct {
 	Name            string `json:"name"`
 	Ecosystem       string `json:"ecosystem,omitempty"`
 	ManifestPath    string `json:"manifest_path"`
+	ManifestKind    string `json:"manifest_kind,omitempty"`
 	DependencyType  string `json:"dependency_type,omitempty"`
 	FromRequirement string `json:"from_requirement,omitempty"`
 	ToRequirement   string `json:"to_requirement,omitempty"`
@@ -69,6 +71,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	toRef, _ := cmd.Flags().GetString("to")
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	depType, _ := cmd.Flags().GetString("type")
+	kind, _ := cmd.Flags().GetString("kind")
 	format, err := getFormatFlag(cmd, formatText, formatJSON)
 	if err != nil {
 		return err
@@ -80,6 +83,9 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	if by != diffByManifest && by != diffByEcosystem {
 		return fmt.Errorf("--by must be one of: %s, %s", diffByManifest, diffByEcosystem)
+	}
+	if kind != "" && kind != manifestKindManifest && kind != manifestKindLockfile {
+		return fmt.Errorf("--kind must be one of: %s, %s", manifestKindManifest, manifestKindLockfile)
 	}
 
 	// Parse range syntax if provided
@@ -118,8 +124,8 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	// Apply filters
-	if ecosystem != "" || depType != "" {
-		result = filterDiffResult(result, ecosystem, depType)
+	if ecosystem != "" || depType != "" || kind != "" {
+		result = filterDiffResult(result, ecosystem, depType, kind)
 	}
 
 	if stat || summary {
@@ -225,6 +231,7 @@ func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResul
 					Name:           d.Name,
 					Ecosystem:      d.Ecosystem,
 					ManifestPath:   d.ManifestPath,
+					ManifestKind:   d.ManifestKind,
 					DependencyType: d.DependencyType,
 					ToRequirement:  d.Requirement,
 				})
@@ -239,6 +246,7 @@ func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResul
 					Name:            toList[0].Name,
 					Ecosystem:       toList[0].Ecosystem,
 					ManifestPath:    toList[0].ManifestPath,
+					ManifestKind:    toList[0].ManifestKind,
 					DependencyType:  toList[0].DependencyType,
 					FromRequirement: fromList[0].Requirement,
 					ToRequirement:   toList[0].Requirement,
@@ -298,6 +306,7 @@ func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResul
 				Name:            ref.Name,
 				Ecosystem:       ref.Ecosystem,
 				ManifestPath:    ref.ManifestPath,
+				ManifestKind:    ref.ManifestKind,
 				DependencyType:  ref.DependencyType,
 				FromRequirement: removedVersions[i],
 				ToRequirement:   addedVersions[i],
@@ -309,6 +318,7 @@ func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResul
 				Name:           ref.Name,
 				Ecosystem:      ref.Ecosystem,
 				ManifestPath:   ref.ManifestPath,
+				ManifestKind:   ref.ManifestKind,
 				DependencyType: ref.DependencyType,
 				ToRequirement:  addedVersions[i],
 			})
@@ -319,6 +329,7 @@ func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResul
 				Name:            ref.Name,
 				Ecosystem:       ref.Ecosystem,
 				ManifestPath:    ref.ManifestPath,
+				ManifestKind:    ref.ManifestKind,
 				DependencyType:  ref.DependencyType,
 				FromRequirement: removedVersions[i],
 			})
@@ -333,6 +344,7 @@ func computeDiffBy(fromDeps, toDeps []database.Dependency, by string) *DiffResul
 					Name:            d.Name,
 					Ecosystem:       d.Ecosystem,
 					ManifestPath:    d.ManifestPath,
+					ManifestKind:    d.ManifestKind,
 					DependencyType:  d.DependencyType,
 					FromRequirement: d.Requirement,
 				})
@@ -370,37 +382,36 @@ func sortDiffEntries(entries []DiffEntry) {
 	})
 }
 
-func filterDiffResult(result *DiffResult, ecosystem, depType string) *DiffResult {
-	filtered := &DiffResult{}
-
-	for _, e := range result.Added {
+func filterDiffResult(result *DiffResult, ecosystem, depType, kind string) *DiffResult {
+	keep := func(e DiffEntry) bool {
 		if ecosystem != "" && !strings.EqualFold(e.Ecosystem, ecosystem) {
-			continue
+			return false
 		}
 		if depType != "" && !strings.EqualFold(e.DependencyType, depType) {
-			continue
+			return false
 		}
-		filtered.Added = append(filtered.Added, e)
+		if kind != "" && e.ManifestKind != kind {
+			return false
+		}
+		return true
+	}
+
+	filtered := &DiffResult{}
+	for _, e := range result.Added {
+		if keep(e) {
+			filtered.Added = append(filtered.Added, e)
+		}
 	}
 	for _, e := range result.Modified {
-		if ecosystem != "" && !strings.EqualFold(e.Ecosystem, ecosystem) {
-			continue
+		if keep(e) {
+			filtered.Modified = append(filtered.Modified, e)
 		}
-		if depType != "" && !strings.EqualFold(e.DependencyType, depType) {
-			continue
-		}
-		filtered.Modified = append(filtered.Modified, e)
 	}
 	for _, e := range result.Removed {
-		if ecosystem != "" && !strings.EqualFold(e.Ecosystem, ecosystem) {
-			continue
+		if keep(e) {
+			filtered.Removed = append(filtered.Removed, e)
 		}
-		if depType != "" && !strings.EqualFold(e.DependencyType, depType) {
-			continue
-		}
-		filtered.Removed = append(filtered.Removed, e)
 	}
-
 	return filtered
 }
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -72,6 +72,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	ecosystem, _ := cmd.Flags().GetString("ecosystem")
 	depType, _ := cmd.Flags().GetString("type")
 	kind, _ := cmd.Flags().GetString("kind")
+	kind = strings.ToLower(kind)
 	format, err := getFormatFlag(cmd, formatText, formatJSON)
 	if err != nil {
 		return err
@@ -115,17 +116,17 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	// When comparing to working tree, use direct parsing since there's
 	// no database state for uncommitted changes
 	if toRef == "" {
-		result, err = diffWithWorkingTree(repo, fromRef, includeSubmodules, by)
+		result, err = diffWithWorkingTree(repo, fromRef, includeSubmodules, by, kind)
 	} else {
-		result, err = diffBetweenCommits(repo, fromRef, toRef, by)
+		result, err = diffBetweenCommits(repo, fromRef, toRef, by, kind)
 	}
 	if err != nil {
 		return err
 	}
 
 	// Apply filters
-	if ecosystem != "" || depType != "" || kind != "" {
-		result = filterDiffResult(result, ecosystem, depType, kind)
+	if ecosystem != "" || depType != "" {
+		result = filterDiffResult(result, ecosystem, depType)
 	}
 
 	if stat || summary {
@@ -147,7 +148,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 }
 
 // diffBetweenCommits compares dependencies between two commits using on-demand indexing.
-func diffBetweenCommits(repo *git.Repository, fromRef, toRef, by string) (*DiffResult, error) {
+func diffBetweenCommits(repo *git.Repository, fromRef, toRef, by, kind string) (*DiffResult, error) {
 	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
@@ -158,11 +159,11 @@ func diffBetweenCommits(repo *git.Repository, fromRef, toRef, by string) (*DiffR
 		return nil, fmt.Errorf("getting deps at %s: %w", toRef, err)
 	}
 
-	return computeDiffBy(fromDeps, toDeps, by), nil
+	return computeDiffBy(filterDepsByKind(fromDeps, kind), filterDepsByKind(toDeps, kind), by), nil
 }
 
 // diffWithWorkingTree compares dependencies between a commit and the working tree.
-func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules bool, by string) (*DiffResult, error) {
+func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules bool, by, kind string) (*DiffResult, error) {
 	fromDeps, err := repo.GetDependencies(fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
@@ -181,7 +182,24 @@ func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules
 	}
 	toDeps := changesToDeps(toChanges)
 
-	return computeDiffBy(fromDeps, toDeps, by), nil
+	return computeDiffBy(filterDepsByKind(fromDeps, kind), filterDepsByKind(toDeps, kind), by), nil
+}
+
+// filterDepsByKind drops dependencies whose ManifestKind doesn't match kind.
+// Filtering before computeDiffBy (rather than on the result) means --by
+// ecosystem never merges manifest and lockfile rows into the same bucket,
+// so a lockfile-only version bump can't be masked by a manifest row.
+func filterDepsByKind(deps []database.Dependency, kind string) []database.Dependency {
+	if kind == "" {
+		return deps
+	}
+	out := make([]database.Dependency, 0, len(deps))
+	for _, d := range deps {
+		if d.ManifestKind == kind {
+			out = append(out, d)
+		}
+	}
+	return out
 }
 
 func changesToDeps(changes []analyzer.Change) []database.Dependency {
@@ -382,15 +400,12 @@ func sortDiffEntries(entries []DiffEntry) {
 	})
 }
 
-func filterDiffResult(result *DiffResult, ecosystem, depType, kind string) *DiffResult {
+func filterDiffResult(result *DiffResult, ecosystem, depType string) *DiffResult {
 	keep := func(e DiffEntry) bool {
 		if ecosystem != "" && !strings.EqualFold(e.Ecosystem, ecosystem) {
 			return false
 		}
 		if depType != "" && !strings.EqualFold(e.DependencyType, depType) {
-			return false
-		}
-		if kind != "" && e.ManifestKind != kind {
 			return false
 		}
 		return true

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -560,7 +560,7 @@ func TestComputeDiffByEcosystem_IgnoresLockfileMigration(t *testing.T) {
 	}
 }
 
-func TestFilterDiffResult_Kind(t *testing.T) {
+func TestDiffKindFilter(t *testing.T) {
 	fromDeps := []database.Dependency{
 		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: manifestKindManifest},
 		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.20", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
@@ -573,10 +573,8 @@ func TestFilterDiffResult_Kind(t *testing.T) {
 		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
 	}
 
-	result := computeDiff(fromDeps, toDeps)
-
-	lock := filterDiffResult(result, "", "", manifestKindLockfile)
-	if len(lock.Added) != 1 || lock.Added[0].ManifestPath != "package-lock.json" {
+	lock := computeDiff(filterDepsByKind(fromDeps, manifestKindLockfile), filterDepsByKind(toDeps, manifestKindLockfile))
+	if len(lock.Added) != 1 || lock.Added[0].ManifestPath != "package-lock.json" || lock.Added[0].ManifestKind != manifestKindLockfile {
 		t.Fatalf("lockfile added = %+v, want 1 from package-lock.json", lock.Added)
 	}
 	if len(lock.Modified) != 1 || lock.Modified[0].ToRequirement != "4.17.21" {
@@ -586,7 +584,7 @@ func TestFilterDiffResult_Kind(t *testing.T) {
 		t.Fatalf("lockfile removed = %+v, want 1 chalk", lock.Removed)
 	}
 
-	manifest := filterDiffResult(result, "", "", manifestKindManifest)
+	manifest := computeDiff(filterDepsByKind(fromDeps, manifestKindManifest), filterDepsByKind(toDeps, manifestKindManifest))
 	if len(manifest.Added) != 1 || manifest.Added[0].ManifestPath != "package.json" {
 		t.Fatalf("manifest added = %+v, want 1 from package.json", manifest.Added)
 	}
@@ -595,6 +593,36 @@ func TestFilterDiffResult_Kind(t *testing.T) {
 	}
 	if len(manifest.Removed) != 0 {
 		t.Fatalf("manifest removed = %+v, want 0", manifest.Removed)
+	}
+}
+
+func TestDiffKindFilter_ByEcosystem(t *testing.T) {
+	// Manifest row first in the slice, lockfile row second: without pre-
+	// filtering, --by ecosystem would key both under (npm, lodash) and pick
+	// the manifest row as the reference, hiding the lockfile bump.
+	fromDeps := []database.Dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: manifestKindManifest},
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.20", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+	}
+	toDeps := []database.Dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: manifestKindManifest},
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.21", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+	}
+
+	result := computeDiffBy(
+		filterDepsByKind(fromDeps, manifestKindLockfile),
+		filterDepsByKind(toDeps, manifestKindLockfile),
+		diffByEcosystem,
+	)
+	if len(result.Modified) != 1 {
+		t.Fatalf("modified = %+v, want 1", result.Modified)
+	}
+	m := result.Modified[0]
+	if m.FromRequirement != "4.17.20" || m.ToRequirement != "4.17.21" {
+		t.Fatalf("requirements = %s -> %s, want 4.17.20 -> 4.17.21", m.FromRequirement, m.ToRequirement)
+	}
+	if m.ManifestKind != manifestKindLockfile {
+		t.Fatalf("manifest kind = %q, want lockfile", m.ManifestKind)
 	}
 }
 

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -560,6 +560,44 @@ func TestComputeDiffByEcosystem_IgnoresLockfileMigration(t *testing.T) {
 	}
 }
 
+func TestFilterDiffResult_Kind(t *testing.T) {
+	fromDeps := []database.Dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: manifestKindManifest},
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.20", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+		{Name: "chalk", Ecosystem: "npm", Requirement: "5.3.0", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+	}
+	toDeps := []database.Dependency{
+		{Name: "lodash", Ecosystem: "npm", Requirement: "^4.0.0", ManifestPath: "package.json", ManifestKind: manifestKindManifest},
+		{Name: "lodash", Ecosystem: "npm", Requirement: "4.17.21", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+		{Name: "express", Ecosystem: "npm", Requirement: "^4.18.0", ManifestPath: "package.json", ManifestKind: manifestKindManifest},
+		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},
+	}
+
+	result := computeDiff(fromDeps, toDeps)
+
+	lock := filterDiffResult(result, "", "", manifestKindLockfile)
+	if len(lock.Added) != 1 || lock.Added[0].ManifestPath != "package-lock.json" {
+		t.Fatalf("lockfile added = %+v, want 1 from package-lock.json", lock.Added)
+	}
+	if len(lock.Modified) != 1 || lock.Modified[0].ToRequirement != "4.17.21" {
+		t.Fatalf("lockfile modified = %+v, want 1 lodash 4.17.21", lock.Modified)
+	}
+	if len(lock.Removed) != 1 || lock.Removed[0].Name != "chalk" {
+		t.Fatalf("lockfile removed = %+v, want 1 chalk", lock.Removed)
+	}
+
+	manifest := filterDiffResult(result, "", "", manifestKindManifest)
+	if len(manifest.Added) != 1 || manifest.Added[0].ManifestPath != "package.json" {
+		t.Fatalf("manifest added = %+v, want 1 from package.json", manifest.Added)
+	}
+	if len(manifest.Modified) != 0 {
+		t.Fatalf("manifest modified = %+v, want 0", manifest.Modified)
+	}
+	if len(manifest.Removed) != 0 {
+		t.Fatalf("manifest removed = %+v, want 0", manifest.Removed)
+	}
+}
+
 func TestComputeDiffByEcosystem_ReportsVersionChangeAcrossLockfileMigration(t *testing.T) {
 	fromDeps := []database.Dependency{
 		{Name: "express", Ecosystem: "npm", Requirement: "4.18.2", ManifestPath: "package-lock.json", ManifestKind: manifestKindLockfile},


### PR DESCRIPTION
Adds `--kind manifest|lockfile` to `git-pkgs diff`, matching the existing `--ecosystem` and `--type` filters. Each diff entry now also carries `manifest_kind` in the JSON output so callers can filter client-side without the flag.

The dependency rows already carry `ManifestKind` from both the database path and the working-tree analyzer, so this just threads it through to `DiffEntry` and adds the filter check.

Closes #298.