### PR TITLE
Bump github.com/git-pkgs/manifests to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/git-pkgs/enrichment v0.6.4
 	github.com/git-pkgs/gitignore v1.2.0
 	github.com/git-pkgs/managers v0.10.1
-	github.com/git-pkgs/manifests v0.6.1
+	github.com/git-pkgs/manifests v0.7.0
 	github.com/git-pkgs/purl v0.1.15
 	github.com/git-pkgs/registries v0.6.4
 	github.com/git-pkgs/resolve v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -221,8 +221,8 @@ github.com/git-pkgs/gitignore v1.2.0 h1:7vdR8/SvF31dvXqIdC1bKgCvyySefXuN8aY3xJLu
 github.com/git-pkgs/gitignore v1.2.0/go.mod h1:Lr0XwhbvP071rZF/zIIhkY1gEhFDoWHH91lngwLpeUg=
 github.com/git-pkgs/managers v0.10.1 h1:T877XtuXoJNweDTMGj1H6AOeVolDO44IvsgDN5jq3Ko=
 github.com/git-pkgs/managers v0.10.1/go.mod h1:8DR7tIQEEyPyJ7QGzStVbovnGl7tAJcrhQLzjQPzFzc=
-github.com/git-pkgs/manifests v0.6.1 h1:lkdtkipyFmJHJVUktkQH7TzliJbYFigCS7kczJHQxFA=
-github.com/git-pkgs/manifests v0.6.1/go.mod h1:za7j4NTkJQ/mk8H5m6Na93dMftGsZrHAYaZzGJNUPQs=
+github.com/git-pkgs/manifests v0.7.0 h1:dEsBXRWSaZl5Li0aI53wzitecg31rnVVfQJh13B8Eng=
+github.com/git-pkgs/manifests v0.7.0/go.mod h1:U2aHcGcF7nJzAtRPU3ktVtb6GitJS9fmkKPKJUNHD38=
 github.com/git-pkgs/packageurl-go v0.3.1 h1:WM3RBABQZLaRBxgKyYughc3cVBE8KyQxbSC6Jt5ak7M=
 github.com/git-pkgs/packageurl-go v0.3.1/go.mod h1:rcIxiG37BlQLB6FZfgdj9Fm7yjhRQd3l+5o7J0QPAk4=
 github.com/git-pkgs/pom v0.1.5 h1:TGT8Az2OMxGWsXnSagtUMGzZm7Oax8HrSCteA+mi0qY=


### PR DESCRIPTION
v0.7.0 adds `Licenses` and `LicenseFile` fields to `ParseResult`, exposing the license declared in the parsed manifest.

Release notes: https://github.com/git-pkgs/manifests/releases/tag/v0.7.0

No behaviour change here; follow-up issues will cover wiring the new fields into `sbom`, `diff`, and the analyzer.