### PR TITLE
diff: report declared license changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ git pkgs diff-file before.lock after.lock --filename=Gemfile.lock  # override ty
 git pkgs diff-file old.lock new.lock -f json  # JSON output
 ```
 
-Useful for comparing dependencies across different projects, archived source code without git history, or repositories using other version control systems.
+Useful for comparing dependencies across different projects, archived source code without git history, or repositories using other version control systems. For package manifests, it also reports changes to the project's declared licenses.
 
 ### Show changes in a commit
 

--- a/cmd/analysis_test.go
+++ b/cmd/analysis_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -885,6 +886,71 @@ func TestDiffFileCommand(t *testing.T) {
 		output := stdout.String()
 		if !strings.Contains(output, "express") {
 			t.Errorf("expected 'express' in diff output, got: %s", output)
+		}
+	})
+
+	t.Run("reports declared license changes", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		writeFile(t, repoDir, "old.json", `{"license":"MIT","dependencies":{"lodash":"^4.17.21"}}`)
+		writeFile(t, repoDir, "new.json", `{"license":"Apache-2.0","dependencies":{"lodash":"^4.17.21"}}`)
+
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"diff-file", "old.json", "new.json", "--filename", "package.json"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("diff-file failed: %v", err)
+		}
+
+		output := stdout.String()
+		for _, expected := range []string{"Declared licenses:", "MIT", "Apache-2.0", "package.json"} {
+			if !strings.Contains(output, expected) {
+				t.Errorf("expected %q in diff output, got: %s", expected, output)
+			}
+		}
+	})
+
+	t.Run("reports declared license changes as json", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		writeFile(t, repoDir, "old.json", `{"licenses":[{"type":"MIT"},{"type":"ISC"}]}`)
+		writeFile(t, repoDir, "new.json", `{"licenses":[{"type":"Apache-2.0"}]}`)
+
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"diff-file", "old.json", "new.json", "--filename", "package.json", "--format", "json"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("diff-file failed: %v", err)
+		}
+
+		var result struct {
+			LicenseChanges []struct {
+				ManifestPath string   `json:"manifest_path"`
+				FromLicenses []string `json:"from_licenses"`
+				ToLicenses   []string `json:"to_licenses"`
+			} `json:"license_changes"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("decoding diff-file JSON: %v\n%s", err, stdout.String())
+		}
+		if len(result.LicenseChanges) != 1 {
+			t.Fatalf("license changes = %+v, want one", result.LicenseChanges)
+		}
+		change := result.LicenseChanges[0]
+		if change.ManifestPath != "package.json" ||
+			!slices.Equal(change.FromLicenses, []string{"ISC", "MIT"}) ||
+			!slices.Equal(change.ToLicenses, []string{"Apache-2.0"}) {
+			t.Fatalf("license change = %+v", change)
 		}
 	})
 

--- a/cmd/analysis_test.go
+++ b/cmd/analysis_test.go
@@ -954,6 +954,35 @@ func TestDiffFileCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("ignores equivalent license spellings", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		writeFile(t, repoDir, "old.json", `{"license":"MIT"}`)
+		writeFile(t, repoDir, "new.json", `{"license":" MIT License "}`)
+
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"diff-file", "old.json", "new.json", "--filename", "package.json", "--format", "json"})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("diff-file failed: %v", err)
+		}
+
+		var result struct {
+			LicenseChanges []json.RawMessage `json:"license_changes"`
+		}
+		if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+			t.Fatalf("decoding diff-file JSON: %v\n%s", err, stdout.String())
+		}
+		if len(result.LicenseChanges) != 0 {
+			t.Fatalf("license changes = %s, want none", result.LicenseChanges)
+		}
+	})
+
 	t.Run("compares workflow files with filename flag", func(t *testing.T) {
 		repoDir := createTestRepo(t)
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -41,9 +41,10 @@ const (
 )
 
 type DiffResult struct {
-	Added    []DiffEntry `json:"added,omitempty"`
-	Modified []DiffEntry `json:"modified,omitempty"`
-	Removed  []DiffEntry `json:"removed,omitempty"`
+	Added          []DiffEntry             `json:"added,omitempty"`
+	Modified       []DiffEntry             `json:"modified,omitempty"`
+	Removed        []DiffEntry             `json:"removed,omitempty"`
+	LicenseChanges []DeclaredLicenseChange `json:"license_changes,omitempty"`
 }
 
 type DiffEntry struct {
@@ -54,6 +55,12 @@ type DiffEntry struct {
 	DependencyType  string `json:"dependency_type,omitempty"`
 	FromRequirement string `json:"from_requirement,omitempty"`
 	ToRequirement   string `json:"to_requirement,omitempty"`
+}
+
+type DeclaredLicenseChange struct {
+	ManifestPath string   `json:"manifest_path"`
+	FromLicenses []string `json:"from_licenses"`
+	ToLicenses   []string `json:"to_licenses"`
 }
 
 type DiffStat struct {
@@ -539,5 +546,24 @@ func outputDiffText(cmd *cobra.Command, result *DiffResult) error {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout())
 	}
 
+	if len(result.LicenseChanges) > 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), Bold("Declared licenses:"))
+		for _, change := range result.LicenseChanges {
+			line := fmt.Sprintf("  %s %s -> %s", Yellow("~"),
+				formatDeclaredLicenses(change.FromLicenses),
+				formatDeclaredLicenses(change.ToLicenses))
+			line += fmt.Sprintf(" %s", Dim("("+change.ManifestPath+")"))
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), line)
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	}
+
 	return nil
+}
+
+func formatDeclaredLicenses(licenses []string) string {
+	if len(licenses) == 0 {
+		return "(none)"
+	}
+	return strings.Join(licenses, ", ")
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -565,5 +565,9 @@ func formatDeclaredLicenses(licenses []string) string {
 	if len(licenses) == 0 {
 		return "(none)"
 	}
-	return strings.Join(licenses, ", ")
+	sanitized := make([]string, len(licenses))
+	for i, license := range licenses {
+		sanitized[i] = Sanitize(license)
+	}
+	return strings.Join(sanitized, ", ")
 }

--- a/cmd/diff_driver.go
+++ b/cmd/diff_driver.go
@@ -192,7 +192,7 @@ func convertLockfile(cmd *cobra.Command, filePath string) error {
 	// Try to parse with manifests library
 	// Use filePath as-is to preserve path info for manifest identification (e.g., .github/workflows/)
 	result, err := manifests.Parse(filePath, content)
-	if err != nil || result == nil || len(result.Dependencies) == 0 {
+	if err != nil || result == nil {
 		// Fall back to just outputting the file as-is
 		_, _ = cmd.OutOrStdout().Write(content)
 		return nil
@@ -212,6 +212,9 @@ func convertLockfile(cmd *cobra.Command, filePath string) error {
 
 	// Output sorted list
 	w := bufio.NewWriter(cmd.OutOrStdout())
+	for _, license := range sortedUniqueLicenses(result.Licenses) {
+		_, _ = fmt.Fprintf(w, "license: %s\n", Sanitize(license))
+	}
 	for _, dep := range deps {
 		line := dep.Name
 		if dep.Version != "" {

--- a/cmd/diff_driver_test.go
+++ b/cmd/diff_driver_test.go
@@ -117,4 +117,48 @@ BUNDLED WITH
 			}
 		}
 	})
+
+	t.Run("emits declared licenses", func(t *testing.T) {
+		content := `{"name":"example","license":"MIT"}`
+		tmpDir := t.TempDir()
+		manifestPath := filepath.Join(tmpDir, "package.json")
+		if err := os.WriteFile(manifestPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"diff-driver", manifestPath})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("diff-driver failed: %v", err)
+		}
+
+		if got, want := strings.TrimSpace(stdout.String()), "license: MIT"; got != want {
+			t.Fatalf("diff-driver output = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("emits no raw content after license removal", func(t *testing.T) {
+		content := `{"name":"example"}`
+		tmpDir := t.TempDir()
+		manifestPath := filepath.Join(tmpDir, "package.json")
+		if err := os.WriteFile(manifestPath, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		var stdout bytes.Buffer
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"diff-driver", manifestPath})
+		rootCmd.SetOut(&stdout)
+
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("diff-driver failed: %v", err)
+		}
+
+		if stdout.Len() != 0 {
+			t.Fatalf("diff-driver output = %q, want empty semantic output", stdout.String())
+		}
+	})
 }

--- a/cmd/diff_driver_test.go
+++ b/cmd/diff_driver_test.go
@@ -117,48 +117,48 @@ BUNDLED WITH
 			}
 		}
 	})
+}
 
-	t.Run("emits declared licenses", func(t *testing.T) {
-		content := `{"name":"example","license":"MIT"}`
-		tmpDir := t.TempDir()
-		manifestPath := filepath.Join(tmpDir, "package.json")
-		if err := os.WriteFile(manifestPath, []byte(content), 0644); err != nil {
-			t.Fatal(err)
-		}
+func TestDiffDriverEmitsDeclaredLicenses(t *testing.T) {
+	content := `{"name":"example","license":"MIT"}`
+	tmpDir := t.TempDir()
+	manifestPath := filepath.Join(tmpDir, "package.json")
+	if err := os.WriteFile(manifestPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-		var stdout bytes.Buffer
-		rootCmd := cmd.NewRootCmd()
-		rootCmd.SetArgs([]string{"diff-driver", manifestPath})
-		rootCmd.SetOut(&stdout)
+	var stdout bytes.Buffer
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"diff-driver", manifestPath})
+	rootCmd.SetOut(&stdout)
 
-		if err := rootCmd.Execute(); err != nil {
-			t.Fatalf("diff-driver failed: %v", err)
-		}
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("diff-driver failed: %v", err)
+	}
 
-		if got, want := strings.TrimSpace(stdout.String()), "license: MIT"; got != want {
-			t.Fatalf("diff-driver output = %q, want %q", got, want)
-		}
-	})
+	if got, want := strings.TrimSpace(stdout.String()), "license: MIT"; got != want {
+		t.Fatalf("diff-driver output = %q, want %q", got, want)
+	}
+}
 
-	t.Run("emits no raw content after license removal", func(t *testing.T) {
-		content := `{"name":"example"}`
-		tmpDir := t.TempDir()
-		manifestPath := filepath.Join(tmpDir, "package.json")
-		if err := os.WriteFile(manifestPath, []byte(content), 0644); err != nil {
-			t.Fatal(err)
-		}
+func TestDiffDriverEmitsNoRawContentAfterLicenseRemoval(t *testing.T) {
+	content := `{"name":"example"}`
+	tmpDir := t.TempDir()
+	manifestPath := filepath.Join(tmpDir, "package.json")
+	if err := os.WriteFile(manifestPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-		var stdout bytes.Buffer
-		rootCmd := cmd.NewRootCmd()
-		rootCmd.SetArgs([]string{"diff-driver", manifestPath})
-		rootCmd.SetOut(&stdout)
+	var stdout bytes.Buffer
+	rootCmd := cmd.NewRootCmd()
+	rootCmd.SetArgs([]string{"diff-driver", manifestPath})
+	rootCmd.SetOut(&stdout)
 
-		if err := rootCmd.Execute(); err != nil {
-			t.Fatalf("diff-driver failed: %v", err)
-		}
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("diff-driver failed: %v", err)
+	}
 
-		if stdout.Len() != 0 {
-			t.Fatalf("diff-driver output = %q, want empty semantic output", stdout.String())
-		}
-	})
+	if stdout.Len() != 0 {
+		t.Fatalf("diff-driver output = %q, want empty semantic output", stdout.String())
+	}
 }

--- a/cmd/diff_file.go
+++ b/cmd/diff_file.go
@@ -107,6 +107,7 @@ func sortedUniqueLicenses(licenses []string) []string {
 	result := make([]string, 0, len(licenses))
 	seen := make(map[string]bool, len(licenses))
 	for _, license := range licenses {
+		license = normalizeLicenseString(license)
 		if license == "" || seen[license] {
 			continue
 		}

--- a/cmd/diff_file.go
+++ b/cmd/diff_file.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/manifests"
@@ -12,7 +14,7 @@ import (
 func addDiffFileCmd(parent *cobra.Command) {
 	diffFileCmd := &cobra.Command{
 		Use:   "diff-file [from] [to]",
-		Short: "Compare dependencies between two files",
+		Short: "Compare dependencies and declared licenses between two files",
 		Args:  cobra.ExactArgs(2),
 		RunE:  runDiffFile,
 	}
@@ -29,16 +31,25 @@ func runDiffFile(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fromDeps, err := parseFile(args[0], defaultFilename)
+	fromFile, err := parseFile(args[0], defaultFilename)
 	if err != nil {
 		return err
 	}
-	toDeps, err := parseFile(args[1], defaultFilename)
+	toFile, err := parseFile(args[1], defaultFilename)
 	if err != nil {
 		return err
 	}
 
-	result := computeDiff(fromDeps, toDeps)
+	result := computeDiff(fromFile.Dependencies, toFile.Dependencies)
+	fromLicenses := sortedUniqueLicenses(fromFile.Licenses)
+	toLicenses := sortedUniqueLicenses(toFile.Licenses)
+	if !slices.Equal(fromLicenses, toLicenses) {
+		result.LicenseChanges = []DeclaredLicenseChange{{
+			ManifestPath: toFile.ManifestPath,
+			FromLicenses: fromLicenses,
+			ToLicenses:   toLicenses,
+		}}
+	}
 
 	switch format {
 	case formatJSON:
@@ -48,24 +59,31 @@ func runDiffFile(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func parseFile(filename, defaultFilename string) ([]database.Dependency, error) {
-	data, err := os.ReadFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	if len(data) == 0 {
-		return []database.Dependency{}, nil
-	}
+type parsedDiffFile struct {
+	Dependencies []database.Dependency
+	Licenses     []string
+	ManifestPath string
+}
 
-	// Use defaultFilename as-is if provided (preserves path for manifest identification)
-	// Otherwise use base name of the actual file
+func parseFile(filename, defaultFilename string) (parsedDiffFile, error) {
 	name := defaultFilename
 	if name == "" {
 		name = filepath.Base(filename)
 	}
+
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return parsedDiffFile{}, err
+	}
+	if len(data) == 0 {
+		return parsedDiffFile{ManifestPath: name}, nil
+	}
+
+	// Use defaultFilename as-is if provided (preserves path for manifest identification)
+	// Otherwise use base name of the actual file
 	result, err := manifests.Parse(name, data)
 	if err != nil {
-		return nil, err
+		return parsedDiffFile{}, err
 	}
 
 	var deps []database.Dependency
@@ -78,5 +96,23 @@ func parseFile(filename, defaultFilename string) ([]database.Dependency, error) 
 			DependencyType: string(dep.Scope),
 		})
 	}
-	return deps, nil
+	return parsedDiffFile{
+		Dependencies: deps,
+		Licenses:     result.Licenses,
+		ManifestPath: name,
+	}, nil
+}
+
+func sortedUniqueLicenses(licenses []string) []string {
+	result := make([]string, 0, len(licenses))
+	seen := make(map[string]bool, len(licenses))
+	for _, license := range licenses {
+		if license == "" || seen[license] {
+			continue
+		}
+		seen[license] = true
+		result = append(result, license)
+	}
+	sort.Strings(result)
+	return result
 }

--- a/cmd/diff_file_test.go
+++ b/cmd/diff_file_test.go
@@ -21,3 +21,11 @@ func TestSortedUniqueLicenses(t *testing.T) {
 		t.Fatalf("sortedUniqueLicenses() = %q, want %q", got, want)
 	}
 }
+
+func TestFormatDeclaredLicensesSanitizesControlCharacters(t *testing.T) {
+	got := formatDeclaredLicenses([]string{"MIT\x1b[31m", "Custom\x00License"})
+	want := "MIT[31m, CustomLicense"
+	if got != want {
+		t.Fatalf("formatDeclaredLicenses() = %q, want %q", got, want)
+	}
+}

--- a/cmd/diff_file_test.go
+++ b/cmd/diff_file_test.go
@@ -6,8 +6,17 @@ import (
 )
 
 func TestSortedUniqueLicenses(t *testing.T) {
-	got := sortedUniqueLicenses([]string{"MIT", "Apache-2.0", "MIT", ""})
-	want := []string{"Apache-2.0", "MIT"}
+	got := sortedUniqueLicenses([]string{
+		" MIT ",
+		"MIT License",
+		"Apache 2.0",
+		"Apache-2.0",
+		"Custom License",
+		" Custom License ",
+		"",
+		"   ",
+	})
+	want := []string{"Apache-2.0", "Custom License", "MIT"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("sortedUniqueLicenses() = %q, want %q", got, want)
 	}

--- a/cmd/diff_file_test.go
+++ b/cmd/diff_file_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSortedUniqueLicenses(t *testing.T) {
+	got := sortedUniqueLicenses([]string{"MIT", "Apache-2.0", "MIT", ""})
+	want := []string{"Apache-2.0", "MIT"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("sortedUniqueLicenses() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #304

## Summary

- Report declared-license changes when comparing manifests with `git pkgs diff-file`.
- Add a structured `license_changes` field to JSON diff output with manifest path and before/after license lists.
- Emit deterministic `license: ...` lines from `diff-driver` so Git textconv can display license changes.
- Deduplicate and sort declared licenses to avoid ordering-only differences.
- Handle license additions and removals, including manifests without dependencies.
- Document declared-license comparison and add focused text, JSON and textconv regression tests.

## Verification

- `go build ./...`
- `go test -race ./... -count=1`
- `go mod tidy -diff`
- `go tool golangci-lint run ./...`
- `git diff --check`