### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -324,7 +324,7 @@ Use `git pkgs licenses --offline` after a cache has been populated when the chec
 Use git-pkgs in a Dockerfile:
 
 ```dockerfile
-FROM golang:1.25 as builder
+FROM golang:1.26 as builder
 RUN curl -sL https://github.com/git-pkgs/git-pkgs/releases/latest/download/git-pkgs-linux-amd64 -o /usr/local/bin/git-pkgs \
     && chmod +x /usr/local/bin/git-pkgs
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-pkgs/git-pkgs
 
-go 1.25.12
+go 1.26.5
 
 require (
 	github.com/git-pkgs/changelog v0.1.3


### PR DESCRIPTION
Updates the project to Go `1.26.5` and the Docker example to Go `1.26`.