### PR TITLE
Store manifest-declared license history

### DIFF
--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -44,6 +44,18 @@ func runReindex(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = db.Close() }()
 
+	schemaVersion, err := db.SchemaVersion()
+	if err != nil {
+		return fmt.Errorf("reading database schema version: %w", err)
+	}
+	if schemaVersion != database.SchemaVersion {
+		return fmt.Errorf(
+			"database schema version %d is outdated (current version is %d); run 'git pkgs upgrade'",
+			schemaVersion,
+			database.SchemaVersion,
+		)
+	}
+
 	if branch != "" {
 		return reindexBranch(cmd, repo, db, branch, quiet)
 	}

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -44,18 +44,6 @@ func runReindex(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = db.Close() }()
 
-	schemaVersion, err := db.SchemaVersion()
-	if err != nil {
-		return fmt.Errorf("reading database schema version: %w", err)
-	}
-	if schemaVersion != database.SchemaVersion {
-		return fmt.Errorf(
-			"database schema version %d is outdated (current version is %d); run 'git pkgs upgrade'",
-			schemaVersion,
-			database.SchemaVersion,
-		)
-	}
-
 	if branch != "" {
 		return reindexBranch(cmd, repo, db, branch, quiet)
 	}

--- a/cmd/reindex_test.go
+++ b/cmd/reindex_test.go
@@ -2,7 +2,6 @@ package cmd_test
 
 import (
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -211,37 +210,14 @@ func TestReindex(t *testing.T) {
 		cleanup := chdir(t, repoDir)
 		defer cleanup()
 
-		_, _, err := runCmd(t, "init", "--no-hooks")
-		if err != nil {
+		if _, _, err := runCmd(t, "init", "--no-hooks"); err != nil {
 			t.Fatalf("init failed: %v", err)
 		}
-
-		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
-		if err != nil {
-			t.Fatalf("opening database: %v", err)
-		}
-		if _, err := db.Exec(`
-			DROP TABLE manifest_licenses;
-			UPDATE schema_info SET version = 15;
-		`); err != nil {
-			_ = db.Close()
-			t.Fatalf("downgrading test database: %v", err)
-		}
-		if err := db.Close(); err != nil {
-			t.Fatalf("closing database: %v", err)
-		}
+		setTestDatabaseSchemaVersion(t, repoDir, database.SchemaVersion-1, true)
 
 		addFileAndCommit(t, repoDir, "package.json", `{"name":"example","license":"Apache-2.0"}`, "Change license")
 
-		_, _, err = runCmd(t, "reindex")
-		if err == nil {
-			t.Fatal("expected reindex to reject an older schema")
-		}
-		if !strings.Contains(err.Error(), "schema version 15") {
-			t.Errorf("expected schema version in error, got: %v", err)
-		}
-		if !strings.Contains(err.Error(), "git pkgs upgrade") {
-			t.Errorf("expected upgrade instruction, got: %v", err)
-		}
+		_, _, err := runCmd(t, "reindex")
+		assertOlderSchemaError(t, err)
 	})
 }

--- a/cmd/reindex_test.go
+++ b/cmd/reindex_test.go
@@ -2,8 +2,11 @@ package cmd_test
 
 import (
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
 )
 
 func TestReindex(t *testing.T) {
@@ -198,6 +201,47 @@ func TestReindex(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "init") {
 			t.Errorf("expected error to mention init, got: %v", err)
+		}
+	})
+
+	t.Run("requires upgrade for an older schema", func(t *testing.T) {
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package.json", `{"name":"example","license":"MIT"}`, "Initial commit")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		_, _, err := runCmd(t, "init", "--no-hooks")
+		if err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+		if err != nil {
+			t.Fatalf("opening database: %v", err)
+		}
+		if _, err := db.Exec(`
+			DROP TABLE manifest_licenses;
+			UPDATE schema_info SET version = 15;
+		`); err != nil {
+			_ = db.Close()
+			t.Fatalf("downgrading test database: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Fatalf("closing database: %v", err)
+		}
+
+		addFileAndCommit(t, repoDir, "package.json", `{"name":"example","license":"Apache-2.0"}`, "Change license")
+
+		_, _, err = runCmd(t, "reindex")
+		if err == nil {
+			t.Fatal("expected reindex to reject an older schema")
+		}
+		if !strings.Contains(err.Error(), "schema version 15") {
+			t.Errorf("expected schema version in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "git pkgs upgrade") {
+			t.Errorf("expected upgrade instruction, got: %v", err)
 		}
 	})
 }

--- a/cmd/schema_compatibility_test.go
+++ b/cmd/schema_compatibility_test.go
@@ -1,0 +1,149 @@
+package cmd_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestBranchAddRejectsOlderSchemaBeforeIndexing(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", `{"name":"example","license":"MIT"}`, "Initial commit")
+
+	gitCmd := exec.Command("git", "branch", "feature")
+	gitCmd.Dir = repoDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("creating feature branch: %v", err)
+	}
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	setTestDatabaseSchemaVersion(t, repoDir, database.SchemaVersion-1, true)
+
+	_, _, err := runCmd(t, "branch", "add", "feature")
+	assertOlderSchemaError(t, err)
+}
+
+func TestBisectReindexRejectsOlderSchemaBeforeIndexing(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", `{
+  "name": "example",
+  "dependencies": {"foo": "1.0.0"}
+}`, "Add foo")
+	addFileAndCommit(t, repoDir, "package.json", `{
+  "name": "example",
+  "dependencies": {"foo": "2.0.0"}
+}`, "Update foo")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	setTestDatabaseSchemaVersion(t, repoDir, database.SchemaVersion-1, true)
+	addFileAndCommit(t, repoDir, "package.json", `{
+  "name": "example",
+  "dependencies": {"foo": "3.0.0"}
+}`, "Update foo again")
+
+	_, _, err := runCmd(t, "bisect", "start", "HEAD", "HEAD~2")
+	assertOlderSchemaError(t, err)
+}
+
+func TestNewerSchemaRequiresCompatibleBinary(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", `{"name":"example","license":"MIT"}`, "Initial commit")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	newerVersion := database.SchemaVersion + 1
+	setTestDatabaseSchemaVersion(t, repoDir, newerVersion, false)
+	addFileAndCommit(t, repoDir, "package.json", `{"name":"example","license":"Apache-2.0"}`, "Change license")
+
+	_, _, err := runCmd(t, "reindex")
+	assertNewerSchemaError(t, err, newerVersion)
+
+	_, _, err = runCmd(t, "upgrade")
+	assertNewerSchemaError(t, err, newerVersion)
+
+	db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("opening database after rejected upgrade: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	version, err := db.SchemaVersion()
+	if err != nil {
+		t.Fatalf("reading schema version after rejected upgrade: %v", err)
+	}
+	if version != newerVersion {
+		t.Fatalf("schema version after rejected upgrade = %d, want %d", version, newerVersion)
+	}
+}
+
+func setTestDatabaseSchemaVersion(t *testing.T, repoDir string, version int, dropManifestLicenses bool) {
+	t.Helper()
+	db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("opening database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if dropManifestLicenses {
+		if _, err := db.Exec("DROP TABLE manifest_licenses"); err != nil {
+			t.Fatalf("dropping manifest_licenses: %v", err)
+		}
+	}
+	if _, err := db.Exec("UPDATE schema_info SET version = ?", version); err != nil {
+		t.Fatalf("setting schema version: %v", err)
+	}
+}
+
+func assertOlderSchemaError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected command to reject an older schema")
+	}
+	for _, want := range []string{
+		"schema version " + strconv.Itoa(database.SchemaVersion-1),
+		"git pkgs upgrade",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "no such table") {
+		t.Errorf("command reached incompatible schema write: %v", err)
+	}
+}
+
+func assertNewerSchemaError(t *testing.T, err error, version int) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected command to reject a newer schema")
+	}
+	for _, want := range []string{
+		"schema version " + strconv.Itoa(version),
+		"newer than this git-pkgs binary supports",
+		"compatible git-pkgs binary",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "run 'git pkgs upgrade'") {
+		t.Errorf("newer schema error incorrectly recommends upgrade: %v", err)
+	}
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -52,6 +52,10 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
+	if currentVersion > database.SchemaVersion {
+		_ = db.Close()
+		return database.CheckSchemaVersion(currentVersion)
+	}
 
 	if !quiet {
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgrading database from schema v%d to v%d...\n", currentVersion, database.SchemaVersion)

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -25,19 +25,21 @@ The CLI uses [cobra](https://github.com/spf13/cobra). Each command is registered
 
 `internal/database` manages the SQLite connection using [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite) (pure Go, no CGO). The database path defaults to `.git/pkgs.sqlite3` but can be overridden with `GIT_PKGS_DB`.
 
-The schema has eleven tables. Six handle dependency tracking:
+The dependency history tables are:
 
 - `commits` holds commit metadata plus a flag indicating whether it changed dependencies
 - `branches` tracks which branches have been analyzed and their last processed SHA
 - `branch_commits` is a join table preserving commit order within each branch
 - `manifests` stores file paths with their ecosystem (npm, rubygems, etc.) and kind (manifest vs lockfile)
+- `manifest_licenses` stores commit-scoped declared license values and license-file paths for package manifests
 - `dependency_changes` records every add, modify, or remove event
 - `dependency_snapshots` stores full dependency state at intervals, including lockfile integrity hashes
 
-Four support vulnerability scanning and package enrichment:
+The following tables support vulnerability scanning and package enrichment:
 
 - `packages` caches package metadata and vulnerability sync status
 - `versions` stores per-version metadata (license, published date, deprecation status) for time-travel queries and external metadata commands
+- `version_lists` records when a complete package version history was fetched
 - `vulnerabilities` caches CVE/GHSA data fetched from OSV
 - `vulnerability_packages` maps which packages are affected by each vulnerability
 
@@ -82,6 +84,11 @@ removed = beforeDeps - afterDeps
 modified = intersection where requirement changed
 ```
 
+For package manifests, the analyzer also records `ParseResult.Licenses` and
+`ParseResult.LicenseFile` whenever the manifest is added, modified, or removed.
+These events are independent of dependency changes, so a license-only edit is
+preserved without marking the commit as a dependency change.
+
 Merge commits are skipped since they don't introduce new changes.
 
 ## The Init Process
@@ -116,6 +123,8 @@ Several commands need the full dependency set at a specific commit. The algorith
 4. Apply each change: added/modified updates the set, removed deletes
 
 This is handled by `GetDependenciesAtRef` and related methods in `internal/database/queries.go`.
+Manifest licenses use the same branch positions to select the latest license
+event for each manifest path at or before the requested commit.
 
 ## Git Hooks
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -72,6 +72,26 @@ Stores manifest file metadata.
 
 Indexes: `path`
 
+### manifest_licenses
+
+Stores the declared license state of package manifests as commit-scoped events.
+Keeping these values separate from `manifests` preserves historical license
+changes for a path that appears across many commits. A removal event prevents a
+deleted manifest from appearing in later point-in-time queries.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | integer | Primary key |
+| commit_id | integer | Foreign key to commits |
+| manifest_id | integer | Foreign key to manifests |
+| licenses | text | JSON-encoded declared license values |
+| license_file | text | Manifest-relative declared license file path |
+| removed | integer | 1 when the manifest was removed by this commit |
+| created_at | datetime | |
+| updated_at | datetime | |
+
+Indexes: `(commit_id, manifest_id)` (unique), `manifest_id`
+
 ### dependency_changes
 
 Records each dependency addition, modification, or removal.

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -57,9 +57,21 @@ type SnapshotKey struct {
 
 type Snapshot map[SnapshotKey]SnapshotEntry
 
+// ManifestLicense records the package license values declared by a manifest.
+// Removed marks the manifest as absent from this commit onward.
+type ManifestLicense struct {
+	ManifestPath string
+	Ecosystem    string
+	Kind         string
+	Licenses     []string
+	LicenseFile  string
+	Removed      bool
+}
+
 type Result struct {
-	Changes  []Change
-	Snapshot Snapshot
+	Changes          []Change
+	Snapshot         Snapshot
+	ManifestLicenses []ManifestLicense
 }
 
 type cachedDiff struct {
@@ -312,6 +324,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 		if !a.allowsEcosystem(deps.Ecosystem) {
 			continue
 		}
+		result.addManifestLicense(path, deps, false)
 
 		// Merge integrity hashes from supplement files in same directory
 		supHashes := a.parseSupplementsInDir(tree, filepath.Dir(path))
@@ -370,6 +383,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 			}
 			continue
 		}
+		result.addManifestLicense(path, afterDeps, false)
 
 		// Merge integrity hashes from supplement files in same directory
 		supHashes := a.parseSupplementsInDir(tree, filepath.Dir(path))
@@ -553,6 +567,7 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 		if !a.allowsEcosystem(deps.Ecosystem) {
 			continue
 		}
+		result.addManifestLicense(path, deps, true)
 
 		for _, dep := range deps.Dependencies {
 			result.Changes = append(result.Changes, Change{
@@ -574,6 +589,24 @@ func (a *Analyzer) AnalyzeCommit(commit *object.Commit, previousSnapshot Snapsho
 	}
 
 	return result, nil
+}
+
+func (r *Result) addManifestLicense(path string, parsed *manifests.ParseResult, removed bool) {
+	if parsed == nil || parsed.Kind != manifests.Manifest {
+		return
+	}
+	licenses := append([]string(nil), parsed.Licenses...)
+	if licenses == nil {
+		licenses = []string{}
+	}
+	r.ManifestLicenses = append(r.ManifestLicenses, ManifestLicense{
+		ManifestPath: path,
+		Ecosystem:    parsed.Ecosystem,
+		Kind:         string(parsed.Kind),
+		Licenses:     licenses,
+		LicenseFile:  parsed.LicenseFile,
+		Removed:      removed,
+	})
 }
 
 func (a *Analyzer) parseManifestInTree(tree *object.Tree, path string) (*manifests.ParseResult, error) {

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -317,6 +318,105 @@ func TestAnalyzeCommitWithPackageJSON(t *testing.T) {
 			t.Errorf("expected ecosystem 'npm', got %s", ch.Ecosystem)
 		}
 	}
+}
+
+func TestAnalyzeCommitTracksManifestLicenses(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFile(t, repoDir, "package.json", `{
+  "name": "example",
+  "version": "1.0.0",
+  "licenses": [{"type": "MIT"}, {"type": "ISC"}]
+}`)
+	addFile(t, repoDir, "Cargo.toml", `[package]
+name = "example"
+version = "1.0.0"
+license-file = "LICENSE"
+`)
+	firstSHA := commit(t, repoDir, "Add licensed manifests")
+
+	repo := openRepo(t, repoDir)
+	a := analyzer.New()
+	firstCommit, err := repo.CommitObject(*getCommit(t, firstSHA))
+	if err != nil {
+		t.Fatalf("CommitObject(first): %v", err)
+	}
+	first, err := a.AnalyzeCommit(firstCommit, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeCommit(first): %v", err)
+	}
+	if len(first.Changes) != 0 {
+		t.Fatalf("dependency changes = %d, want 0", len(first.Changes))
+	}
+	packageLicense := findManifestLicense(t, first.ManifestLicenses, "package.json")
+	if !slices.Equal(packageLicense.Licenses, []string{"MIT", "ISC"}) || packageLicense.Removed {
+		t.Fatalf("package.json license = %+v", packageLicense)
+	}
+	cargoLicense := findManifestLicense(t, first.ManifestLicenses, "Cargo.toml")
+	if cargoLicense.LicenseFile != "LICENSE" || cargoLicense.Removed {
+		t.Fatalf("Cargo.toml license = %+v", cargoLicense)
+	}
+
+	addFile(t, repoDir, "package.json", `{
+  "name": "example",
+  "version": "1.0.0",
+  "license": "Apache-2.0"
+}`)
+	secondSHA := commit(t, repoDir, "Change declared license")
+	secondCommit, err := repo.CommitObject(*getCommit(t, secondSHA))
+	if err != nil {
+		t.Fatalf("CommitObject(second): %v", err)
+	}
+	second, err := a.AnalyzeCommit(secondCommit, first.Snapshot)
+	if err != nil {
+		t.Fatalf("AnalyzeCommit(second): %v", err)
+	}
+	if len(second.Changes) != 0 {
+		t.Fatalf("dependency changes = %d, want 0", len(second.Changes))
+	}
+	if len(second.ManifestLicenses) != 1 {
+		t.Fatalf("manifest licenses = %+v, want one", second.ManifestLicenses)
+	}
+	packageLicense = second.ManifestLicenses[0]
+	if !slices.Equal(packageLicense.Licenses, []string{"Apache-2.0"}) || packageLicense.Removed {
+		t.Fatalf("modified package.json license = %+v", packageLicense)
+	}
+
+	if err := os.Remove(filepath.Join(repoDir, "package.json")); err != nil {
+		t.Fatalf("removing package.json: %v", err)
+	}
+	rmCmd := exec.Command("git", "add", "-u", "package.json")
+	rmCmd.Dir = repoDir
+	if output, err := rmCmd.CombinedOutput(); err != nil {
+		t.Fatalf("staging package.json removal: %v\n%s", err, output)
+	}
+	thirdSHA := commit(t, repoDir, "Remove package manifest")
+	thirdCommit, err := repo.CommitObject(*getCommit(t, thirdSHA))
+	if err != nil {
+		t.Fatalf("CommitObject(third): %v", err)
+	}
+	third, err := a.AnalyzeCommit(thirdCommit, second.Snapshot)
+	if err != nil {
+		t.Fatalf("AnalyzeCommit(third): %v", err)
+	}
+	packageLicense = findManifestLicense(t, third.ManifestLicenses, "package.json")
+	if !packageLicense.Removed || !slices.Equal(packageLicense.Licenses, []string{"Apache-2.0"}) {
+		t.Fatalf("removed package.json license = %+v", packageLicense)
+	}
+}
+
+func findManifestLicense(
+	t *testing.T,
+	licenses []analyzer.ManifestLicense,
+	path string,
+) analyzer.ManifestLicense {
+	t.Helper()
+	for _, license := range licenses {
+		if license.ManifestPath == path {
+			return license
+		}
+	}
+	t.Fatalf("manifest license for %s not found in %+v", path, licenses)
+	return analyzer.ManifestLicense{}
 }
 
 func TestDependenciesAtCommit(t *testing.T) {

--- a/internal/database/batch_writer.go
+++ b/internal/database/batch_writer.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -25,6 +26,12 @@ type ManifestInfo struct {
 	Path      string
 	Ecosystem string
 	Kind      string
+}
+
+type ManifestLicenseInfo struct {
+	Licenses    []string
+	LicenseFile string
+	Removed     bool
 }
 
 type ChangeInfo struct {
@@ -69,6 +76,12 @@ type pendingSnapshot struct {
 	snapshot SnapshotInfo
 }
 
+type pendingManifestLicense struct {
+	sha      string
+	manifest ManifestInfo
+	license  ManifestLicenseInfo
+}
+
 type BatchWriter struct {
 	db            *DB
 	branchID      int64
@@ -78,6 +91,7 @@ type BatchWriter struct {
 	pendingCommits   []pendingCommit
 	pendingChanges   []pendingChange
 	pendingSnapshots []pendingSnapshot
+	pendingLicenses  []pendingManifestLicense
 
 	batchSize        int
 	snapshotInterval int
@@ -163,6 +177,14 @@ func (w *BatchWriter) AddSnapshot(sha string, manifest ManifestInfo, snapshot Sn
 	})
 }
 
+func (w *BatchWriter) AddManifestLicense(sha string, manifest ManifestInfo, license ManifestLicenseInfo) {
+	w.pendingLicenses = append(w.pendingLicenses, pendingManifestLicense{
+		sha:      sha,
+		manifest: manifest,
+		license:  license,
+	})
+}
+
 // AddEmptySnapshot stores a marker to indicate this commit has no dependencies.
 // This allows GetDependenciesAtRef to distinguish "no snapshot taken" from "empty snapshot".
 func (w *BatchWriter) AddEmptySnapshot(sha string) {
@@ -194,7 +216,7 @@ func (w *BatchWriter) Flush() error {
 // performs the DB transaction. The caller gets fresh empty slices immediately.
 // Call WaitForFlush before the next FlushAsync or Flush to collect the result.
 func (w *BatchWriter) FlushAsync() {
-	commits, changes, snapshots := w.takePending()
+	commits, changes, snapshots, licenses := w.takePending()
 	w.flushDone = make(chan error, 1)
 	ch := w.flushDone
 	go func() {
@@ -203,7 +225,7 @@ func (w *BatchWriter) FlushAsync() {
 				ch <- fmt.Errorf("panic during async flush: %v", r)
 			}
 		}()
-		ch <- w.flushPending(commits, changes, snapshots)
+		ch <- w.flushPending(commits, changes, snapshots, licenses)
 	}()
 }
 
@@ -219,17 +241,29 @@ func (w *BatchWriter) WaitForFlush() error {
 }
 
 // takePending returns the current pending slices and replaces them with fresh empties.
-func (w *BatchWriter) takePending() ([]pendingCommit, []pendingChange, []pendingSnapshot) {
+func (w *BatchWriter) takePending() (
+	[]pendingCommit,
+	[]pendingChange,
+	[]pendingSnapshot,
+	[]pendingManifestLicense,
+) {
 	commits := w.pendingCommits
 	changes := w.pendingChanges
 	snapshots := w.pendingSnapshots
+	licenses := w.pendingLicenses
 	w.pendingCommits = nil
 	w.pendingChanges = nil
 	w.pendingSnapshots = nil
-	return commits, changes, snapshots
+	w.pendingLicenses = nil
+	return commits, changes, snapshots, licenses
 }
 
-func (w *BatchWriter) flushPending(commits []pendingCommit, changes []pendingChange, snapshots []pendingSnapshot) error {
+func (w *BatchWriter) flushPending(
+	commits []pendingCommit,
+	changes []pendingChange,
+	snapshots []pendingSnapshot,
+	licenses []pendingManifestLicense,
+) error {
 	if len(commits) == 0 {
 		return nil
 	}
@@ -264,7 +298,7 @@ func (w *BatchWriter) flushPending(commits []pendingCommit, changes []pendingCha
 		return fmt.Errorf("inserting branch commits: %w", err)
 	}
 
-	// 5. Filter out changes and snapshots for commits that already existed,
+	// 5. Filter out commit-scoped records for commits that already existed,
 	// since their data is already stored from another branch.
 	if len(existingCommits) > 0 {
 		newChanges := changes[:0]
@@ -282,10 +316,18 @@ func (w *BatchWriter) flushPending(commits []pendingCommit, changes []pendingCha
 			}
 		}
 		snapshots = newSnapshots
+
+		newLicenses := licenses[:0]
+		for _, license := range licenses {
+			if _, exists := existingCommits[license.sha]; !exists {
+				newLicenses = append(newLicenses, license)
+			}
+		}
+		licenses = newLicenses
 	}
 
 	// 6. Ensure manifests exist and get their IDs
-	if err := w.ensureManifests(tx, now, changes, snapshots); err != nil {
+	if err := w.ensureManifests(tx, now, changes, snapshots, licenses); err != nil {
 		return fmt.Errorf("ensuring manifests: %w", err)
 	}
 
@@ -294,7 +336,12 @@ func (w *BatchWriter) flushPending(commits []pendingCommit, changes []pendingCha
 		return fmt.Errorf("inserting changes: %w", err)
 	}
 
-	// 8. Batch insert snapshots
+	// 8. Batch insert manifest license states
+	if err := w.insertManifestLicenses(tx, commitIDs, now, licenses); err != nil {
+		return fmt.Errorf("inserting manifest licenses: %w", err)
+	}
+
+	// 9. Batch insert snapshots
 	if err := w.insertSnapshots(tx, commitIDs, now, snapshots); err != nil {
 		return fmt.Errorf("inserting snapshots: %w", err)
 	}
@@ -427,7 +474,13 @@ func (w *BatchWriter) insertBranchCommits(tx *sql.Tx, commitIDs map[string]int64
 	return nil
 }
 
-func (w *BatchWriter) ensureManifests(tx *sql.Tx, now time.Time, changes []pendingChange, snapshots []pendingSnapshot) error {
+func (w *BatchWriter) ensureManifests(
+	tx *sql.Tx,
+	now time.Time,
+	changes []pendingChange,
+	snapshots []pendingSnapshot,
+	licenses []pendingManifestLicense,
+) error {
 	// Collect unique manifests from changes and snapshots
 	manifests := make(map[string]ManifestInfo)
 	for _, pc := range changes {
@@ -435,6 +488,9 @@ func (w *BatchWriter) ensureManifests(tx *sql.Tx, now time.Time, changes []pendi
 	}
 	for _, ps := range snapshots {
 		manifests[ps.manifest.Path] = ps.manifest
+	}
+	for _, license := range licenses {
+		manifests[license.manifest.Path] = license.manifest
 	}
 
 	// Filter out already cached
@@ -493,6 +549,59 @@ func (w *BatchWriter) ensureManifests(tx *sql.Tx, now time.Time, changes []pendi
 		w.manifestCache[path] = id
 	}
 	return rows.Err()
+}
+
+func (w *BatchWriter) insertManifestLicenses(
+	tx *sql.Tx,
+	commitIDs map[string]int64,
+	now time.Time,
+	pending []pendingManifestLicense,
+) error {
+	if len(pending) == 0 {
+		return nil
+	}
+
+	const columnsPerRow = 7
+	maxRowsPerBatch := MaxSQLVariables / columnsPerRow
+	for start := 0; start < len(pending); start += maxRowsPerBatch {
+		end := start + maxRowsPerBatch
+		if end > len(pending) {
+			end = len(pending)
+		}
+		batch := pending[start:end]
+
+		var sb strings.Builder
+		sb.WriteString("INSERT INTO manifest_licenses (commit_id, manifest_id, licenses, license_file, removed, created_at, updated_at) VALUES ")
+		args := make([]any, 0, len(batch)*columnsPerRow)
+		for i, pendingLicense := range batch {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString("(?,?,?,?,?,?,?)")
+
+			licenses := pendingLicense.license.Licenses
+			if licenses == nil {
+				licenses = []string{}
+			}
+			licensesJSON, err := json.Marshal(licenses)
+			if err != nil {
+				return fmt.Errorf("encoding licenses for %s: %w", pendingLicense.manifest.Path, err)
+			}
+			args = append(args,
+				commitIDs[pendingLicense.sha],
+				w.manifestCache[pendingLicense.manifest.Path],
+				string(licensesJSON),
+				pendingLicense.license.LicenseFile,
+				pendingLicense.license.Removed,
+				now,
+				now,
+			)
+		}
+		if _, err := tx.Exec(sb.String(), args...); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (w *BatchWriter) insertChanges(tx *sql.Tx, commitIDs map[string]int64, now time.Time, pending []pendingChange) error {

--- a/internal/database/batch_writer_test.go
+++ b/internal/database/batch_writer_test.go
@@ -3,6 +3,7 @@ package database_test
 import (
 	"fmt"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -153,5 +154,67 @@ func TestWaitForFlushNoOp(t *testing.T) {
 	// WaitForFlush with no prior FlushAsync should return nil
 	if err := writer.WaitForFlush(); err != nil {
 		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+func TestManifestLicensesAtRef(t *testing.T) {
+	writer, db := newTestBatchWriter(t)
+	manifest := database.ManifestInfo{Path: "package.json", Ecosystem: "npm", Kind: "manifest"}
+	committedAt := time.Now()
+
+	writer.AddCommit(database.CommitInfo{SHA: "license-1", CommittedAt: committedAt}, false)
+	writer.AddManifestLicense("license-1", manifest, database.ManifestLicenseInfo{
+		Licenses: []string{"MIT", "ISC"},
+	})
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush(first): %v", err)
+	}
+	branch, err := db.GetBranch("main")
+	if err != nil {
+		t.Fatalf("GetBranch: %v", err)
+	}
+
+	// Use a fresh writer to reproduce incremental indexing, where the same
+	// logical path may be associated with a different manifests row.
+	writer = database.NewBatchWriter(db)
+	if err := writer.UseBranch(branch.ID); err != nil {
+		t.Fatalf("UseBranch: %v", err)
+	}
+	writer.AddCommit(database.CommitInfo{SHA: "license-2", CommittedAt: committedAt.Add(time.Second)}, false)
+	writer.AddManifestLicense("license-2", manifest, database.ManifestLicenseInfo{
+		Licenses:    []string{"Apache-2.0"},
+		LicenseFile: "LICENSE",
+	})
+	writer.AddCommit(database.CommitInfo{SHA: "license-3", CommittedAt: committedAt.Add(2 * time.Second)}, false)
+	writer.AddManifestLicense("license-3", manifest, database.ManifestLicenseInfo{
+		Licenses: []string{"Apache-2.0"},
+		Removed:  true,
+	})
+	if err := writer.Flush(); err != nil {
+		t.Fatalf("Flush(incremental): %v", err)
+	}
+	first, err := db.GetManifestLicensesAtRef("license-1", branch.ID)
+	if err != nil {
+		t.Fatalf("GetManifestLicensesAtRef(first): %v", err)
+	}
+	if len(first) != 1 || !slices.Equal(first[0].Licenses, []string{"MIT", "ISC"}) {
+		t.Fatalf("first licenses = %+v", first)
+	}
+
+	second, err := db.GetManifestLicensesAtRef("license-2", branch.ID)
+	if err != nil {
+		t.Fatalf("GetManifestLicensesAtRef(second): %v", err)
+	}
+	if len(second) != 1 || !slices.Equal(second[0].Licenses, []string{"Apache-2.0"}) ||
+		second[0].LicenseFile != "LICENSE" {
+		t.Fatalf("second licenses = %+v", second)
+	}
+
+	third, err := db.GetManifestLicensesAtRef("license-3", branch.ID)
+	if err != nil {
+		t.Fatalf("GetManifestLicensesAtRef(third): %v", err)
+	}
+	if len(third) != 0 {
+		t.Fatalf("third licenses = %+v, want none after removal", third)
 	}
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -9,7 +9,7 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 15
+const SchemaVersion = 16
 
 type DB struct {
 	*sql.DB

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -3,6 +3,7 @@ package database_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -142,6 +143,25 @@ func TestCreate(t *testing.T) {
 			t.Error("expected fresh database with no branches")
 		}
 	})
+}
+
+func TestCheckSchemaVersion(t *testing.T) {
+	if err := database.CheckSchemaVersion(database.SchemaVersion); err != nil {
+		t.Fatalf("current schema rejected: %v", err)
+	}
+
+	olderErr := database.CheckSchemaVersion(database.SchemaVersion - 1)
+	if olderErr == nil || !strings.Contains(olderErr.Error(), "git pkgs upgrade") {
+		t.Fatalf("older schema error = %v, want upgrade instruction", olderErr)
+	}
+
+	newerErr := database.CheckSchemaVersion(database.SchemaVersion + 1)
+	if newerErr == nil || !strings.Contains(newerErr.Error(), "compatible git-pkgs binary") {
+		t.Fatalf("newer schema error = %v, want compatible binary instruction", newerErr)
+	}
+	if strings.Contains(newerErr.Error(), "git pkgs upgrade") {
+		t.Fatalf("newer schema error incorrectly recommends upgrade: %v", newerErr)
+	}
 }
 
 func TestOpen(t *testing.T) {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -69,6 +69,7 @@ func TestCreate(t *testing.T) {
 			"commits",
 			"branch_commits",
 			"manifests",
+			"manifest_licenses",
 			"dependency_changes",
 			"dependency_snapshots",
 			"packages",

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -310,6 +310,80 @@ type Dependency struct {
 	Direct         bool   `json:"-"`
 }
 
+// ManifestLicense is the declared license state of a package manifest at a
+// point in repository history.
+type ManifestLicense struct {
+	ManifestPath string   `json:"manifest_path"`
+	Ecosystem    string   `json:"ecosystem"`
+	Kind         string   `json:"kind"`
+	Licenses     []string `json:"licenses"`
+	LicenseFile  string   `json:"license_file,omitempty"`
+}
+
+// GetManifestLicensesAtRef returns the latest license state for every active
+// package manifest at ref on the given branch. License events are stored only
+// when a manifest changes, so the query selects each manifest's most recent
+// event at or before the target commit.
+func (db *DB) GetManifestLicensesAtRef(ref string, branchID int64) ([]ManifestLicense, error) {
+	rows, err := db.Query(`
+		WITH target_position AS (
+			SELECT bc.position
+			FROM branch_commits bc
+			JOIN commits c ON c.id = bc.commit_id
+			WHERE c.sha = ? AND bc.branch_id = ?
+		), ranked AS (
+			SELECT m.path, m.ecosystem, m.kind, ml.licenses, ml.license_file, ml.removed,
+				ROW_NUMBER() OVER (
+					PARTITION BY m.path
+					ORDER BY bc.position DESC
+				) AS row_num
+			FROM manifest_licenses ml
+			JOIN manifests m ON m.id = ml.manifest_id
+			JOIN branch_commits bc ON bc.commit_id = ml.commit_id
+			CROSS JOIN target_position tp
+			WHERE bc.branch_id = ? AND bc.position <= tp.position
+		)
+		SELECT path, ecosystem, kind, licenses, license_file
+		FROM ranked
+		WHERE row_num = 1 AND removed = 0
+		ORDER BY path
+	`, ref, branchID, branchID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var result []ManifestLicense
+	for rows.Next() {
+		var license ManifestLicense
+		var ecosystem, kind sql.NullString
+		var licensesJSON string
+		if err := rows.Scan(
+			&license.ManifestPath,
+			&ecosystem,
+			&kind,
+			&licensesJSON,
+			&license.LicenseFile,
+		); err != nil {
+			return nil, err
+		}
+		if ecosystem.Valid {
+			license.Ecosystem = ecosystem.String
+		}
+		if kind.Valid {
+			license.Kind = kind.String
+		}
+		if err := json.Unmarshal([]byte(licensesJSON), &license.Licenses); err != nil {
+			return nil, fmt.Errorf("decoding licenses for %s: %w", license.ManifestPath, err)
+		}
+		if license.Licenses == nil {
+			license.Licenses = []string{}
+		}
+		result = append(result, license)
+	}
+	return result, rows.Err()
+}
+
 func (db *DB) GetDependenciesAtRef(ref string, branchID int64) ([]Dependency, error) {
 	// Find the commit ID for this ref on this branch
 	var commitID int64
@@ -722,6 +796,7 @@ func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
 		"commits",
 		"branch_commits",
 		"manifests",
+		"manifest_licenses",
 		"dependency_changes",
 		"dependency_snapshots",
 		"packages",

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -53,6 +53,19 @@ func (db *DB) CreateSchema() error {
 	);
 	CREATE INDEX IF NOT EXISTS idx_manifests_path ON manifests(path);
 
+	CREATE TABLE IF NOT EXISTS manifest_licenses (
+		id INTEGER PRIMARY KEY,
+		commit_id INTEGER NOT NULL REFERENCES commits(id),
+		manifest_id INTEGER NOT NULL REFERENCES manifests(id),
+		licenses TEXT NOT NULL DEFAULT '[]',
+		license_file TEXT NOT NULL DEFAULT '',
+		removed INTEGER NOT NULL DEFAULT 0,
+		created_at DATETIME,
+		updated_at DATETIME
+	);
+	CREATE UNIQUE INDEX IF NOT EXISTS idx_manifest_licenses_unique ON manifest_licenses(commit_id, manifest_id);
+	CREATE INDEX IF NOT EXISTS idx_manifest_licenses_manifest ON manifest_licenses(manifest_id);
+
 	CREATE TABLE IF NOT EXISTS dependency_changes (
 		id INTEGER PRIMARY KEY,
 		commit_id INTEGER REFERENCES commits(id),

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -220,3 +220,30 @@ func (db *DB) SchemaVersion() (int, error) {
 	}
 	return version, nil
 }
+
+func CheckSchemaVersion(version int) error {
+	switch {
+	case version < SchemaVersion:
+		return fmt.Errorf(
+			"database schema version %d is outdated (current version is %d); run 'git pkgs upgrade'",
+			version,
+			SchemaVersion,
+		)
+	case version > SchemaVersion:
+		return fmt.Errorf(
+			"database schema version %d is newer than this git-pkgs binary supports (maximum supported version is %d); use a compatible git-pkgs binary",
+			version,
+			SchemaVersion,
+		)
+	default:
+		return nil
+	}
+}
+
+func (db *DB) CheckSchemaVersion() error {
+	version, err := db.SchemaVersion()
+	if err != nil {
+		return fmt.Errorf("reading database schema version: %w", err)
+	}
+	return CheckSchemaVersion(version)
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -51,6 +51,10 @@ func New(repo *git.Repository, db *database.DB, opts Options) *Indexer {
 }
 
 func (idx *Indexer) Run() (*Result, error) {
+	if err := idx.db.CheckSchemaVersion(); err != nil {
+		return nil, err
+	}
+
 	branch := idx.opts.Branch
 	if branch == "" {
 		var err error

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -201,6 +201,21 @@ func (idx *Indexer) Run() (*Result, error) {
 			writer.AddCommit(commitInfo, hasChanges)
 			result.CommitsAnalyzed++
 
+			if analysisResult != nil {
+				for _, license := range analysisResult.ManifestLicenses {
+					manifest := database.ManifestInfo{
+						Path:      license.ManifestPath,
+						Ecosystem: license.Ecosystem,
+						Kind:      license.Kind,
+					}
+					writer.AddManifestLicense(sha, manifest, database.ManifestLicenseInfo{
+						Licenses:    license.Licenses,
+						LicenseFile: license.LicenseFile,
+						Removed:     license.Removed,
+					})
+				}
+			}
+
 			if hasChanges {
 				result.CommitsWithChanges++
 				result.TotalChanges += len(analysisResult.Changes)

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -71,6 +71,17 @@ func gitRun(t *testing.T, repoDir string, args ...string) {
 	}
 }
 
+func gitOutput(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func TestIndexerWithGemfile(t *testing.T) {
 	repoDir := createTestRepo(t)
 
@@ -145,6 +156,68 @@ gem "sidekiq"
 	}
 	if changeCount != 4 {
 		t.Errorf("expected 4 changes, got %d", changeCount)
+	}
+}
+
+func TestIndexerStoresLicenseOnlyManifestHistory(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", `{
+  "name": "example",
+  "version": "1.0.0",
+  "license": "MIT"
+}`, "Add package license")
+	firstSHA := gitOutput(t, repoDir, "rev-parse", "HEAD")
+	addFileAndCommit(t, repoDir, "package.json", `{
+  "name": "example",
+  "version": "1.0.0",
+  "license": "Apache-2.0"
+}`, "Change package license")
+	secondSHA := gitOutput(t, repoDir, "rev-parse", "HEAD")
+
+	repo, err := gitpkg.OpenRepository(repoDir)
+	if err != nil {
+		t.Fatalf("OpenRepository: %v", err)
+	}
+	db, err := database.Create(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("Create database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	idx := indexer.New(repo, db, indexer.Options{Quiet: true})
+	result, err := idx.Run()
+	if err != nil {
+		t.Fatalf("indexer Run: %v", err)
+	}
+	if result.CommitsAnalyzed != 2 || result.CommitsWithChanges != 0 || result.TotalChanges != 0 {
+		t.Fatalf("index result = %+v", result)
+	}
+
+	branch, err := db.GetBranch("main")
+	if err != nil {
+		t.Fatalf("GetBranch: %v", err)
+	}
+	first, err := db.GetManifestLicensesAtRef(firstSHA, branch.ID)
+	if err != nil {
+		t.Fatalf("GetManifestLicensesAtRef(first): %v", err)
+	}
+	if len(first) != 1 || len(first[0].Licenses) != 1 || first[0].Licenses[0] != "MIT" {
+		t.Fatalf("first licenses = %+v", first)
+	}
+	second, err := db.GetManifestLicensesAtRef(secondSHA, branch.ID)
+	if err != nil {
+		t.Fatalf("GetManifestLicensesAtRef(second): %v", err)
+	}
+	if len(second) != 1 || len(second[0].Licenses) != 1 || second[0].Licenses[0] != "Apache-2.0" {
+		t.Fatalf("second licenses = %+v", second)
+	}
+
+	var dependencyChangeCommits int
+	if err := db.QueryRow("SELECT COUNT(*) FROM commits WHERE has_dependency_changes = 1").Scan(&dependencyChangeCommits); err != nil {
+		t.Fatalf("counting dependency-change commits: %v", err)
+	}
+	if dependencyChangeCommits != 0 {
+		t.Fatalf("dependency-change commits = %d, want 0", dependencyChangeCommits)
 	}
 }
 


### PR DESCRIPTION
Closes #305

## Summary

- add commit-scoped database storage for licenses declared by project manifests
- persist both `ParseResult.Licenses` and `ParseResult.LicenseFile`
- track license-only manifest changes without counting them as dependency changes
- record manifest removal events so historical queries do not return deleted manifests
- add `GetManifestLicensesAtRef` for retrieving manifest license state at a specific commit
- bump the database schema version and document the new table

## Implementation

The new `manifest_licenses` table stores license state against a commit and manifest. This preserves historical license information while supporting manifests that declare multiple licenses.

The analyzer emits manifest-license events for additions, modifications, and removals. The batch writer persists these events independently of dependency changes, allowing a commit that only changes a project's declared license to be indexed correctly.

## Testing

Added regression coverage for:

- manifests declaring multiple licenses
- `license-file` declarations
- license-only manifest modifications
- manifest deletion
- historical license lookups at different commits
- incremental indexing with existing manifest paths
- ensuring license-only commits are not marked as dependency-change commits

## Verification

- `go build ./...`
- `go mod tidy -diff`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go tool golangci-lint run ./...`
- `git diff --check`