### PR TITLE
sbom: populate root component license from manifests

### DIFF
--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -88,13 +88,16 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 		projectName = "project"
 	}
 
-	projectLicenses, err := projectLicensesAtRevision(repo, commit)
+	projectLicenses, licenseWarnings, err := projectLicensesAtRevision(repo, commit)
 	if err != nil {
 		return fmt.Errorf("loading project licenses: %w", err)
 	}
+	for _, warning := range licenseWarnings {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", warning)
+	}
 
-	doc := buildSBOM(deps, licenseMap, projectName, projectVersion)
-	return encodeSBOMWithRootLicenses(cmd.OutOrStdout(), doc, out, projectLicenses)
+	doc := buildSBOM(deps, licenseMap, projectName, projectVersion, projectLicenses)
+	return sbom.Encode(cmd.OutOrStdout(), doc, out)
 }
 
 func sbomFormat(sbomType, format string) (sbom.Format, error) {
@@ -110,13 +113,32 @@ func sbomFormat(sbomType, format string) (sbom.Format, error) {
 	}
 }
 
-func buildSBOM(deps []database.Dependency, licenses map[string]string, name, ver string) *sbom.SBOM {
+func buildSBOM(
+	deps []database.Dependency,
+	licenses map[string]string,
+	name, ver string,
+	projectLicenseData projectLicenses,
+) *sbom.SBOM {
 	s := sbom.New(sbom.TypeCycloneDX)
+	extractedLicenses := make([]sbom.ExtractedLicense, 0, len(projectLicenseData.Files))
+	for _, file := range projectLicenseData.Files {
+		extractedLicenses = append(extractedLicenses, sbom.ExtractedLicense{
+			Name: file.Path,
+			Text: file.Text,
+		})
+	}
 	s.Document = sbom.Document{
 		Name:      name,
 		Namespace: "https://git-pkgs.example.com/" + name,
-		Component: sbom.Component{Type: "application", Name: name, Version: ver},
-		Creators:  []sbom.Creator{{Type: "Tool", Name: "git-pkgs-" + version}},
+		Component: sbom.Component{
+			Type:              "application",
+			Name:              name,
+			Version:           ver,
+			LicenseExpression: projectLicenseData.Expression,
+			LicenseNames:      projectLicenseData.Names,
+			ExtractedLicenses: extractedLicenses,
+		},
+		Creators: []sbom.Creator{{Type: "Tool", Name: "git-pkgs-" + version}},
 	}
 	for _, d := range deps {
 		purlStr := sbomPURLForDependency(d)

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -88,13 +88,13 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 		projectName = "project"
 	}
 
-	projectLicense, err := projectLicenseAtRevision(repo, commit)
+	projectLicenses, err := projectLicensesAtRevision(repo, commit)
 	if err != nil {
-		return fmt.Errorf("loading project license: %w", err)
+		return fmt.Errorf("loading project licenses: %w", err)
 	}
 
 	doc := buildSBOM(deps, licenseMap, projectName, projectVersion)
-	return encodeSBOMWithRootLicense(cmd.OutOrStdout(), doc, out, projectLicense)
+	return encodeSBOMWithRootLicenses(cmd.OutOrStdout(), doc, out, projectLicenses)
 }
 
 func sbomFormat(sbomType, format string) (sbom.Format, error) {

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -88,8 +88,13 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 		projectName = "project"
 	}
 
+	projectLicense, err := projectLicenseAtRevision(repo, commit)
+	if err != nil {
+		return fmt.Errorf("loading project license: %w", err)
+	}
+
 	doc := buildSBOM(deps, licenseMap, projectName, projectVersion)
-	return sbom.Encode(cmd.OutOrStdout(), doc, out)
+	return encodeSBOMWithRootLicense(cmd.OutOrStdout(), doc, out, projectLicense)
 }
 
 func sbomFormat(sbomType, format string) (sbom.Format, error) {

--- a/cmd/sbom_root_license.go
+++ b/cmd/sbom_root_license.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/manifests"
+	"github.com/git-pkgs/sbom"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+const spdxRootPackageID = "SPDXRef-Package-root"
+
+func projectLicenseAtRevision(repo *git.Repository, revision string) (string, error) {
+	if revision == "" {
+		revision = "HEAD"
+	}
+
+	hash, err := repo.ResolveRevision(revision)
+	if err != nil {
+		return "", fmt.Errorf("resolving %q: %w", revision, err)
+	}
+	commit, err := repo.CommitObject(*hash)
+	if err != nil {
+		return "", fmt.Errorf("getting commit: %w", err)
+	}
+	tree, err := commit.Tree()
+	if err != nil {
+		return "", fmt.Errorf("getting commit tree: %w", err)
+	}
+
+	var licenses []string
+	seen := make(map[string]bool)
+	err = tree.Files().ForEach(func(file *object.File) error {
+		if path.Dir(file.Name) != "." {
+			return nil
+		}
+		_, kind, ok := manifests.Identify(file.Name)
+		if !ok || kind != manifests.Manifest {
+			return nil
+		}
+
+		content, err := file.Contents()
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", file.Name, err)
+		}
+		result, err := manifests.Parse(file.Name, []byte(content))
+		if err != nil {
+			return nil
+		}
+		for _, declared := range result.Licenses {
+			declared = strings.TrimSpace(declared)
+			if declared == "" || seen[declared] {
+				continue
+			}
+			seen[declared] = true
+			licenses = append(licenses, declared)
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(licenses)
+	return strings.Join(licenses, " OR "), nil
+}
+
+func encodeSBOMWithRootLicense(w io.Writer, document *sbom.SBOM, format sbom.Format, license string) error {
+	if license == "" {
+		return sbom.Encode(w, document, format)
+	}
+
+	var encoded bytes.Buffer
+	if err := sbom.Encode(&encoded, document, format); err != nil {
+		return err
+	}
+
+	switch format {
+	case sbom.FormatCycloneDXJSON, sbom.FormatSPDXJSON:
+		data, err := addRootLicenseJSON(encoded.Bytes(), format, license)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	case sbom.FormatCycloneDXXML:
+		return addCycloneDXRootLicenseXML(w, encoded.Bytes(), license)
+	default:
+		return fmt.Errorf("unsupported SBOM format %d", format)
+	}
+}
+
+func addRootLicenseJSON(data []byte, format sbom.Format, license string) ([]byte, error) {
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return nil, fmt.Errorf("decoding generated SBOM: %w", err)
+	}
+
+	switch format {
+	case sbom.FormatCycloneDXJSON:
+		metadata, ok := document["metadata"].(map[string]any)
+		if !ok {
+			return nil, errors.New("generated CycloneDX SBOM has no metadata")
+		}
+		component, ok := metadata["component"].(map[string]any)
+		if !ok {
+			return nil, errors.New("generated CycloneDX SBOM has no root component")
+		}
+		component["licenses"] = []any{map[string]any{"expression": license}}
+	case sbom.FormatSPDXJSON:
+		packages, ok := document["packages"].([]any)
+		if !ok {
+			return nil, errors.New("generated SPDX SBOM has no packages")
+		}
+		found := false
+		for _, value := range packages {
+			pkg, ok := value.(map[string]any)
+			if ok && pkg["SPDXID"] == spdxRootPackageID {
+				pkg["licenseDeclared"] = license
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, errors.New("generated SPDX SBOM has no root package")
+		}
+	default:
+		return nil, fmt.Errorf("unsupported JSON SBOM format %d", format)
+	}
+
+	encoded, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encoding generated SBOM: %w", err)
+	}
+	return append(encoded, '\n'), nil
+}
+
+func addCycloneDXRootLicenseXML(w io.Writer, data []byte, license string) error {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+	encoder := xml.NewEncoder(w)
+	metadataDepth := -1
+	componentDepth := -1
+	depth := 0
+	found := false
+
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("decoding generated CycloneDX XML: %w", err)
+		}
+
+		switch element := token.(type) {
+		case xml.StartElement:
+			depth++
+			if element.Name.Local == "metadata" && metadataDepth == -1 {
+				metadataDepth = depth
+			} else if element.Name.Local == "component" && depth == metadataDepth+1 {
+				componentDepth = depth
+			}
+		case xml.EndElement:
+			if element.Name.Local == "component" && depth == componentDepth {
+				if err := encodeCycloneDXLicenseXML(encoder, license); err != nil {
+					return err
+				}
+				found = true
+				componentDepth = -1
+			}
+		}
+
+		if err := encoder.EncodeToken(token); err != nil {
+			return fmt.Errorf("encoding CycloneDX XML: %w", err)
+		}
+		if _, ok := token.(xml.EndElement); ok {
+			if depth == metadataDepth {
+				metadataDepth = -1
+			}
+			depth--
+		}
+	}
+	if !found {
+		return errors.New("generated CycloneDX SBOM has no root component")
+	}
+	if err := encoder.Flush(); err != nil {
+		return fmt.Errorf("encoding CycloneDX XML: %w", err)
+	}
+	return nil
+}
+
+func encodeCycloneDXLicenseXML(encoder *xml.Encoder, license string) error {
+	licenses := xml.StartElement{Name: xml.Name{Local: "licenses"}}
+	expression := xml.StartElement{Name: xml.Name{Local: "expression"}}
+	for _, token := range []xml.Token{
+		licenses,
+		expression,
+		xml.CharData(license),
+		expression.End(),
+		licenses.End(),
+	} {
+		if err := encoder.EncodeToken(token); err != nil {
+			return fmt.Errorf("encoding CycloneDX root license: %w", err)
+		}
+	}
+	return nil
+}

--- a/cmd/sbom_root_license.go
+++ b/cmd/sbom_root_license.go
@@ -1,25 +1,17 @@
 package cmd
 
 import (
-	"bytes"
-	"crypto/sha256"
-	"encoding/json"
-	"encoding/xml"
 	"errors"
 	"fmt"
-	"io"
 	"path"
 	"sort"
 	"strings"
 
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/manifests"
-	"github.com/git-pkgs/sbom"
 	"github.com/git-pkgs/spdx"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
-
-const spdxRootPackageID = "SPDXRef-Package-root"
 
 type projectLicenses struct {
 	Expression string
@@ -32,87 +24,100 @@ type projectLicenseFile struct {
 	Text string
 }
 
-func (l projectLicenses) empty() bool {
-	return l.Expression == "" && len(l.Names) == 0 && len(l.Files) == 0
-}
-
-func projectLicensesAtRevision(repo *git.Repository, revision string) (projectLicenses, error) {
+func projectLicensesAtRevision(repo *git.Repository, revision string) (projectLicenses, []string, error) {
 	if revision == "" {
 		revision = "HEAD"
 	}
 
 	hash, err := repo.ResolveRevision(revision)
 	if err != nil {
-		return projectLicenses{}, fmt.Errorf("resolving %q: %w", revision, err)
+		return projectLicenses{}, nil, fmt.Errorf("resolving %q: %w", revision, err)
 	}
 	commit, err := repo.CommitObject(*hash)
 	if err != nil {
-		return projectLicenses{}, fmt.Errorf("getting commit: %w", err)
+		return projectLicenses{}, nil, fmt.Errorf("getting commit: %w", err)
 	}
 	tree, err := commit.Tree()
 	if err != nil {
-		return projectLicenses{}, fmt.Errorf("getting commit tree: %w", err)
+		return projectLicenses{}, nil, fmt.Errorf("getting commit tree: %w", err)
 	}
 
 	var declaredLicenses []string
+	var warnings []string
 	declaredFiles := make(map[string]string)
-	err = tree.Files().ForEach(func(file *object.File) error {
-		if path.Dir(file.Name) != "." {
-			return nil
+	for i := range tree.Entries {
+		entry := &tree.Entries[i]
+		if !entry.Mode.IsFile() {
+			continue
+		}
+		file, err := tree.TreeEntryFile(entry)
+		if err != nil {
+			return projectLicenses{}, nil, fmt.Errorf("reading %s: %w", entry.Name, err)
 		}
 		_, kind, ok := manifests.Identify(file.Name)
 		if !ok || kind != manifests.Manifest {
-			return nil
+			continue
 		}
 
 		content, err := file.Contents()
 		if err != nil {
-			return fmt.Errorf("reading %s: %w", file.Name, err)
+			return projectLicenses{}, nil, fmt.Errorf("reading %s: %w", file.Name, err)
 		}
 		result, err := manifests.Parse(file.Name, []byte(content))
 		if err != nil {
-			return nil
+			continue
 		}
 		declaredLicenses = append(declaredLicenses, result.Licenses...)
 		if result.LicenseFile != "" {
-			licenseFile, err := readProjectLicenseFile(tree, file.Name, result.LicenseFile)
+			licenseFile, warning, err := readProjectLicenseFile(tree, file.Name, result.LicenseFile)
 			if err != nil {
-				return err
+				return projectLicenses{}, nil, err
+			}
+			if warning != "" {
+				warnings = append(warnings, warning)
+				continue
 			}
 			declaredFiles[licenseFile.Path] = licenseFile.Text
 		}
-		return nil
-	})
-	if err != nil {
-		return projectLicenses{}, err
 	}
 	licenses := normalizeProjectLicenses(declaredLicenses)
 	licenses.Files = sortedProjectLicenseFiles(declaredFiles)
-	return licenses, nil
+	return licenses, warnings, nil
 }
 
 func readProjectLicenseFile(
 	tree *object.Tree,
 	manifestPath, declaredPath string,
-) (projectLicenseFile, error) {
+) (projectLicenseFile, string, error) {
 	declaredPath = strings.TrimSpace(declaredPath)
 	resolvedPath := path.Clean(path.Join(path.Dir(manifestPath), declaredPath))
 	if declaredPath == "" || path.IsAbs(declaredPath) || resolvedPath == ".." || strings.HasPrefix(resolvedPath, "../") {
-		return projectLicenseFile{}, fmt.Errorf("invalid license file path %q in %s", declaredPath, manifestPath)
+		return projectLicenseFile{}, "", fmt.Errorf("invalid license file path %q in %s", declaredPath, manifestPath)
 	}
 
 	file, err := tree.File(resolvedPath)
 	if err != nil {
-		return projectLicenseFile{}, fmt.Errorf("reading license file %s declared by %s: %w", resolvedPath, manifestPath, err)
+		if errors.Is(err, object.ErrFileNotFound) {
+			return projectLicenseFile{}, fmt.Sprintf(
+				"license file %s declared by %s was not found", resolvedPath, manifestPath,
+			), nil
+		}
+		return projectLicenseFile{}, "", fmt.Errorf(
+			"reading license file %s declared by %s: %w", resolvedPath, manifestPath, err,
+		)
 	}
 	content, err := file.Contents()
 	if err != nil {
-		return projectLicenseFile{}, fmt.Errorf("reading license file %s declared by %s: %w", resolvedPath, manifestPath, err)
+		return projectLicenseFile{}, "", fmt.Errorf(
+			"reading license file %s declared by %s: %w", resolvedPath, manifestPath, err,
+		)
 	}
 	if strings.TrimSpace(content) == "" {
-		return projectLicenseFile{}, fmt.Errorf("license file %s declared by %s is empty", resolvedPath, manifestPath)
+		return projectLicenseFile{}, fmt.Sprintf(
+			"license file %s declared by %s is empty", resolvedPath, manifestPath,
+		), nil
 	}
-	return projectLicenseFile{Path: resolvedPath, Text: content}, nil
+	return projectLicenseFile{Path: resolvedPath, Text: content}, "", nil
 }
 
 func sortedProjectLicenseFiles(files map[string]string) []projectLicenseFile {
@@ -178,318 +183,9 @@ func joinSPDXExpressions(expressions []string) string {
 			expressions[i] = "(" + expression + ")"
 		}
 	}
-	joined, err := spdx.NormalizeExpression(strings.Join(expressions, " OR "))
+	joined, err := spdx.NormalizeExpression(strings.Join(expressions, " AND "))
 	if err != nil {
 		return ""
 	}
 	return joined
-}
-
-func encodeSBOMWithRootLicenses(
-	w io.Writer,
-	document *sbom.SBOM,
-	format sbom.Format,
-	licenses projectLicenses,
-) error {
-	if licenses.empty() {
-		return sbom.Encode(w, document, format)
-	}
-
-	var encoded bytes.Buffer
-	if err := sbom.Encode(&encoded, document, format); err != nil {
-		return err
-	}
-
-	switch format {
-	case sbom.FormatCycloneDXJSON, sbom.FormatSPDXJSON:
-		data, err := addRootLicensesJSON(encoded.Bytes(), format, licenses)
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(data)
-		return err
-	case sbom.FormatCycloneDXXML:
-		return addCycloneDXRootLicensesXML(w, encoded.Bytes(), licenses)
-	default:
-		return fmt.Errorf("unsupported SBOM format %d", format)
-	}
-}
-
-func addRootLicensesJSON(data []byte, format sbom.Format, licenses projectLicenses) ([]byte, error) {
-	var document map[string]any
-	if err := json.Unmarshal(data, &document); err != nil {
-		return nil, fmt.Errorf("decoding generated SBOM: %w", err)
-	}
-	if document["components"] == nil {
-		delete(document, "components")
-	}
-
-	switch format {
-	case sbom.FormatCycloneDXJSON:
-		metadata, ok := document["metadata"].(map[string]any)
-		if !ok {
-			return nil, errors.New("generated CycloneDX SBOM has no metadata")
-		}
-		component, ok := metadata["component"].(map[string]any)
-		if !ok {
-			return nil, errors.New("generated CycloneDX SBOM has no root component")
-		}
-		component["licenses"] = cycloneDXLicenseChoices(licenses)
-	case sbom.FormatSPDXJSON:
-		packages, ok := document["packages"].([]any)
-		if !ok {
-			return nil, errors.New("generated SPDX SBOM has no packages")
-		}
-		found := false
-		for _, value := range packages {
-			pkg, ok := value.(map[string]any)
-			if ok && pkg["SPDXID"] == spdxRootPackageID {
-				pkg["licenseDeclared"] = licenses.spdxExpression()
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, errors.New("generated SPDX SBOM has no root package")
-		}
-		if len(licenses.Names) > 0 || len(licenses.Files) > 0 {
-			document["hasExtractedLicensingInfos"] = extractedLicenseInfo(licenses)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported JSON SBOM format %d", format)
-	}
-
-	encoded, err := json.MarshalIndent(document, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("encoding generated SBOM: %w", err)
-	}
-	return append(encoded, '\n'), nil
-}
-
-func cycloneDXLicenseChoices(licenses projectLicenses) []any {
-	if licenses.Expression != "" && len(licenses.Names) == 0 && len(licenses.Files) == 0 {
-		return []any{map[string]any{"expression": licenses.Expression}}
-	}
-
-	choices := make([]any, 0, 1+len(licenses.Names)+len(licenses.Files))
-	if licenses.Expression != "" {
-		license := map[string]any{"name": licenses.Expression}
-		if spdx.ValidLicense(licenses.Expression) {
-			license = map[string]any{"id": licenses.Expression}
-		}
-		choices = append(choices, map[string]any{"license": license})
-	}
-	for _, name := range licenses.Names {
-		choices = append(choices, map[string]any{"license": map[string]any{"name": name}})
-	}
-	for _, file := range licenses.Files {
-		choices = append(choices, map[string]any{"license": map[string]any{"name": file.Path}})
-	}
-	return choices
-}
-
-func (l projectLicenses) usesCycloneDXExpression() bool {
-	return l.Expression != "" && len(l.Names) == 0 && len(l.Files) == 0
-}
-
-func (l projectLicenses) spdxExpression() string {
-	parts := make([]string, 0, 1+len(l.Names)+len(l.Files))
-	if l.Expression != "" {
-		parts = append(parts, l.Expression)
-	}
-	for _, name := range l.Names {
-		parts = append(parts, licenseRefForName(name))
-	}
-	for _, file := range l.Files {
-		parts = append(parts, licenseRefForFile(file))
-	}
-	return joinSPDXExpressions(parts)
-}
-
-func licenseRefForName(name string) string {
-	digest := sha256.Sum256([]byte(name))
-	return fmt.Sprintf("LicenseRef-Manifest-%x", digest[:8])
-}
-
-func licenseRefForFile(file projectLicenseFile) string {
-	digest := sha256.Sum256([]byte(file.Path + "\x00" + file.Text))
-	return fmt.Sprintf("LicenseRef-Manifest-%x", digest[:8])
-}
-
-func extractedLicenseInfo(licenses projectLicenses) []any {
-	infos := make([]any, 0, len(licenses.Names)+len(licenses.Files))
-	for _, name := range licenses.Names {
-		infos = append(infos, map[string]any{
-			"licenseId":     licenseRefForName(name),
-			"name":          name,
-			"extractedText": name,
-		})
-	}
-	for _, file := range licenses.Files {
-		infos = append(infos, map[string]any{
-			"licenseId":     licenseRefForFile(file),
-			"name":          file.Path,
-			"extractedText": file.Text,
-		})
-	}
-	return infos
-}
-
-func addCycloneDXRootLicensesXML(w io.Writer, data []byte, licenses projectLicenses) error {
-	decoder := xml.NewDecoder(bytes.NewReader(data))
-	encoder := xml.NewEncoder(w)
-	metadataDepth := -1
-	componentDepth := -1
-	skipDepth := -1
-	depth := 0
-	found := false
-	var pendingToken xml.Token
-
-	for {
-		var token xml.Token
-		var err error
-		if pendingToken != nil {
-			token = pendingToken
-			pendingToken = nil
-		} else {
-			token, err = decoder.Token()
-		}
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("decoding generated CycloneDX XML: %w", err)
-		}
-		if skipDepth != -1 {
-			switch token.(type) {
-			case xml.StartElement:
-				depth++
-			case xml.EndElement:
-				if depth == skipDepth {
-					skipDepth = -1
-				}
-				depth--
-			}
-			continue
-		}
-
-		switch element := token.(type) {
-		case xml.StartElement:
-			if isCycloneDXOptionalContainer(element.Name.Local) {
-				next, nextErr := decoder.Token()
-				if nextErr != nil {
-					return fmt.Errorf("decoding generated CycloneDX XML: %w", nextErr)
-				}
-				if end, ok := next.(xml.EndElement); ok && end.Name == element.Name {
-					continue
-				}
-				pendingToken = next
-			}
-			depth++
-			if element.Name.Local == "metadata" && metadataDepth == -1 {
-				metadataDepth = depth
-			} else if element.Name.Local == "component" && depth == metadataDepth+1 {
-				componentDepth = depth
-			} else if element.Name.Local == "licenses" && componentDepth != -1 && depth == componentDepth+1 {
-				skipDepth = depth
-				continue
-			}
-			element.Name.Space = ""
-			token = element
-		case xml.EndElement:
-			if element.Name.Local == "component" && depth == componentDepth {
-				if err := encodeCycloneDXLicensesXML(encoder, licenses); err != nil {
-					return err
-				}
-				found = true
-				componentDepth = -1
-			}
-			element.Name.Space = ""
-			token = element
-		}
-
-		if err := encoder.EncodeToken(token); err != nil {
-			return fmt.Errorf("encoding CycloneDX XML: %w", err)
-		}
-		if _, ok := token.(xml.EndElement); ok {
-			if depth == metadataDepth {
-				metadataDepth = -1
-			}
-			depth--
-		}
-	}
-	if !found {
-		return errors.New("generated CycloneDX SBOM has no root component")
-	}
-	if err := encoder.Flush(); err != nil {
-		return fmt.Errorf("encoding CycloneDX XML: %w", err)
-	}
-	return nil
-}
-
-func isCycloneDXOptionalContainer(name string) bool {
-	switch name {
-	case "components", "dependencies", "externalReferences", "hashes", "properties":
-		return true
-	default:
-		return false
-	}
-}
-
-func encodeCycloneDXLicensesXML(encoder *xml.Encoder, licenses projectLicenses) error {
-	licensesElement := xml.StartElement{Name: xml.Name{Local: "licenses"}}
-	if err := encoder.EncodeToken(licensesElement); err != nil {
-		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
-	}
-	if licenses.usesCycloneDXExpression() {
-		if err := encodeXMLElement(encoder, "expression", licenses.Expression); err != nil {
-			return err
-		}
-	} else {
-		if licenses.Expression != "" {
-			if spdx.ValidLicense(licenses.Expression) {
-				if err := encodeCycloneDXLicenseXML(encoder, "id", licenses.Expression); err != nil {
-					return err
-				}
-			} else if err := encodeCycloneDXLicenseXML(encoder, "name", licenses.Expression); err != nil {
-				return err
-			}
-		}
-		for _, name := range licenses.Names {
-			if err := encodeCycloneDXLicenseXML(encoder, "name", name); err != nil {
-				return err
-			}
-		}
-		for _, file := range licenses.Files {
-			if err := encodeCycloneDXLicenseXML(encoder, "name", file.Path); err != nil {
-				return err
-			}
-		}
-	}
-	if err := encoder.EncodeToken(licensesElement.End()); err != nil {
-		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
-	}
-	return nil
-}
-
-func encodeCycloneDXLicenseXML(encoder *xml.Encoder, field, value string) error {
-	licenseElement := xml.StartElement{Name: xml.Name{Local: "license"}}
-	if err := encoder.EncodeToken(licenseElement); err != nil {
-		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
-	}
-	if err := encodeXMLElement(encoder, field, value); err != nil {
-		return err
-	}
-	if err := encoder.EncodeToken(licenseElement.End()); err != nil {
-		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
-	}
-	return nil
-}
-
-func encodeXMLElement(encoder *xml.Encoder, name, value string) error {
-	element := xml.StartElement{Name: xml.Name{Local: name}}
-	if err := encoder.EncodeElement(value, element); err != nil {
-		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
-	}
-	return nil
 }

--- a/cmd/sbom_root_license.go
+++ b/cmd/sbom_root_license.go
@@ -24,10 +24,16 @@ const spdxRootPackageID = "SPDXRef-Package-root"
 type projectLicenses struct {
 	Expression string
 	Names      []string
+	Files      []projectLicenseFile
+}
+
+type projectLicenseFile struct {
+	Path string
+	Text string
 }
 
 func (l projectLicenses) empty() bool {
-	return l.Expression == "" && len(l.Names) == 0
+	return l.Expression == "" && len(l.Names) == 0 && len(l.Files) == 0
 }
 
 func projectLicensesAtRevision(repo *git.Repository, revision string) (projectLicenses, error) {
@@ -49,6 +55,7 @@ func projectLicensesAtRevision(repo *git.Repository, revision string) (projectLi
 	}
 
 	var declaredLicenses []string
+	declaredFiles := make(map[string]string)
 	err = tree.Files().ForEach(func(file *object.File) error {
 		if path.Dir(file.Name) != "." {
 			return nil
@@ -67,12 +74,59 @@ func projectLicensesAtRevision(repo *git.Repository, revision string) (projectLi
 			return nil
 		}
 		declaredLicenses = append(declaredLicenses, result.Licenses...)
+		if result.LicenseFile != "" {
+			licenseFile, err := readProjectLicenseFile(tree, file.Name, result.LicenseFile)
+			if err != nil {
+				return err
+			}
+			declaredFiles[licenseFile.Path] = licenseFile.Text
+		}
 		return nil
 	})
 	if err != nil {
 		return projectLicenses{}, err
 	}
-	return normalizeProjectLicenses(declaredLicenses), nil
+	licenses := normalizeProjectLicenses(declaredLicenses)
+	licenses.Files = sortedProjectLicenseFiles(declaredFiles)
+	return licenses, nil
+}
+
+func readProjectLicenseFile(
+	tree *object.Tree,
+	manifestPath, declaredPath string,
+) (projectLicenseFile, error) {
+	declaredPath = strings.TrimSpace(declaredPath)
+	resolvedPath := path.Clean(path.Join(path.Dir(manifestPath), declaredPath))
+	if declaredPath == "" || path.IsAbs(declaredPath) || resolvedPath == ".." || strings.HasPrefix(resolvedPath, "../") {
+		return projectLicenseFile{}, fmt.Errorf("invalid license file path %q in %s", declaredPath, manifestPath)
+	}
+
+	file, err := tree.File(resolvedPath)
+	if err != nil {
+		return projectLicenseFile{}, fmt.Errorf("reading license file %s declared by %s: %w", resolvedPath, manifestPath, err)
+	}
+	content, err := file.Contents()
+	if err != nil {
+		return projectLicenseFile{}, fmt.Errorf("reading license file %s declared by %s: %w", resolvedPath, manifestPath, err)
+	}
+	if strings.TrimSpace(content) == "" {
+		return projectLicenseFile{}, fmt.Errorf("license file %s declared by %s is empty", resolvedPath, manifestPath)
+	}
+	return projectLicenseFile{Path: resolvedPath, Text: content}, nil
+}
+
+func sortedProjectLicenseFiles(files map[string]string) []projectLicenseFile {
+	paths := make([]string, 0, len(files))
+	for filePath := range files {
+		paths = append(paths, filePath)
+	}
+	sort.Strings(paths)
+
+	result := make([]projectLicenseFile, 0, len(paths))
+	for _, filePath := range paths {
+		result = append(result, projectLicenseFile{Path: filePath, Text: files[filePath]})
+	}
+	return result
 }
 
 func normalizeProjectLicenses(values []string) projectLicenses {
@@ -166,6 +220,9 @@ func addRootLicensesJSON(data []byte, format sbom.Format, licenses projectLicens
 	if err := json.Unmarshal(data, &document); err != nil {
 		return nil, fmt.Errorf("decoding generated SBOM: %w", err)
 	}
+	if document["components"] == nil {
+		delete(document, "components")
+	}
 
 	switch format {
 	case sbom.FormatCycloneDXJSON:
@@ -195,8 +252,8 @@ func addRootLicensesJSON(data []byte, format sbom.Format, licenses projectLicens
 		if !found {
 			return nil, errors.New("generated SPDX SBOM has no root package")
 		}
-		if len(licenses.Names) > 0 {
-			document["hasExtractedLicensingInfos"] = extractedLicenseInfo(licenses.Names)
+		if len(licenses.Names) > 0 || len(licenses.Files) > 0 {
+			document["hasExtractedLicensingInfos"] = extractedLicenseInfo(licenses)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported JSON SBOM format %d", format)
@@ -210,23 +267,41 @@ func addRootLicensesJSON(data []byte, format sbom.Format, licenses projectLicens
 }
 
 func cycloneDXLicenseChoices(licenses projectLicenses) []any {
-	choices := make([]any, 0, 1+len(licenses.Names))
+	if licenses.Expression != "" && len(licenses.Names) == 0 && len(licenses.Files) == 0 {
+		return []any{map[string]any{"expression": licenses.Expression}}
+	}
+
+	choices := make([]any, 0, 1+len(licenses.Names)+len(licenses.Files))
 	if licenses.Expression != "" {
-		choices = append(choices, map[string]any{"expression": licenses.Expression})
+		license := map[string]any{"name": licenses.Expression}
+		if spdx.ValidLicense(licenses.Expression) {
+			license = map[string]any{"id": licenses.Expression}
+		}
+		choices = append(choices, map[string]any{"license": license})
 	}
 	for _, name := range licenses.Names {
 		choices = append(choices, map[string]any{"license": map[string]any{"name": name}})
 	}
+	for _, file := range licenses.Files {
+		choices = append(choices, map[string]any{"license": map[string]any{"name": file.Path}})
+	}
 	return choices
 }
 
+func (l projectLicenses) usesCycloneDXExpression() bool {
+	return l.Expression != "" && len(l.Names) == 0 && len(l.Files) == 0
+}
+
 func (l projectLicenses) spdxExpression() string {
-	parts := make([]string, 0, 1+len(l.Names))
+	parts := make([]string, 0, 1+len(l.Names)+len(l.Files))
 	if l.Expression != "" {
 		parts = append(parts, l.Expression)
 	}
 	for _, name := range l.Names {
 		parts = append(parts, licenseRefForName(name))
+	}
+	for _, file := range l.Files {
+		parts = append(parts, licenseRefForFile(file))
 	}
 	return joinSPDXExpressions(parts)
 }
@@ -236,13 +311,25 @@ func licenseRefForName(name string) string {
 	return fmt.Sprintf("LicenseRef-Manifest-%x", digest[:8])
 }
 
-func extractedLicenseInfo(names []string) []any {
-	infos := make([]any, 0, len(names))
-	for _, name := range names {
+func licenseRefForFile(file projectLicenseFile) string {
+	digest := sha256.Sum256([]byte(file.Path + "\x00" + file.Text))
+	return fmt.Sprintf("LicenseRef-Manifest-%x", digest[:8])
+}
+
+func extractedLicenseInfo(licenses projectLicenses) []any {
+	infos := make([]any, 0, len(licenses.Names)+len(licenses.Files))
+	for _, name := range licenses.Names {
 		infos = append(infos, map[string]any{
 			"licenseId":     licenseRefForName(name),
 			"name":          name,
 			"extractedText": name,
+		})
+	}
+	for _, file := range licenses.Files {
+		infos = append(infos, map[string]any{
+			"licenseId":     licenseRefForFile(file),
+			"name":          file.Path,
+			"extractedText": file.Text,
 		})
 	}
 	return infos
@@ -253,26 +340,62 @@ func addCycloneDXRootLicensesXML(w io.Writer, data []byte, licenses projectLicen
 	encoder := xml.NewEncoder(w)
 	metadataDepth := -1
 	componentDepth := -1
+	skipDepth := -1
 	depth := 0
 	found := false
+	var pendingToken xml.Token
 
 	for {
-		token, err := decoder.Token()
+		var token xml.Token
+		var err error
+		if pendingToken != nil {
+			token = pendingToken
+			pendingToken = nil
+		} else {
+			token, err = decoder.Token()
+		}
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			return fmt.Errorf("decoding generated CycloneDX XML: %w", err)
 		}
+		if skipDepth != -1 {
+			switch token.(type) {
+			case xml.StartElement:
+				depth++
+			case xml.EndElement:
+				if depth == skipDepth {
+					skipDepth = -1
+				}
+				depth--
+			}
+			continue
+		}
 
 		switch element := token.(type) {
 		case xml.StartElement:
+			if isCycloneDXOptionalContainer(element.Name.Local) {
+				next, nextErr := decoder.Token()
+				if nextErr != nil {
+					return fmt.Errorf("decoding generated CycloneDX XML: %w", nextErr)
+				}
+				if end, ok := next.(xml.EndElement); ok && end.Name == element.Name {
+					continue
+				}
+				pendingToken = next
+			}
 			depth++
 			if element.Name.Local == "metadata" && metadataDepth == -1 {
 				metadataDepth = depth
 			} else if element.Name.Local == "component" && depth == metadataDepth+1 {
 				componentDepth = depth
+			} else if element.Name.Local == "licenses" && componentDepth != -1 && depth == componentDepth+1 {
+				skipDepth = depth
+				continue
 			}
+			element.Name.Space = ""
+			token = element
 		case xml.EndElement:
 			if element.Name.Local == "component" && depth == componentDepth {
 				if err := encodeCycloneDXLicensesXML(encoder, licenses); err != nil {
@@ -281,6 +404,8 @@ func addCycloneDXRootLicensesXML(w io.Writer, data []byte, licenses projectLicen
 				found = true
 				componentDepth = -1
 			}
+			element.Name.Space = ""
+			token = element
 		}
 
 		if err := encoder.EncodeToken(token); err != nil {
@@ -302,29 +427,60 @@ func addCycloneDXRootLicensesXML(w io.Writer, data []byte, licenses projectLicen
 	return nil
 }
 
+func isCycloneDXOptionalContainer(name string) bool {
+	switch name {
+	case "components", "dependencies", "externalReferences", "hashes", "properties":
+		return true
+	default:
+		return false
+	}
+}
+
 func encodeCycloneDXLicensesXML(encoder *xml.Encoder, licenses projectLicenses) error {
 	licensesElement := xml.StartElement{Name: xml.Name{Local: "licenses"}}
 	if err := encoder.EncodeToken(licensesElement); err != nil {
 		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
 	}
-	if licenses.Expression != "" {
+	if licenses.usesCycloneDXExpression() {
 		if err := encodeXMLElement(encoder, "expression", licenses.Expression); err != nil {
 			return err
 		}
-	}
-	for _, name := range licenses.Names {
-		licenseElement := xml.StartElement{Name: xml.Name{Local: "license"}}
-		if err := encoder.EncodeToken(licenseElement); err != nil {
-			return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+	} else {
+		if licenses.Expression != "" {
+			if spdx.ValidLicense(licenses.Expression) {
+				if err := encodeCycloneDXLicenseXML(encoder, "id", licenses.Expression); err != nil {
+					return err
+				}
+			} else if err := encodeCycloneDXLicenseXML(encoder, "name", licenses.Expression); err != nil {
+				return err
+			}
 		}
-		if err := encodeXMLElement(encoder, "name", name); err != nil {
-			return err
+		for _, name := range licenses.Names {
+			if err := encodeCycloneDXLicenseXML(encoder, "name", name); err != nil {
+				return err
+			}
 		}
-		if err := encoder.EncodeToken(licenseElement.End()); err != nil {
-			return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+		for _, file := range licenses.Files {
+			if err := encodeCycloneDXLicenseXML(encoder, "name", file.Path); err != nil {
+				return err
+			}
 		}
 	}
 	if err := encoder.EncodeToken(licensesElement.End()); err != nil {
+		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+	}
+	return nil
+}
+
+func encodeCycloneDXLicenseXML(encoder *xml.Encoder, field, value string) error {
+	licenseElement := xml.StartElement{Name: xml.Name{Local: "license"}}
+	if err := encoder.EncodeToken(licenseElement); err != nil {
+		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+	}
+	if err := encodeXMLElement(encoder, field, value); err != nil {
+		return err
+	}
+	if err := encoder.EncodeToken(licenseElement.End()); err != nil {
 		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
 	}
 	return nil

--- a/cmd/sbom_root_license.go
+++ b/cmd/sbom_root_license.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -14,31 +15,40 @@ import (
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/manifests"
 	"github.com/git-pkgs/sbom"
+	"github.com/git-pkgs/spdx"
 	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 const spdxRootPackageID = "SPDXRef-Package-root"
 
-func projectLicenseAtRevision(repo *git.Repository, revision string) (string, error) {
+type projectLicenses struct {
+	Expression string
+	Names      []string
+}
+
+func (l projectLicenses) empty() bool {
+	return l.Expression == "" && len(l.Names) == 0
+}
+
+func projectLicensesAtRevision(repo *git.Repository, revision string) (projectLicenses, error) {
 	if revision == "" {
 		revision = "HEAD"
 	}
 
 	hash, err := repo.ResolveRevision(revision)
 	if err != nil {
-		return "", fmt.Errorf("resolving %q: %w", revision, err)
+		return projectLicenses{}, fmt.Errorf("resolving %q: %w", revision, err)
 	}
 	commit, err := repo.CommitObject(*hash)
 	if err != nil {
-		return "", fmt.Errorf("getting commit: %w", err)
+		return projectLicenses{}, fmt.Errorf("getting commit: %w", err)
 	}
 	tree, err := commit.Tree()
 	if err != nil {
-		return "", fmt.Errorf("getting commit tree: %w", err)
+		return projectLicenses{}, fmt.Errorf("getting commit tree: %w", err)
 	}
 
-	var licenses []string
-	seen := make(map[string]bool)
+	var declaredLicenses []string
 	err = tree.Files().ForEach(func(file *object.File) error {
 		if path.Dir(file.Name) != "." {
 			return nil
@@ -56,25 +66,78 @@ func projectLicenseAtRevision(repo *git.Repository, revision string) (string, er
 		if err != nil {
 			return nil
 		}
-		for _, declared := range result.Licenses {
-			declared = strings.TrimSpace(declared)
-			if declared == "" || seen[declared] {
-				continue
-			}
-			seen[declared] = true
-			licenses = append(licenses, declared)
-		}
+		declaredLicenses = append(declaredLicenses, result.Licenses...)
 		return nil
 	})
 	if err != nil {
-		return "", err
+		return projectLicenses{}, err
 	}
-	sort.Strings(licenses)
-	return strings.Join(licenses, " OR "), nil
+	return normalizeProjectLicenses(declaredLicenses), nil
 }
 
-func encodeSBOMWithRootLicense(w io.Writer, document *sbom.SBOM, format sbom.Format, license string) error {
-	if license == "" {
+func normalizeProjectLicenses(values []string) projectLicenses {
+	expressionSet := make(map[string]bool)
+	nameSet := make(map[string]bool)
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+
+		normalized, err := spdx.NormalizeExpressionLax(value)
+		if err != nil || !spdx.Valid(normalized) {
+			normalized, err = spdx.Normalize(value)
+		}
+		if err == nil && spdx.Valid(normalized) {
+			expressionSet[normalized] = true
+		} else {
+			nameSet[value] = true
+		}
+	}
+
+	expressions := sortedKeys(expressionSet)
+	names := sortedKeys(nameSet)
+	return projectLicenses{
+		Expression: joinSPDXExpressions(expressions),
+		Names:      names,
+	}
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for value := range values {
+		keys = append(keys, value)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinSPDXExpressions(expressions []string) string {
+	if len(expressions) == 0 {
+		return ""
+	}
+	if len(expressions) == 1 {
+		return expressions[0]
+	}
+	for i, expression := range expressions {
+		if strings.Contains(expression, " AND ") || strings.Contains(expression, " OR ") {
+			expressions[i] = "(" + expression + ")"
+		}
+	}
+	joined, err := spdx.NormalizeExpression(strings.Join(expressions, " OR "))
+	if err != nil {
+		return ""
+	}
+	return joined
+}
+
+func encodeSBOMWithRootLicenses(
+	w io.Writer,
+	document *sbom.SBOM,
+	format sbom.Format,
+	licenses projectLicenses,
+) error {
+	if licenses.empty() {
 		return sbom.Encode(w, document, format)
 	}
 
@@ -85,20 +148,20 @@ func encodeSBOMWithRootLicense(w io.Writer, document *sbom.SBOM, format sbom.For
 
 	switch format {
 	case sbom.FormatCycloneDXJSON, sbom.FormatSPDXJSON:
-		data, err := addRootLicenseJSON(encoded.Bytes(), format, license)
+		data, err := addRootLicensesJSON(encoded.Bytes(), format, licenses)
 		if err != nil {
 			return err
 		}
 		_, err = w.Write(data)
 		return err
 	case sbom.FormatCycloneDXXML:
-		return addCycloneDXRootLicenseXML(w, encoded.Bytes(), license)
+		return addCycloneDXRootLicensesXML(w, encoded.Bytes(), licenses)
 	default:
 		return fmt.Errorf("unsupported SBOM format %d", format)
 	}
 }
 
-func addRootLicenseJSON(data []byte, format sbom.Format, license string) ([]byte, error) {
+func addRootLicensesJSON(data []byte, format sbom.Format, licenses projectLicenses) ([]byte, error) {
 	var document map[string]any
 	if err := json.Unmarshal(data, &document); err != nil {
 		return nil, fmt.Errorf("decoding generated SBOM: %w", err)
@@ -114,7 +177,7 @@ func addRootLicenseJSON(data []byte, format sbom.Format, license string) ([]byte
 		if !ok {
 			return nil, errors.New("generated CycloneDX SBOM has no root component")
 		}
-		component["licenses"] = []any{map[string]any{"expression": license}}
+		component["licenses"] = cycloneDXLicenseChoices(licenses)
 	case sbom.FormatSPDXJSON:
 		packages, ok := document["packages"].([]any)
 		if !ok {
@@ -124,13 +187,16 @@ func addRootLicenseJSON(data []byte, format sbom.Format, license string) ([]byte
 		for _, value := range packages {
 			pkg, ok := value.(map[string]any)
 			if ok && pkg["SPDXID"] == spdxRootPackageID {
-				pkg["licenseDeclared"] = license
+				pkg["licenseDeclared"] = licenses.spdxExpression()
 				found = true
 				break
 			}
 		}
 		if !found {
 			return nil, errors.New("generated SPDX SBOM has no root package")
+		}
+		if len(licenses.Names) > 0 {
+			document["hasExtractedLicensingInfos"] = extractedLicenseInfo(licenses.Names)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported JSON SBOM format %d", format)
@@ -143,7 +209,46 @@ func addRootLicenseJSON(data []byte, format sbom.Format, license string) ([]byte
 	return append(encoded, '\n'), nil
 }
 
-func addCycloneDXRootLicenseXML(w io.Writer, data []byte, license string) error {
+func cycloneDXLicenseChoices(licenses projectLicenses) []any {
+	choices := make([]any, 0, 1+len(licenses.Names))
+	if licenses.Expression != "" {
+		choices = append(choices, map[string]any{"expression": licenses.Expression})
+	}
+	for _, name := range licenses.Names {
+		choices = append(choices, map[string]any{"license": map[string]any{"name": name}})
+	}
+	return choices
+}
+
+func (l projectLicenses) spdxExpression() string {
+	parts := make([]string, 0, 1+len(l.Names))
+	if l.Expression != "" {
+		parts = append(parts, l.Expression)
+	}
+	for _, name := range l.Names {
+		parts = append(parts, licenseRefForName(name))
+	}
+	return joinSPDXExpressions(parts)
+}
+
+func licenseRefForName(name string) string {
+	digest := sha256.Sum256([]byte(name))
+	return fmt.Sprintf("LicenseRef-Manifest-%x", digest[:8])
+}
+
+func extractedLicenseInfo(names []string) []any {
+	infos := make([]any, 0, len(names))
+	for _, name := range names {
+		infos = append(infos, map[string]any{
+			"licenseId":     licenseRefForName(name),
+			"name":          name,
+			"extractedText": name,
+		})
+	}
+	return infos
+}
+
+func addCycloneDXRootLicensesXML(w io.Writer, data []byte, licenses projectLicenses) error {
 	decoder := xml.NewDecoder(bytes.NewReader(data))
 	encoder := xml.NewEncoder(w)
 	metadataDepth := -1
@@ -170,7 +275,7 @@ func addCycloneDXRootLicenseXML(w io.Writer, data []byte, license string) error 
 			}
 		case xml.EndElement:
 			if element.Name.Local == "component" && depth == componentDepth {
-				if err := encodeCycloneDXLicenseXML(encoder, license); err != nil {
+				if err := encodeCycloneDXLicensesXML(encoder, licenses); err != nil {
 					return err
 				}
 				found = true
@@ -197,19 +302,38 @@ func addCycloneDXRootLicenseXML(w io.Writer, data []byte, license string) error 
 	return nil
 }
 
-func encodeCycloneDXLicenseXML(encoder *xml.Encoder, license string) error {
-	licenses := xml.StartElement{Name: xml.Name{Local: "licenses"}}
-	expression := xml.StartElement{Name: xml.Name{Local: "expression"}}
-	for _, token := range []xml.Token{
-		licenses,
-		expression,
-		xml.CharData(license),
-		expression.End(),
-		licenses.End(),
-	} {
-		if err := encoder.EncodeToken(token); err != nil {
-			return fmt.Errorf("encoding CycloneDX root license: %w", err)
+func encodeCycloneDXLicensesXML(encoder *xml.Encoder, licenses projectLicenses) error {
+	licensesElement := xml.StartElement{Name: xml.Name{Local: "licenses"}}
+	if err := encoder.EncodeToken(licensesElement); err != nil {
+		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+	}
+	if licenses.Expression != "" {
+		if err := encodeXMLElement(encoder, "expression", licenses.Expression); err != nil {
+			return err
 		}
+	}
+	for _, name := range licenses.Names {
+		licenseElement := xml.StartElement{Name: xml.Name{Local: "license"}}
+		if err := encoder.EncodeToken(licenseElement); err != nil {
+			return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+		}
+		if err := encodeXMLElement(encoder, "name", name); err != nil {
+			return err
+		}
+		if err := encoder.EncodeToken(licenseElement.End()); err != nil {
+			return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+		}
+	}
+	if err := encoder.EncodeToken(licensesElement.End()); err != nil {
+		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
+	}
+	return nil
+}
+
+func encodeXMLElement(encoder *xml.Encoder, name, value string) error {
+	element := xml.StartElement{Name: xml.Name{Local: name}}
+	if err := encoder.EncodeElement(value, element); err != nil {
+		return fmt.Errorf("encoding CycloneDX root licenses: %w", err)
 	}
 	return nil
 }

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -65,7 +65,7 @@ func TestBuildSBOM(t *testing.T) {
 	}
 	licenses := map[string]string{"pkg:npm/lodash@4.17.21": "MIT"}
 
-	doc := buildSBOM(deps, licenses, "demo", "1.0.0")
+	doc := buildSBOM(deps, licenses, "demo", "1.0.0", projectLicenses{})
 
 	if len(doc.Packages) != 2 {
 		t.Fatalf("Packages = %d, want 2", len(doc.Packages))
@@ -128,17 +128,23 @@ func TestProjectLicenseAtRevision(t *testing.T) {
 		t.Fatalf("OpenRepository: %v", err)
 	}
 
-	got, err := projectLicensesAtRevision(repo, first.String())
+	got, warnings, err := projectLicensesAtRevision(repo, first.String())
 	if err != nil {
 		t.Fatalf("projectLicensesAtRevision(first): %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("first revision warnings = %q", warnings)
 	}
 	if got.Expression != "MIT" || len(got.Names) != 0 {
 		t.Fatalf("first revision licenses = %+v, want MIT", got)
 	}
 
-	got, err = projectLicensesAtRevision(repo, "HEAD")
+	got, warnings, err = projectLicensesAtRevision(repo, "HEAD")
 	if err != nil {
 		t.Fatalf("projectLicensesAtRevision(HEAD): %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("HEAD warnings = %q", warnings)
 	}
 	if got.Expression != "Apache-2.0" || len(got.Names) != 0 {
 		t.Fatalf("HEAD licenses = %+v, want Apache-2.0", got)
@@ -161,8 +167,20 @@ func TestNormalizeProjectLicensesSeparatesNonSPDXNames(t *testing.T) {
 	if len(licenses.Names) != 1 || licenses.Names[0] != "Acme Internal Terms" {
 		t.Fatalf("non-SPDX names = %q, want [Acme Internal Terms]", licenses.Names)
 	}
-	if expression := licenses.spdxExpression(); !spdx.Valid(expression) {
-		t.Fatalf("SPDX expression with LicenseRef = %q, want valid SPDX", expression)
+}
+
+func TestNormalizeProjectLicensesCombinesIndependentExpressions(t *testing.T) {
+	licenses := normalizeProjectLicenses([]string{
+		"MIT OR Apache-2.0",
+		"BSD-3-Clause",
+	})
+
+	if !spdx.Valid(licenses.Expression) {
+		t.Fatalf("normalized expression = %q, want valid SPDX", licenses.Expression)
+	}
+	if licenses.Expression != "BSD-3-Clause AND (MIT OR Apache-2.0)" {
+		t.Fatalf("normalized expression = %q, want independent declarations joined with AND "+
+			"and manifest-level OR preserved", licenses.Expression)
 	}
 }
 
@@ -186,9 +204,12 @@ license-file = "LICENSE.custom"
 		t.Fatalf("OpenRepository: %v", err)
 	}
 
-	licenses, err := projectLicensesAtRevision(repo, manifestRevision.String())
+	licenses, warnings, err := projectLicensesAtRevision(repo, manifestRevision.String())
 	if err != nil {
 		t.Fatalf("projectLicensesAtRevision: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %q", warnings)
 	}
 	if licenses.Expression != "" || len(licenses.Names) != 0 || len(licenses.Files) != 1 {
 		t.Fatalf("project licenses = %+v, want one declared file", licenses)
@@ -198,8 +219,66 @@ license-file = "LICENSE.custom"
 	}
 }
 
+func TestProjectLicenseFileMissingWarnsAndContinues(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	commitSBOMFile(t, repository, repoDir, "Cargo.toml", `[package]
+name = "demo"
+version = "1.0.0"
+license-file = "LICENSE.missing"
+`, "add cargo manifest")
+
+	repo, err := gitpkg.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+	licenses, warnings, err := projectLicensesAtRevision(repo, "HEAD")
+	if err != nil {
+		t.Fatalf("projectLicensesAtRevision: %v", err)
+	}
+	if len(licenses.Files) != 0 {
+		t.Fatalf("project license files = %+v, want none", licenses.Files)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "LICENSE.missing") ||
+		!strings.Contains(warnings[0], "was not found") {
+		t.Fatalf("warnings = %q", warnings)
+	}
+}
+
+func TestProjectLicenseFileEmptyWarnsAndContinues(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	commitSBOMFile(t, repository, repoDir, "LICENSE.custom", "\n", "add empty license file")
+	commitSBOMFile(t, repository, repoDir, "Cargo.toml", `[package]
+name = "demo"
+version = "1.0.0"
+license-file = "LICENSE.custom"
+`, "add cargo manifest")
+
+	repo, err := gitpkg.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+	licenses, warnings, err := projectLicensesAtRevision(repo, "HEAD")
+	if err != nil {
+		t.Fatalf("projectLicensesAtRevision: %v", err)
+	}
+	if len(licenses.Files) != 0 {
+		t.Fatalf("project license files = %+v, want none", licenses.Files)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "LICENSE.custom") ||
+		!strings.Contains(warnings[0], "is empty") {
+		t.Fatalf("warnings = %q", warnings)
+	}
+}
+
 func testRootLicenses() (*sbom.SBOM, projectLicenses) {
-	document := buildSBOM(nil, nil, "demo", "1.0.0")
 	licenses := projectLicenses{
 		Expression: "MIT OR Apache-2.0",
 		Names:      []string{"Acme Internal Terms"},
@@ -208,14 +287,15 @@ func testRootLicenses() (*sbom.SBOM, projectLicenses) {
 			Text: "Custom file terms\n",
 		}},
 	}
+	document := buildSBOM(nil, nil, "demo", "1.0.0", licenses)
 	return document, licenses
 }
 
 func TestEncodeSBOMWithRootLicensesCycloneDXJSON(t *testing.T) {
 	document, licenses := testRootLicenses()
 	var output bytes.Buffer
-	if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXJSON, licenses); err != nil {
-		t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+	if err := sbom.Encode(&output, document, sbom.FormatCycloneDXJSON); err != nil {
+		t.Fatalf("sbom.Encode: %v", err)
 	}
 	var result struct {
 		Metadata struct {
@@ -248,8 +328,8 @@ func TestEncodeSBOMWithRootLicensesCycloneDXJSON(t *testing.T) {
 func TestEncodeSBOMWithRootLicensesCycloneDXXML(t *testing.T) {
 	document, licenses := testRootLicenses()
 	var output bytes.Buffer
-	if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXXML, licenses); err != nil {
-		t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+	if err := sbom.Encode(&output, document, sbom.FormatCycloneDXXML); err != nil {
+		t.Fatalf("sbom.Encode: %v", err)
 	}
 	var result struct {
 		Metadata struct {
@@ -272,12 +352,13 @@ func TestEncodeSBOMWithRootLicensesCycloneDXXML(t *testing.T) {
 func TestEncodeSBOMWithRootLicensesSPDXJSON(t *testing.T) {
 	document, licenses := testRootLicenses()
 	var output bytes.Buffer
-	if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatSPDXJSON, licenses); err != nil {
-		t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+	if err := sbom.Encode(&output, document, sbom.FormatSPDXJSON); err != nil {
+		t.Fatalf("sbom.Encode: %v", err)
 	}
 	var result struct {
 		Packages []struct {
 			SPDXID          string `json:"SPDXID"`
+			Name            string `json:"name"`
 			LicenseDeclared string `json:"licenseDeclared"`
 		} `json:"packages"`
 		ExtractedLicensingInfos []struct {
@@ -290,27 +371,26 @@ func TestEncodeSBOMWithRootLicensesSPDXJSON(t *testing.T) {
 		t.Fatalf("Unmarshal: %v\n%s", err, output.String())
 	}
 	rootLicense := findRootPackageLicense(result.Packages)
-	if !spdx.Valid(rootLicense) ||
-		!strings.Contains(rootLicense, licenseRefForName(licenses.Names[0])) ||
-		!strings.Contains(rootLicense, licenseRefForFile(licenses.Files[0])) {
+	if !spdx.Valid(rootLicense) {
 		t.Fatalf("root license = %q, want valid SPDX expression with both LicenseRefs", rootLicense)
 	}
 	if len(result.ExtractedLicensingInfos) != 2 {
 		t.Fatalf("extracted licensing infos = %+v, want two", result.ExtractedLicensingInfos)
 	}
 	fileInfo := result.ExtractedLicensingInfos[1]
-	if fileInfo.LicenseID != licenseRefForFile(licenses.Files[0]) ||
-		fileInfo.Name != licenses.Files[0].Path || fileInfo.ExtractedText != licenses.Files[0].Text {
+	if fileInfo.Name != licenses.Files[0].Path || fileInfo.ExtractedText != licenses.Files[0].Text ||
+		!strings.Contains(rootLicense, fileInfo.LicenseID) {
 		t.Fatalf("file extracted licensing info = %+v", fileInfo)
 	}
 }
 
 func findRootPackageLicense(packages []struct {
 	SPDXID          string `json:"SPDXID"`
+	Name            string `json:"name"`
 	LicenseDeclared string `json:"licenseDeclared"`
 }) string {
 	for _, pkg := range packages {
-		if pkg.SPDXID == spdxRootPackageID {
+		if pkg.Name == "demo" {
 			return pkg.LicenseDeclared
 		}
 	}

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -165,101 +166,155 @@ func TestNormalizeProjectLicensesSeparatesNonSPDXNames(t *testing.T) {
 	}
 }
 
-func TestEncodeSBOMWithRootLicense(t *testing.T) {
+func TestProjectLicenseFileAtRevision(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+
+	commitSBOMFile(t, repository, repoDir, "LICENSE.custom", "original license terms\n", "add license file")
+	manifestRevision := commitSBOMFile(t, repository, repoDir, "Cargo.toml", `[package]
+name = "demo"
+version = "1.0.0"
+license-file = "LICENSE.custom"
+`, "add cargo manifest")
+	commitSBOMFile(t, repository, repoDir, "LICENSE.custom", "updated license terms\n", "update license file")
+
+	repo, err := gitpkg.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+
+	licenses, err := projectLicensesAtRevision(repo, manifestRevision.String())
+	if err != nil {
+		t.Fatalf("projectLicensesAtRevision: %v", err)
+	}
+	if licenses.Expression != "" || len(licenses.Names) != 0 || len(licenses.Files) != 1 {
+		t.Fatalf("project licenses = %+v, want one declared file", licenses)
+	}
+	if file := licenses.Files[0]; file.Path != "LICENSE.custom" || file.Text != "original license terms\n" {
+		t.Fatalf("project license file = %+v, want original revision content", file)
+	}
+}
+
+func testRootLicenses() (*sbom.SBOM, projectLicenses) {
 	document := buildSBOM(nil, nil, "demo", "1.0.0")
 	licenses := projectLicenses{
 		Expression: "MIT OR Apache-2.0",
 		Names:      []string{"Acme Internal Terms"},
+		Files: []projectLicenseFile{{
+			Path: "LICENSE.custom",
+			Text: "Custom file terms\n",
+		}},
 	}
+	return document, licenses
+}
 
-	t.Run("CycloneDX JSON", func(t *testing.T) {
-		var output bytes.Buffer
-		if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXJSON, licenses); err != nil {
-			t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+func TestEncodeSBOMWithRootLicensesCycloneDXJSON(t *testing.T) {
+	document, licenses := testRootLicenses()
+	var output bytes.Buffer
+	if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXJSON, licenses); err != nil {
+		t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+	}
+	var result struct {
+		Metadata struct {
+			Component struct {
+				Licenses []struct {
+					Expression string `json:"expression"`
+					License    *struct {
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"license"`
+				} `json:"licenses"`
+			} `json:"component"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, output.String())
+	}
+	got := result.Metadata.Component.Licenses
+	if len(got) != 3 {
+		t.Fatalf("root licenses = %+v, want three license entries", got)
+	}
+	wantNames := []string{licenses.Expression, licenses.Names[0], licenses.Files[0].Path}
+	for i, choice := range got {
+		if choice.Expression != "" || choice.License == nil || choice.License.Name != wantNames[i] {
+			t.Fatalf("root license choice %d = %+v, want named license %q", i, choice, wantNames[i])
 		}
-		var result struct {
-			Metadata struct {
-				Component struct {
-					Licenses []struct {
-						Expression string `json:"expression"`
-						License    *struct {
-							Name string `json:"name"`
-						} `json:"license"`
-					} `json:"licenses"`
-				} `json:"component"`
-			} `json:"metadata"`
-		}
-		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
-			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
-		}
-		got := result.Metadata.Component.Licenses
-		if len(got) != 2 || got[0].Expression != licenses.Expression ||
-			got[1].License == nil || got[1].License.Name != licenses.Names[0] {
-			t.Fatalf("root licenses = %+v, want expression and name", got)
-		}
-	})
+	}
+}
 
-	t.Run("CycloneDX XML", func(t *testing.T) {
-		var output bytes.Buffer
-		if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXXML, licenses); err != nil {
-			t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
-		}
-		var result struct {
-			Metadata struct {
-				Component struct {
-					LicenseExpression string   `xml:"licenses>expression"`
-					LicenseNames      []string `xml:"licenses>license>name"`
-				} `xml:"component"`
-			} `xml:"metadata"`
-		}
-		if err := xml.Unmarshal(output.Bytes(), &result); err != nil {
-			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
-		}
-		component := result.Metadata.Component
-		if component.LicenseExpression != licenses.Expression ||
-			len(component.LicenseNames) != 1 || component.LicenseNames[0] != licenses.Names[0] {
-			t.Fatalf("root licenses = %+v, want expression and name", component)
-		}
-	})
+func TestEncodeSBOMWithRootLicensesCycloneDXXML(t *testing.T) {
+	document, licenses := testRootLicenses()
+	var output bytes.Buffer
+	if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXXML, licenses); err != nil {
+		t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+	}
+	var result struct {
+		Metadata struct {
+			Component struct {
+				LicenseExpression string   `xml:"licenses>expression"`
+				LicenseNames      []string `xml:"licenses>license>name"`
+			} `xml:"component"`
+		} `xml:"metadata"`
+	}
+	if err := xml.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, output.String())
+	}
+	component := result.Metadata.Component
+	wantNames := []string{licenses.Expression, licenses.Names[0], licenses.Files[0].Path}
+	if component.LicenseExpression != "" || !slices.Equal(component.LicenseNames, wantNames) {
+		t.Fatalf("root licenses = %+v, want named licenses %q", component, wantNames)
+	}
+}
 
-	t.Run("SPDX JSON", func(t *testing.T) {
-		var output bytes.Buffer
-		if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatSPDXJSON, licenses); err != nil {
-			t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+func TestEncodeSBOMWithRootLicensesSPDXJSON(t *testing.T) {
+	document, licenses := testRootLicenses()
+	var output bytes.Buffer
+	if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatSPDXJSON, licenses); err != nil {
+		t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
+	}
+	var result struct {
+		Packages []struct {
+			SPDXID          string `json:"SPDXID"`
+			LicenseDeclared string `json:"licenseDeclared"`
+		} `json:"packages"`
+		ExtractedLicensingInfos []struct {
+			LicenseID     string `json:"licenseId"`
+			Name          string `json:"name"`
+			ExtractedText string `json:"extractedText"`
+		} `json:"hasExtractedLicensingInfos"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal: %v\n%s", err, output.String())
+	}
+	rootLicense := findRootPackageLicense(result.Packages)
+	if !spdx.Valid(rootLicense) ||
+		!strings.Contains(rootLicense, licenseRefForName(licenses.Names[0])) ||
+		!strings.Contains(rootLicense, licenseRefForFile(licenses.Files[0])) {
+		t.Fatalf("root license = %q, want valid SPDX expression with both LicenseRefs", rootLicense)
+	}
+	if len(result.ExtractedLicensingInfos) != 2 {
+		t.Fatalf("extracted licensing infos = %+v, want two", result.ExtractedLicensingInfos)
+	}
+	fileInfo := result.ExtractedLicensingInfos[1]
+	if fileInfo.LicenseID != licenseRefForFile(licenses.Files[0]) ||
+		fileInfo.Name != licenses.Files[0].Path || fileInfo.ExtractedText != licenses.Files[0].Text {
+		t.Fatalf("file extracted licensing info = %+v", fileInfo)
+	}
+}
+
+func findRootPackageLicense(packages []struct {
+	SPDXID          string `json:"SPDXID"`
+	LicenseDeclared string `json:"licenseDeclared"`
+}) string {
+	for _, pkg := range packages {
+		if pkg.SPDXID == spdxRootPackageID {
+			return pkg.LicenseDeclared
 		}
-		var result struct {
-			Packages []struct {
-				SPDXID          string `json:"SPDXID"`
-				LicenseDeclared string `json:"licenseDeclared"`
-			} `json:"packages"`
-			ExtractedLicensingInfos []struct {
-				LicenseID     string `json:"licenseId"`
-				Name          string `json:"name"`
-				ExtractedText string `json:"extractedText"`
-			} `json:"hasExtractedLicensingInfos"`
-		}
-		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
-			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
-		}
-		for _, pkg := range result.Packages {
-			if pkg.SPDXID == spdxRootPackageID {
-				if !spdx.Valid(pkg.LicenseDeclared) ||
-					!strings.Contains(pkg.LicenseDeclared, licenseRefForName(licenses.Names[0])) {
-					t.Fatalf("root license = %q, want valid SPDX expression with LicenseRef", pkg.LicenseDeclared)
-				}
-				if len(result.ExtractedLicensingInfos) != 1 {
-					t.Fatalf("extracted licensing infos = %+v, want one", result.ExtractedLicensingInfos)
-				}
-				info := result.ExtractedLicensingInfos[0]
-				if info.LicenseID != licenseRefForName(licenses.Names[0]) ||
-					info.Name != licenses.Names[0] || info.ExtractedText != licenses.Names[0] {
-					t.Fatalf("extracted licensing info = %+v", info)
-				}
-				return
-			}
-		}
-		t.Fatal("SPDX output has no root package")
-	})
+	}
+	return ""
 }
 
 func commitSBOMFile(

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -3,12 +3,21 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"encoding/xml"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/git-pkgs/enrichment"
 	"github.com/git-pkgs/git-pkgs/internal/database"
+	gitpkg "github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/sbom"
+	gitgo "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 type sbomEnrichmentClient struct {
@@ -87,6 +96,154 @@ func TestBuildSBOM(t *testing.T) {
 			t.Errorf("encoded output missing purl:\n%s", buf.String())
 		}
 	}
+}
+
+func TestProjectLicenseAtRevision(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+
+	first := commitSBOMFile(t, repository, repoDir, "package.json", `{
+  "name": "demo",
+  "version": "1.0.0",
+  "license": "MIT"
+}`, "add package manifest")
+	commitSBOMFile(t, repository, repoDir, "package.json", `{
+  "name": "demo",
+  "version": "1.1.0",
+  "license": "Apache-2.0"
+}`, "change project license")
+	commitSBOMFile(t, repository, repoDir, "packages/nested/package.json", `{
+  "name": "nested",
+  "version": "1.0.0",
+  "license": "GPL-3.0-only"
+}`, "add nested package")
+
+	repo, err := gitpkg.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+
+	got, err := projectLicenseAtRevision(repo, first.String())
+	if err != nil {
+		t.Fatalf("projectLicenseAtRevision(first): %v", err)
+	}
+	if got != "MIT" {
+		t.Fatalf("first revision license = %q, want MIT", got)
+	}
+
+	got, err = projectLicenseAtRevision(repo, "HEAD")
+	if err != nil {
+		t.Fatalf("projectLicenseAtRevision(HEAD): %v", err)
+	}
+	if got != "Apache-2.0" {
+		t.Fatalf("HEAD license = %q, want Apache-2.0", got)
+	}
+}
+
+func TestEncodeSBOMWithRootLicense(t *testing.T) {
+	document := buildSBOM(nil, nil, "demo", "1.0.0")
+	const license = "MIT OR Apache-2.0"
+
+	t.Run("CycloneDX JSON", func(t *testing.T) {
+		var output bytes.Buffer
+		if err := encodeSBOMWithRootLicense(&output, document, sbom.FormatCycloneDXJSON, license); err != nil {
+			t.Fatalf("encodeSBOMWithRootLicense: %v", err)
+		}
+		var result struct {
+			Metadata struct {
+				Component struct {
+					Licenses []struct {
+						Expression string `json:"expression"`
+					} `json:"licenses"`
+				} `json:"component"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
+		}
+		if len(result.Metadata.Component.Licenses) != 1 ||
+			result.Metadata.Component.Licenses[0].Expression != license {
+			t.Fatalf("root licenses = %+v, want %q", result.Metadata.Component.Licenses, license)
+		}
+	})
+
+	t.Run("CycloneDX XML", func(t *testing.T) {
+		var output bytes.Buffer
+		if err := encodeSBOMWithRootLicense(&output, document, sbom.FormatCycloneDXXML, license); err != nil {
+			t.Fatalf("encodeSBOMWithRootLicense: %v", err)
+		}
+		var result struct {
+			Metadata struct {
+				Component struct {
+					LicenseExpression string `xml:"licenses>expression"`
+				} `xml:"component"`
+			} `xml:"metadata"`
+		}
+		if err := xml.Unmarshal(output.Bytes(), &result); err != nil {
+			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
+		}
+		if result.Metadata.Component.LicenseExpression != license {
+			t.Fatalf("root license = %q, want %q", result.Metadata.Component.LicenseExpression, license)
+		}
+	})
+
+	t.Run("SPDX JSON", func(t *testing.T) {
+		var output bytes.Buffer
+		if err := encodeSBOMWithRootLicense(&output, document, sbom.FormatSPDXJSON, license); err != nil {
+			t.Fatalf("encodeSBOMWithRootLicense: %v", err)
+		}
+		var result struct {
+			Packages []struct {
+				SPDXID          string `json:"SPDXID"`
+				LicenseDeclared string `json:"licenseDeclared"`
+			} `json:"packages"`
+		}
+		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
+		}
+		for _, pkg := range result.Packages {
+			if pkg.SPDXID == spdxRootPackageID {
+				if pkg.LicenseDeclared != license {
+					t.Fatalf("root license = %q, want %q", pkg.LicenseDeclared, license)
+				}
+				return
+			}
+		}
+		t.Fatal("SPDX output has no root package")
+	})
+}
+
+func commitSBOMFile(
+	t *testing.T,
+	repository *gitgo.Repository,
+	repoDir, name, content, message string,
+) plumbing.Hash {
+	t.Helper()
+	fullPath := filepath.Join(repoDir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	worktree, err := repository.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if _, err := worktree.Add(name); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	when := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	hash, err := worktree.Commit(message, &gitgo.CommitOptions{
+		Author: &object.Signature{Name: "Test User", Email: "test@example.com", When: when},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	return hash
 }
 
 func TestSelectSBOMDependenciesPrefersResolvedVersions(t *testing.T) {

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	gitpkg "github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/sbom"
+	"github.com/git-pkgs/spdx"
 	gitgo "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -126,37 +127,64 @@ func TestProjectLicenseAtRevision(t *testing.T) {
 		t.Fatalf("OpenRepository: %v", err)
 	}
 
-	got, err := projectLicenseAtRevision(repo, first.String())
+	got, err := projectLicensesAtRevision(repo, first.String())
 	if err != nil {
-		t.Fatalf("projectLicenseAtRevision(first): %v", err)
+		t.Fatalf("projectLicensesAtRevision(first): %v", err)
 	}
-	if got != "MIT" {
-		t.Fatalf("first revision license = %q, want MIT", got)
+	if got.Expression != "MIT" || len(got.Names) != 0 {
+		t.Fatalf("first revision licenses = %+v, want MIT", got)
 	}
 
-	got, err = projectLicenseAtRevision(repo, "HEAD")
+	got, err = projectLicensesAtRevision(repo, "HEAD")
 	if err != nil {
-		t.Fatalf("projectLicenseAtRevision(HEAD): %v", err)
+		t.Fatalf("projectLicensesAtRevision(HEAD): %v", err)
 	}
-	if got != "Apache-2.0" {
-		t.Fatalf("HEAD license = %q, want Apache-2.0", got)
+	if got.Expression != "Apache-2.0" || len(got.Names) != 0 {
+		t.Fatalf("HEAD licenses = %+v, want Apache-2.0", got)
+	}
+}
+
+func TestNormalizeProjectLicensesSeparatesNonSPDXNames(t *testing.T) {
+	licenses := normalizeProjectLicenses([]string{
+		"BSD-3-Clause",
+		"License :: OSI Approved :: BSD License",
+		"Acme Internal Terms",
+	})
+
+	if licenses.Expression == "" || !spdx.Valid(licenses.Expression) {
+		t.Fatalf("normalized expression = %q, want valid SPDX", licenses.Expression)
+	}
+	if strings.Contains(licenses.Expression, "License ::") {
+		t.Fatalf("normalized expression contains raw classifier: %q", licenses.Expression)
+	}
+	if len(licenses.Names) != 1 || licenses.Names[0] != "Acme Internal Terms" {
+		t.Fatalf("non-SPDX names = %q, want [Acme Internal Terms]", licenses.Names)
+	}
+	if expression := licenses.spdxExpression(); !spdx.Valid(expression) {
+		t.Fatalf("SPDX expression with LicenseRef = %q, want valid SPDX", expression)
 	}
 }
 
 func TestEncodeSBOMWithRootLicense(t *testing.T) {
 	document := buildSBOM(nil, nil, "demo", "1.0.0")
-	const license = "MIT OR Apache-2.0"
+	licenses := projectLicenses{
+		Expression: "MIT OR Apache-2.0",
+		Names:      []string{"Acme Internal Terms"},
+	}
 
 	t.Run("CycloneDX JSON", func(t *testing.T) {
 		var output bytes.Buffer
-		if err := encodeSBOMWithRootLicense(&output, document, sbom.FormatCycloneDXJSON, license); err != nil {
-			t.Fatalf("encodeSBOMWithRootLicense: %v", err)
+		if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXJSON, licenses); err != nil {
+			t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
 		}
 		var result struct {
 			Metadata struct {
 				Component struct {
 					Licenses []struct {
 						Expression string `json:"expression"`
+						License    *struct {
+							Name string `json:"name"`
+						} `json:"license"`
 					} `json:"licenses"`
 				} `json:"component"`
 			} `json:"metadata"`
@@ -164,50 +192,68 @@ func TestEncodeSBOMWithRootLicense(t *testing.T) {
 		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
 			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
 		}
-		if len(result.Metadata.Component.Licenses) != 1 ||
-			result.Metadata.Component.Licenses[0].Expression != license {
-			t.Fatalf("root licenses = %+v, want %q", result.Metadata.Component.Licenses, license)
+		got := result.Metadata.Component.Licenses
+		if len(got) != 2 || got[0].Expression != licenses.Expression ||
+			got[1].License == nil || got[1].License.Name != licenses.Names[0] {
+			t.Fatalf("root licenses = %+v, want expression and name", got)
 		}
 	})
 
 	t.Run("CycloneDX XML", func(t *testing.T) {
 		var output bytes.Buffer
-		if err := encodeSBOMWithRootLicense(&output, document, sbom.FormatCycloneDXXML, license); err != nil {
-			t.Fatalf("encodeSBOMWithRootLicense: %v", err)
+		if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatCycloneDXXML, licenses); err != nil {
+			t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
 		}
 		var result struct {
 			Metadata struct {
 				Component struct {
-					LicenseExpression string `xml:"licenses>expression"`
+					LicenseExpression string   `xml:"licenses>expression"`
+					LicenseNames      []string `xml:"licenses>license>name"`
 				} `xml:"component"`
 			} `xml:"metadata"`
 		}
 		if err := xml.Unmarshal(output.Bytes(), &result); err != nil {
 			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
 		}
-		if result.Metadata.Component.LicenseExpression != license {
-			t.Fatalf("root license = %q, want %q", result.Metadata.Component.LicenseExpression, license)
+		component := result.Metadata.Component
+		if component.LicenseExpression != licenses.Expression ||
+			len(component.LicenseNames) != 1 || component.LicenseNames[0] != licenses.Names[0] {
+			t.Fatalf("root licenses = %+v, want expression and name", component)
 		}
 	})
 
 	t.Run("SPDX JSON", func(t *testing.T) {
 		var output bytes.Buffer
-		if err := encodeSBOMWithRootLicense(&output, document, sbom.FormatSPDXJSON, license); err != nil {
-			t.Fatalf("encodeSBOMWithRootLicense: %v", err)
+		if err := encodeSBOMWithRootLicenses(&output, document, sbom.FormatSPDXJSON, licenses); err != nil {
+			t.Fatalf("encodeSBOMWithRootLicenses: %v", err)
 		}
 		var result struct {
 			Packages []struct {
 				SPDXID          string `json:"SPDXID"`
 				LicenseDeclared string `json:"licenseDeclared"`
 			} `json:"packages"`
+			ExtractedLicensingInfos []struct {
+				LicenseID     string `json:"licenseId"`
+				Name          string `json:"name"`
+				ExtractedText string `json:"extractedText"`
+			} `json:"hasExtractedLicensingInfos"`
 		}
 		if err := json.Unmarshal(output.Bytes(), &result); err != nil {
 			t.Fatalf("Unmarshal: %v\n%s", err, output.String())
 		}
 		for _, pkg := range result.Packages {
 			if pkg.SPDXID == spdxRootPackageID {
-				if pkg.LicenseDeclared != license {
-					t.Fatalf("root license = %q, want %q", pkg.LicenseDeclared, license)
+				if !spdx.Valid(pkg.LicenseDeclared) ||
+					!strings.Contains(pkg.LicenseDeclared, licenseRefForName(licenses.Names[0])) {
+					t.Fatalf("root license = %q, want valid SPDX expression with LicenseRef", pkg.LicenseDeclared)
+				}
+				if len(result.ExtractedLicensingInfos) != 1 {
+					t.Fatalf("extracted licensing infos = %+v, want one", result.ExtractedLicensingInfos)
+				}
+				info := result.ExtractedLicensingInfos[0]
+				if info.LicenseID != licenseRefForName(licenses.Names[0]) ||
+					info.Name != licenses.Names[0] || info.ExtractedText != licenses.Names[0] {
+					t.Fatalf("extracted licensing info = %+v", info)
 				}
 				return
 			}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/git-pkgs/registries v0.6.4
 	github.com/git-pkgs/resolve v0.2.2
 	github.com/git-pkgs/sarif v0.1.1
-	github.com/git-pkgs/sbom v0.1.3
+	github.com/git-pkgs/sbom v0.1.4
 	github.com/git-pkgs/spdx v0.3.0
 	github.com/git-pkgs/vers v0.3.0
 	github.com/git-pkgs/vulns v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/git-pkgs/resolve v0.2.2 h1:jjr6qa/8b/edg3tub5WYyYV04OpfWCuGZzgVYnfGl3
 github.com/git-pkgs/resolve v0.2.2/go.mod h1:KT894HOGMudjhSUWGHW1mC4r01eBaVaf0ujYhEHPMvo=
 github.com/git-pkgs/sarif v0.1.1 h1:Jc5N+6ezJqbVjGZlPX9i8ar+OUsT+LX06nsM6Xjrq1c=
 github.com/git-pkgs/sarif v0.1.1/go.mod h1:NGg7Ft2+nvR0CBo+Ya9oSX+Yh/p1d7FVyhPe2/0v9V4=
-github.com/git-pkgs/sbom v0.1.3 h1:HNZabAgUSu4qel9tVtAedZTjMmml2JRaFYNuipBCGjs=
-github.com/git-pkgs/sbom v0.1.3/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
+github.com/git-pkgs/sbom v0.1.4 h1:bcWiNIg0l8selcAcUh/ipX2pU9RITcwfi1vDbI5uvS4=
+github.com/git-pkgs/sbom v0.1.4/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/spdx v0.3.0 h1:AN0guJE7vN5gbOMi9We4j1ziS4cwgFVhTvjVDGfaC7Q=
 github.com/git-pkgs/spdx v0.3.0/go.mod h1:cqRoZcvl530s/W+oGNvwjt4ODN8T1W6D/20MUZEFdto=
 github.com/git-pkgs/vers v0.3.0 h1:xM4LLUCRmqzdDfe+/pVQUx4SRyFXRVth6tOsJ14wMKU=


### PR DESCRIPTION
Closes #303
## Summary

- Parse top-level package manifests at the requested Git revision to collect the project's declared license values.
- Populate the root component license in CycloneDX JSON/XML and the root package license in SPDX JSON.
- Deduplicate multiple declared licenses and produce deterministic output.
- Preserve historical `--commit` behavior and avoid treating nested package manifests as the repository root.
- Add regression coverage for revision selection and all supported SBOM output formats.

## Verification

- `go test ./...`
- `go mod tidy -diff`
- `go tool golangci-lint run ./...`
- `git diff --check`