### PR TITLE
Record parser-reported manifest kind in on-demand snapshots

### DIFF
--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -422,6 +422,7 @@ func TestGetVulnsAtCommitAppliesEcosystemConfig(t *testing.T) {
 	snapshots := []database.SnapshotInfo{
 		{
 			ManifestPath:   "package-lock.json",
+			Kind:           "lockfile",
 			Name:           "foo",
 			Ecosystem:      "npm",
 			PURL:           "pkg:npm/foo@1.0.0",
@@ -431,6 +432,7 @@ func TestGetVulnsAtCommitAppliesEcosystemConfig(t *testing.T) {
 		},
 		{
 			ManifestPath:   "Gemfile.lock",
+			Kind:           "lockfile",
 			Name:           "bar",
 			Ecosystem:      "rubygems",
 			PURL:           "pkg:gem/bar@1.0.0",

--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -41,6 +41,7 @@ type ChangeInfo struct {
 
 type SnapshotInfo struct {
 	ManifestPath   string
+	Kind           string
 	Name           string
 	Ecosystem      string
 	PURL           string

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -3007,13 +3007,9 @@ func (db *DB) StoreSnapshot(branchID int64, commit CommitInfo, snapshots []Snaps
 		if !ok {
 			err = tx.QueryRow("SELECT id FROM manifests WHERE path = ?", s.ManifestPath).Scan(&manifestID)
 			if err == sql.ErrNoRows {
-				kind := "manifest"
-				if s.Integrity != "" {
-					kind = "lockfile"
-				}
 				result, err := tx.Exec(
 					"INSERT INTO manifests (path, ecosystem, kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
-					s.ManifestPath, s.Ecosystem, kind, now, now,
+					s.ManifestPath, s.Ecosystem, s.Kind, now, now,
 				)
 				if err != nil {
 					return fmt.Errorf("inserting manifest: %w", err)

--- a/internal/git/query.go
+++ b/internal/git/query.go
@@ -130,6 +130,7 @@ func (r *Repository) IndexCommitSnapshot(db *database.DB, branchID int64, sha st
 	for _, c := range changes {
 		snapshots = append(snapshots, database.SnapshotInfo{
 			ManifestPath:   c.ManifestPath,
+			Kind:           c.Kind,
 			Name:           c.Name,
 			Ecosystem:      c.Ecosystem,
 			PURL:           c.PURL,

--- a/internal/git/query_test.go
+++ b/internal/git/query_test.go
@@ -1,0 +1,91 @@
+package git_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/git-pkgs/internal/git"
+)
+
+const gemfileLockFixture = `GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (13.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+
+BUNDLED WITH
+   2.5.0
+`
+
+const gemfileFixture = `source "https://rubygems.org"
+
+gem "rake"
+`
+
+func TestIndexCommitSnapshotManifestKind(t *testing.T) {
+	// IndexCommitSnapshot is the on-demand indexing path used by
+	// `list --commit` when no snapshot exists for the requested commit.
+	// It must record the manifest kind returned by the parser, not guess
+	// from whether entries carry integrity hashes: Gemfile.lock has no
+	// per-entry hashes without a CHECKSUMS section but is still a lockfile.
+	repoDir := createTestRepo(t)
+	addFile(t, repoDir, "Gemfile", gemfileFixture)
+	addFile(t, repoDir, "Gemfile.lock", gemfileLockFixture)
+	sha := commit(t, repoDir, "add gems")
+
+	repo, err := git.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("database.Create: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	branch, err := db.GetOrCreateBranch("main")
+	if err != nil {
+		t.Fatalf("GetOrCreateBranch: %v", err)
+	}
+
+	if err := repo.IndexCommitSnapshot(db, branch.ID, sha); err != nil {
+		t.Fatalf("IndexCommitSnapshot: %v", err)
+	}
+
+	want := map[string]string{
+		"Gemfile":      "manifest",
+		"Gemfile.lock": "lockfile",
+	}
+
+	rows, err := db.Query("SELECT path, kind FROM manifests")
+	if err != nil {
+		t.Fatalf("query manifests: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	got := map[string]string{}
+	for rows.Next() {
+		var path, kind string
+		if err := rows.Scan(&path, &kind); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[path] = kind
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	for path, wantKind := range want {
+		if got[path] != wantKind {
+			t.Errorf("manifests.kind for %s = %q, want %q", path, got[path], wantKind)
+		}
+	}
+}


### PR DESCRIPTION
`list --commit` on a commit with no stored snapshot calls `IndexCommitSnapshot`, which converts each `analyzer.Change` to a `database.SnapshotInfo` and hands the batch to `StoreSnapshot`. `SnapshotInfo` had no `Kind` field, so the analyzer's kind was dropped, and `StoreSnapshot` guessed at `manifests.kind`:

```go
kind := "manifest"
if s.Integrity != "" {
    kind = "lockfile"
}
```

That is wrong for any lockfile format without per-entry hashes (`Gemfile.lock` without `CHECKSUMS`, `Cargo.lock` v1/v2, `mix.lock`, older `yarn.lock`) and wrong the other way for a manifest that carries an integrity value. The full-index path via `BatchWriter.ensureManifests` already writes the parser's kind, so the two paths disagreed and whichever inserted the `manifests` row first won. `diff --kind lockfile` (#301) and the vuln query both filter on this column.

Add `Kind` to `SnapshotInfo`, populate it in `IndexCommitSnapshot`, and write it directly in `StoreSnapshot`. `TestGetVulnsAtCommitAppliesEcosystemConfig` now sets `Kind` explicitly since it was relying on the removed heuristic.

Existing databases where `list --commit` created a `manifests` row before `init` will keep the wrong `kind` until reindexed; both write paths skip when the row already exists.