### PR TITLE
Refactor where command

### DIFF
--- a/cmd/where.go
+++ b/cmd/where.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/git-pkgs/git-pkgs/internal/config"
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/gitignore"
 	"github.com/git-pkgs/manifests"
@@ -41,131 +42,182 @@ type WhereMatch struct {
 	Ecosystem        string   `json:"ecosystem"`
 }
 
-func runWhere(cmd *cobra.Command, args []string) error {
-	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+type whereOptions struct {
+	ecosystem         string
+	packageName       string
+	contextLines      int
+	format            string
+	includeSubmodules bool
+}
 
-	ecosystem, packageName, _, err := ParsePackageArg(args[0], ecosystemFlag)
+func runWhere(cmd *cobra.Command, args []string) error {
+	opts, err := whereOptionsFromCommand(cmd, args[0])
 	if err != nil {
 		return err
 	}
-	context, _ := cmd.Flags().GetInt("context")
-	format, err := getFormatFlag(cmd, formatText, formatJSON)
-	if err != nil {
-		return err
-	}
-	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
 
 	repo, err := git.OpenRepository(".")
 	if err != nil {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
+	matches, err := findWhereMatches(repo, opts)
+	if err != nil {
+		return err
+	}
+	return outputWhereMatches(cmd, matches, opts)
+}
+
+func whereOptionsFromCommand(cmd *cobra.Command, packageArg string) (whereOptions, error) {
+	ecosystemFlag, _ := cmd.Flags().GetString("ecosystem")
+
+	ecosystem, packageName, _, err := ParsePackageArg(packageArg, ecosystemFlag)
+	if err != nil {
+		return whereOptions{}, err
+	}
+	contextLines, _ := cmd.Flags().GetInt("context")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return whereOptions{}, err
+	}
+	includeSubmodules, _ := cmd.Flags().GetBool("include-submodules")
+	return whereOptions{
+		ecosystem:         ecosystem,
+		packageName:       packageName,
+		contextLines:      contextLines,
+		format:            format,
+		includeSubmodules: includeSubmodules,
+	}, nil
+}
+
+func findWhereMatches(repo *git.Repository, opts whereOptions) ([]WhereMatch, error) {
 	workDir := repo.WorkDir()
 	ecosystemFilter, err := repo.EcosystemFilter()
 	if err != nil {
-		return fmt.Errorf("loading ecosystem config: %w", err)
-	}
-
-	matcher := gitignore.New(workDir)
-
-	// Load submodule paths only if we need to skip them
-	var submoduleMap map[string]bool
-	if !includeSubmodules {
-		submodulePaths, err := repo.GetSubmodulePaths()
-		if err != nil {
-			// Continue without submodule filtering if loading fails
-			submodulePaths = nil
-		}
-		submoduleMap = make(map[string]bool, len(submodulePaths))
-		for _, p := range submodulePaths {
-			submoduleMap[p] = true
-		}
+		return nil, fmt.Errorf("loading ecosystem config: %w", err)
 	}
 
 	// Scope all file reads to the repo directory so that symlinks
 	// pointing outside the repository are rejected by the kernel.
 	osRoot, err := os.OpenRoot(workDir)
 	if err != nil {
-		return fmt.Errorf("opening root %q: %w", workDir, err)
+		return nil, fmt.Errorf("opening root %q: %w", workDir, err)
 	}
 	defer func() { _ = osRoot.Close() }()
 
-	var matches []WhereMatch
+	search := whereSearch{
+		workDir:         workDir,
+		root:            osRoot,
+		matcher:         gitignore.New(workDir),
+		submodules:      whereSubmoduleMap(repo, opts.includeSubmodules),
+		ecosystemFilter: ecosystemFilter,
+		ecosystem:       opts.ecosystem,
+		packageName:     opts.packageName,
+		contextLines:    opts.contextLines,
+	}
+	if err := filepath.WalkDir(workDir, search.visit); err != nil {
+		return nil, fmt.Errorf("searching files: %w", err)
+	}
+	return search.matches, nil
+}
 
-	// Walk the working directory looking for manifest files
-	err = filepath.Walk(workDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // Skip files we can't read
-		}
-
-		// Get relative path for manifest identification
-		osRel, _ := filepath.Rel(workDir, path)
-		// Normalize to forward slashes for cross-platform consistency
-		relPath := filepath.ToSlash(osRel)
-
-		if info.IsDir() {
-			// Always skip .git
-			if info.Name() == ".git" {
-				return filepath.SkipDir
-			}
-			// Skip directories that match gitignore patterns
-			if relPath != "." && matcher.Match(relPath+"/") {
-				return filepath.SkipDir
-			}
-			// Skip git submodule directories
-			if submoduleMap[relPath] {
-				return filepath.SkipDir
-			}
-			// Pick up nested .gitignore files
-			if relPath != "." {
-				nestedIgnore := filepath.Join(path, ".gitignore")
-				if _, err := os.Stat(nestedIgnore); err == nil {
-					matcher.AddFromFile(nestedIgnore, relPath)
-				}
-			}
-			return nil
-		}
-
-		// Skip files that match gitignore patterns
-		if matcher.Match(relPath) {
-			return nil
-		}
-
-		// Check if this is a manifest file
-		eco, _, ok := manifests.Identify(relPath)
-		if !ok {
-			return nil
-		}
-
-		// Filter by ecosystem if specified
-		if ecosystem != "" && !strings.EqualFold(eco, ecosystem) {
-			return nil
-		}
-		if !ecosystemFilter.Allows(eco) {
-			return nil
-		}
-		fileMatches, err := searchFileForPackage(osRoot, osRel, relPath, packageName, eco, context)
-		if err != nil {
-			return nil // Skip files we can't read
-		}
-
-		matches = append(matches, fileMatches...)
+func whereSubmoduleMap(repo *git.Repository, includeSubmodules bool) map[string]bool {
+	if includeSubmodules {
 		return nil
-	})
+	}
+	paths, err := repo.GetSubmodulePaths()
 	if err != nil {
-		return fmt.Errorf("searching files: %w", err)
+		return nil
 	}
+	result := make(map[string]bool, len(paths))
+	for _, path := range paths {
+		result[path] = true
+	}
+	return result
+}
 
-	switch format {
-	case formatJSON:
-		return outputWhereJSON(cmd, matches)
-	default:
-		if len(matches) == 0 {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Package %q not found in manifest files.\n", packageName)
-			return nil
-		}
-		return outputWhereText(cmd, matches, context > 0)
+type whereSearch struct {
+	workDir         string
+	root            *os.Root
+	matcher         *gitignore.Matcher
+	submodules      map[string]bool
+	ecosystemFilter config.EcosystemFilter
+	ecosystem       string
+	packageName     string
+	contextLines    int
+	matches         []WhereMatch
+}
+
+func (search *whereSearch) visit(path string, entry os.DirEntry, walkErr error) error {
+	if walkErr != nil {
+		return nil
 	}
+	osRel, _ := filepath.Rel(search.workDir, path)
+	relPath := filepath.ToSlash(osRel)
+	if entry.IsDir() {
+		return search.visitDirectory(path, entry, relPath)
+	}
+	search.visitFile(osRel, relPath)
+	return nil
+}
+
+func (search *whereSearch) visitDirectory(path string, entry os.DirEntry, relPath string) error {
+	if entry.Name() == ".git" {
+		return filepath.SkipDir
+	}
+	if relPath != "." && search.matcher.Match(relPath+"/") {
+		return filepath.SkipDir
+	}
+	if search.submodules[relPath] {
+		return filepath.SkipDir
+	}
+	if relPath == "." {
+		return nil
+	}
+	nestedIgnore := filepath.Join(path, ".gitignore")
+	if _, err := os.Stat(nestedIgnore); err == nil {
+		search.matcher.AddFromFile(nestedIgnore, relPath)
+	}
+	return nil
+}
+
+func (search *whereSearch) visitFile(osRel, relPath string) {
+	if search.matcher.Match(relPath) {
+		return
+	}
+	ecosystem, _, ok := manifests.Identify(relPath)
+	if !ok {
+		return
+	}
+	if search.ecosystem != "" && !strings.EqualFold(ecosystem, search.ecosystem) {
+		return
+	}
+	if !search.ecosystemFilter.Allows(ecosystem) {
+		return
+	}
+	matches, err := searchFileForPackage(
+		search.root,
+		osRel,
+		relPath,
+		search.packageName,
+		ecosystem,
+		search.contextLines,
+	)
+	if err == nil {
+		search.matches = append(search.matches, matches...)
+	}
+}
+
+func outputWhereMatches(cmd *cobra.Command, matches []WhereMatch, opts whereOptions) error {
+	if opts.format == formatJSON {
+		return outputWhereJSON(cmd, matches)
+	}
+	if len(matches) == 0 {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Package %q not found in manifest files.\n", opts.packageName)
+		return nil
+	}
+	outputWhereText(cmd, matches, opts.contextLines > 0)
+	return nil
 }
 
 func searchFileForPackage(root *os.Root, osRel, relPath, packageName, ecosystem string, contextLines int) ([]WhereMatch, error) {
@@ -235,7 +287,7 @@ func outputWhereJSON(cmd *cobra.Command, matches []WhereMatch) error {
 	return enc.Encode(nonNilSlice(matches))
 }
 
-func outputWhereText(cmd *cobra.Command, matches []WhereMatch, showContext bool) error {
+func outputWhereText(cmd *cobra.Command, matches []WhereMatch, showContext bool) {
 	for _, m := range matches {
 		if showContext && len(m.Context) > 0 {
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:\n", m.FilePath)
@@ -256,6 +308,4 @@ func outputWhereText(cmd *cobra.Command, matches []WhereMatch, showContext bool)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "%s:%d:%s\n", m.FilePath, m.LineNumber, Sanitize(m.Content))
 		}
 	}
-
-	return nil
 }

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -155,13 +155,13 @@ func (search *whereSearch) visit(path string, entry os.DirEntry, walkErr error) 
 	osRel, _ := filepath.Rel(search.workDir, path)
 	relPath := filepath.ToSlash(osRel)
 	if entry.IsDir() {
-		return search.visitDirectory(path, entry, relPath)
+		return search.visitDirectory(osRel, entry, relPath)
 	}
 	search.visitFile(osRel, relPath)
 	return nil
 }
 
-func (search *whereSearch) visitDirectory(path string, entry os.DirEntry, relPath string) error {
+func (search *whereSearch) visitDirectory(osRel string, entry os.DirEntry, relPath string) error {
 	if entry.Name() == ".git" {
 		return filepath.SkipDir
 	}
@@ -174,9 +174,14 @@ func (search *whereSearch) visitDirectory(path string, entry os.DirEntry, relPat
 	if relPath == "." {
 		return nil
 	}
-	nestedIgnore := filepath.Join(path, ".gitignore")
-	if _, err := os.Stat(nestedIgnore); err == nil {
-		search.matcher.AddFromFile(nestedIgnore, relPath)
+	nestedIgnore := filepath.Join(osRel, ".gitignore")
+	info, err := search.root.Lstat(nestedIgnore)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil
+	}
+	patterns, err := search.root.ReadFile(nestedIgnore)
+	if err == nil {
+		search.matcher.AddPatterns(patterns, relPath)
 	}
 	return nil
 }

--- a/cmd/where_benchmark_test.go
+++ b/cmd/where_benchmark_test.go
@@ -1,0 +1,81 @@
+package cmd_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/cmd"
+)
+
+func BenchmarkWhereCommand(b *testing.B) {
+	repoDir := benchmarkWhereRepository(b)
+	previousDir, err := os.Getwd()
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := os.Chdir(repoDir); err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = os.Chdir(previousDir) })
+
+	runBenchmarkWhereCommand(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		runBenchmarkWhereCommand(b)
+	}
+}
+
+func benchmarkWhereRepository(b *testing.B) string {
+	b.Helper()
+	dir := b.TempDir()
+	benchmarkWhereGit(b, dir, "init", "--initial-branch=main")
+	benchmarkWhereWriteFile(b, dir, ".gitignore", "ignored/\n")
+
+	const manifest = `{"dependencies":{"lodash":"4.17.21","express":"4.21.2"}}`
+	for i := range 40 {
+		packageDir := filepath.Join("packages", fmt.Sprintf("package-%02d", i))
+		benchmarkWhereWriteFile(b, dir, filepath.Join(packageDir, "package.json"), manifest)
+		benchmarkWhereWriteFile(b, dir, filepath.Join(packageDir, "README.md"), "package documentation")
+	}
+	for i := range 20 {
+		ignoredDir := filepath.Join("ignored", fmt.Sprintf("package-%02d", i))
+		benchmarkWhereWriteFile(b, dir, filepath.Join(ignoredDir, "package.json"), manifest)
+	}
+	return dir
+}
+
+func benchmarkWhereWriteFile(b *testing.B, dir, name, content string) {
+	b.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		b.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func benchmarkWhereGit(b *testing.B, dir string, args ...string) {
+	b.Helper()
+	commandArgs := append([]string{"-C", dir}, args...)
+	command := exec.Command("git", commandArgs...)
+	if output, err := command.CombinedOutput(); err != nil {
+		b.Fatalf("git %v: %v: %s", args, err, output)
+	}
+}
+
+func runBenchmarkWhereCommand(b *testing.B) {
+	b.Helper()
+	root := cmd.NewRootCmd()
+	root.SetArgs([]string{"where", "lodash", "--format", "json"})
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	if err := root.Execute(); err != nil {
+		b.Fatalf("git pkgs where: %v", err)
+	}
+}

--- a/cmd/where_command_test.go
+++ b/cmd/where_command_test.go
@@ -1,0 +1,44 @@
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWhereCommandHonorsNestedGitignore(t *testing.T) {
+	repoDir := createTestRepo(t)
+	writeFile(t, repoDir, "packages/.gitignore", "ignored/\n")
+	writeFile(t, repoDir, "packages/included/package.json", `{"dependencies":{"lodash":"4.17.21"}}`)
+	writeFile(t, repoDir, "packages/ignored/package.json", `{"dependencies":{"lodash":"4.17.21"}}`)
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	stdout, _, err := runCmd(t, "where", "lodash")
+	if err != nil {
+		t.Fatalf("where failed: %v", err)
+	}
+	if !strings.Contains(stdout, "packages/included/package.json") {
+		t.Fatalf("where output missing included manifest: %s", stdout)
+	}
+	if strings.Contains(stdout, "packages/ignored/package.json") {
+		t.Fatalf("where output contains ignored manifest: %s", stdout)
+	}
+}
+
+func TestWhereCommandHonorsEcosystemFilter(t *testing.T) {
+	repoDir := createTestRepo(t)
+	writeFile(t, repoDir, "package.json", `{"dependencies":{"lodash":"4.17.21"}}`)
+	setGitConfig(t, repoDir, "pkgs.ignoredEcosystems", "npm")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	stdout, _, err := runCmd(t, "where", "lodash")
+	if err != nil {
+		t.Fatalf("where failed: %v", err)
+	}
+	if !strings.Contains(stdout, `Package "lodash" not found in manifest files.`) {
+		t.Fatalf("unexpected where output: %s", stdout)
+	}
+}

--- a/cmd/where_test.go
+++ b/cmd/where_test.go
@@ -192,6 +192,39 @@ func TestSearchFileForPackageRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestFindWhereMatchesRejectsSymlinkedNestedGitignore(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlinks require elevation on windows")
+	}
+
+	dir := t.TempDir()
+	repo := openWhereTestRepository(t, dir)
+	packagesDir := filepath.Join(dir, "packages")
+	if err := os.Mkdir(packagesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := []byte(`{"dependencies":{"lodash":"4.17.21"}}`)
+	if err := os.WriteFile(filepath.Join(packagesDir, "package.json"), manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outsideIgnore := filepath.Join(t.TempDir(), ".gitignore")
+	if err := os.WriteFile(outsideIgnore, []byte("package.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideIgnore, filepath.Join(packagesDir, ".gitignore")); err != nil {
+		t.Fatal(err)
+	}
+
+	matches, err := findWhereMatches(repo, whereOptions{packageName: "lodash"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 1 || matches[0].FilePath != "packages/package.json" {
+		t.Fatalf("matches = %v, want packages/package.json", matches)
+	}
+}
+
 func TestWhereSubmoduleMap(t *testing.T) {
 	dir := t.TempDir()
 	repo := openWhereTestRepository(t, dir)

--- a/cmd/where_test.go
+++ b/cmd/where_test.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	gitrepo "github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/spf13/cobra"
 )
 
@@ -132,9 +134,7 @@ func TestOutputWhereTextContextNearEOFUsesOriginalLineNumbers(t *testing.T) {
 	cmd := &cobra.Command{}
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	if err := outputWhereText(cmd, matches, true); err != nil {
-		t.Fatal(err)
-	}
+	outputWhereText(cmd, matches, true)
 
 	got := out.String()
 	if !strings.Contains(got, `     5:     "other": "1.0.0",`) {
@@ -190,4 +190,54 @@ func TestSearchFileForPackageRejectsSymlinkEscape(t *testing.T) {
 	if len(matches) != 1 {
 		t.Fatalf("expected 1 match for lodash, got %d", len(matches))
 	}
+}
+
+func TestWhereSubmoduleMap(t *testing.T) {
+	dir := t.TempDir()
+	repo := openWhereTestRepository(t, dir)
+	modules := `[submodule "example"]
+	path = vendor/example
+	url = https://example.com/example.git
+`
+	if err := os.WriteFile(filepath.Join(dir, ".gitmodules"), []byte(modules), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := whereSubmoduleMap(repo, false)
+	if !got["vendor/example"] {
+		t.Fatalf("submodule map = %v, want vendor/example", got)
+	}
+	if got := whereSubmoduleMap(repo, true); got != nil {
+		t.Fatalf("included submodule map = %v, want nil", got)
+	}
+}
+
+func TestFindWhereMatchesMissingRoot(t *testing.T) {
+	dir := t.TempDir()
+	repo := openWhereTestRepository(t, dir)
+	if _, err := repo.EcosystemFilter(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := findWhereMatches(repo, whereOptions{packageName: "lodash"})
+	if err == nil || !strings.Contains(err.Error(), "opening root") {
+		t.Fatalf("findWhereMatches error = %v, want opening root error", err)
+	}
+}
+
+func openWhereTestRepository(t *testing.T, dir string) *gitrepo.Repository {
+	t.Helper()
+	command := exec.Command("git", "init", "--initial-branch=main")
+	command.Dir = dir
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, output)
+	}
+	repo, err := gitrepo.OpenRepository(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo
 }


### PR DESCRIPTION
Breaks the `where` command into focused helpers for option parsing, traversal, filtering, and output.

Uses `filepath.WalkDir` to avoid per-file metadata lookups, removes the unnecessary error return from text output, and adds coverage for ignored paths, ecosystem filters, submodules, and missing roots. Adds a command benchmark for repositories with multiple manifests.
