### PR TITLE
Automatically upgrade existing databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,13 +646,13 @@ git pkgs hooks --uninstall  # remove hooks
 
 ### Upgrading
 
-After updating git-pkgs, you may need to rebuild the database if the schema has changed:
+After updating git-pkgs, the first command that opens an existing database upgrades it automatically. Schema-only changes are applied in place. If a parser or another indexing change requires fresh historical data, git-pkgs builds a replacement database, reindexes every tracked branch, and installs it after the rebuild succeeds. Notes and cached package, version, and vulnerability data are preserved.
+
+The upgrade does not prompt for input, so the same path works in hooks and CI. Run this command to perform the work before another command needs the database:
 
 ```bash
 git pkgs upgrade
 ```
-
-This is detected automatically and you'll see a message if an upgrade is needed.
 
 ### Show database schema
 

--- a/cmd/bisect.go
+++ b/cmd/bisect.go
@@ -493,7 +493,7 @@ func runBisectLog(cmd *cobra.Command, args []string) error {
 }
 
 func doBisectStep(cmd *cobra.Command, repo *git.Repository, mgr *bisect.Manager, state *bisect.State) error {
-	db, err := database.Open(repo.DatabasePath())
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
@@ -611,7 +611,7 @@ func doBisectStep(cmd *cobra.Command, repo *git.Repository, mgr *bisect.Manager,
 }
 
 func checkBisectComplete(repo *git.Repository, mgr *bisect.Manager, state *bisect.State) (bool, string, error) {
-	db, err := database.Open(repo.DatabasePath())
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return false, "", err
 	}
@@ -701,7 +701,7 @@ func printCulprit(cmd *cobra.Command, repo *git.Repository, sha string) error {
 	_, _ = fmt.Fprintln(cmd.OutOrStdout())
 
 	// Show dependency changes
-	db, err := database.Open(repo.DatabasePath())
+	db, err := openDatabaseForRepository(repo)
 	if err == nil {
 		defer func() { _ = db.Close() }()
 

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -157,7 +157,7 @@ func runBranchRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := openDatabaseForRepository(repo)
+	db, err := openDatabaseForBranchRemoval(repo, branchName)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -58,7 +58,7 @@ func runBranchList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
@@ -106,7 +106,7 @@ func runBranchAdd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("branch %q not found in repository", branchName)
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
@@ -157,7 +157,7 @@ func runBranchRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/branch.go
+++ b/cmd/branch.go
@@ -157,14 +157,7 @@ func runBranchRemove(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := openDatabaseForBranchRemoval(repo, branchName)
-	if err != nil {
-		return fmt.Errorf("opening database: %w", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	err = db.RemoveBranch(branchName)
-	if err != nil {
+	if err := removeRepositoryDatabaseBranch(repo, branchName); err != nil {
 		return fmt.Errorf("removing branch: %w", err)
 	}
 

--- a/cmd/database_test.go
+++ b/cmd/database_test.go
@@ -3,11 +3,13 @@ package cmd_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 
 	"github.com/git-pkgs/git-pkgs/cmd"
+	"github.com/git-pkgs/git-pkgs/internal/database"
 )
 
 func TestBranchCommand(t *testing.T) {
@@ -214,8 +216,13 @@ func TestInfoCommand(t *testing.T) {
 		if !strings.Contains(stdout, "Database Info") {
 			t.Errorf("expected 'Database Info' header, got: %s", stdout)
 		}
-		if !strings.Contains(stdout, "Schema version") {
-			t.Errorf("expected 'Schema version' in output, got: %s", stdout)
+		for _, version := range []string{
+			fmt.Sprintf("Schema version: %d", database.SchemaVersion),
+			fmt.Sprintf("Index version: %d", database.IndexVersion),
+		} {
+			if !strings.Contains(stdout, version) {
+				t.Errorf("expected %q in output, got: %s", version, stdout)
+			}
 		}
 		if !strings.Contains(stdout, "Branch") {
 			t.Errorf("expected 'Branch' in output, got: %s", stdout)
@@ -317,6 +324,9 @@ func TestInfoCommand(t *testing.T) {
 
 		if _, ok := info["schema_version"]; !ok {
 			t.Error("expected 'schema_version' in JSON")
+		}
+		if got := info["index_version"]; got != float64(database.IndexVersion) {
+			t.Errorf("expected index_version %d, got: %#v", database.IndexVersion, got)
 		}
 		if _, ok := info["row_counts"]; !ok {
 			t.Error("expected 'row_counts' in JSON")

--- a/cmd/database_upgrade.go
+++ b/cmd/database_upgrade.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
@@ -11,6 +12,11 @@ import (
 
 func openDatabaseForRepository(repo *git.Repository) (*database.DB, error) {
 	db, _, err := openRepositoryDatabase(repo, io.Discard, true)
+	return db, err
+}
+
+func openDatabaseForBranchRemoval(repo *git.Repository, branchName string) (*database.DB, error) {
+	db, _, err := openRepositoryDatabaseExceptBranch(repo, io.Discard, true, branchName)
 	return db, err
 }
 
@@ -47,6 +53,15 @@ func openRepositoryDatabase(
 	output io.Writer,
 	quiet bool,
 ) (*database.DB, database.UpgradeResult, error) {
+	return openRepositoryDatabaseExceptBranch(repo, output, quiet, "")
+}
+
+func openRepositoryDatabaseExceptBranch(
+	repo *git.Repository,
+	output io.Writer,
+	quiet bool,
+	excludedBranch string,
+) (*database.DB, database.UpgradeResult, error) {
 	return database.OpenWithRebuild(repo.DatabasePath(), func(previous, replacement *database.DB) error {
 		branches, err := previous.GetBranches()
 		if err != nil {
@@ -68,7 +83,16 @@ func openRepositoryDatabase(
 		if !quiet {
 			_, _ = fmt.Fprintln(output, "Database index is out of date. Rebuilding it now...")
 		}
+		sort.Slice(branches, func(i, j int) bool {
+			return branches[i].ID < branches[j].ID
+		})
 		for _, branch := range branches {
+			if branch.ID != 0 && branch.Name == excludedBranch {
+				if _, err := replacement.GetOrCreateBranch(branch.Name); err != nil {
+					return fmt.Errorf("preserving branch %q for removal: %w", branch.Name, err)
+				}
+				continue
+			}
 			revision, err := rebuildRevision(repo, branch)
 			if err != nil {
 				return err

--- a/cmd/database_upgrade.go
+++ b/cmd/database_upgrade.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -15,9 +16,28 @@ func openDatabaseForRepository(repo *git.Repository) (*database.DB, error) {
 	return db, err
 }
 
-func openDatabaseForBranchRemoval(repo *git.Repository, branchName string) (*database.DB, error) {
-	db, _, err := openRepositoryDatabaseExceptBranch(repo, io.Discard, true, branchName)
-	return db, err
+func removeRepositoryDatabaseBranch(repo *git.Repository, branchName string) error {
+	removedDuringRebuild := false
+	db, _, err := openRepositoryDatabaseWithPreparation(repo, io.Discard, true, func(previous *database.DB) error {
+		if err := previous.RemoveBranch(branchName); err != nil {
+			return err
+		}
+		removedDuringRebuild = true
+		return nil
+	})
+	if err != nil {
+		var unresolvableBranch *unresolvableTrackedBranchError
+		if removedDuringRebuild && errors.As(err, &unresolvableBranch) {
+			return nil
+		}
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if removedDuringRebuild {
+		return nil
+	}
+	return db.RemoveBranch(branchName)
 }
 
 func prepareRepositoryDatabase(repo *git.Repository) error {
@@ -53,16 +73,22 @@ func openRepositoryDatabase(
 	output io.Writer,
 	quiet bool,
 ) (*database.DB, database.UpgradeResult, error) {
-	return openRepositoryDatabaseExceptBranch(repo, output, quiet, "")
+	return openRepositoryDatabaseWithPreparation(repo, output, quiet, nil)
 }
 
-func openRepositoryDatabaseExceptBranch(
+func openRepositoryDatabaseWithPreparation(
 	repo *git.Repository,
 	output io.Writer,
 	quiet bool,
-	excludedBranch string,
+	preparePrevious func(*database.DB) error,
 ) (*database.DB, database.UpgradeResult, error) {
 	return database.OpenWithRebuild(repo.DatabasePath(), func(previous, replacement *database.DB) error {
+		if preparePrevious != nil {
+			if err := preparePrevious(previous); err != nil {
+				return err
+			}
+		}
+
 		branches, err := previous.GetBranches()
 		if err != nil {
 			return fmt.Errorf("reading tracked branches: %w", err)
@@ -87,22 +113,17 @@ func openRepositoryDatabaseExceptBranch(
 			return branches[i].ID < branches[j].ID
 		})
 		for _, branch := range branches {
-			if branch.ID != 0 && branch.Name == excludedBranch {
-				if _, err := replacement.GetOrCreateBranch(branch.Name); err != nil {
-					return fmt.Errorf("preserving branch %q for removal: %w", branch.Name, err)
-				}
-				continue
-			}
 			revision, err := rebuildRevision(repo, branch)
 			if err != nil {
 				return err
 			}
 			idx := indexer.New(repo, replacement, indexer.Options{
-				Branch:          branch.Name,
-				Revision:        revision,
-				Output:          output,
-				Quiet:           quiet,
-				EcosystemFilter: ecosystemFilter,
+				Branch:            branch.Name,
+				Revision:          revision,
+				Output:            output,
+				Quiet:             quiet,
+				FailOnCommitError: true,
+				EcosystemFilter:   ecosystemFilter,
 			})
 			if _, err := idx.Run(); err != nil {
 				return fmt.Errorf("reindexing branch %q: %w", branch.Name, err)
@@ -112,14 +133,29 @@ func openRepositoryDatabaseExceptBranch(
 	})
 }
 
+type unresolvableTrackedBranchError struct {
+	name string
+}
+
+func (e *unresolvableTrackedBranchError) Error() string {
+	return fmt.Sprintf("tracked branch %q cannot be resolved", e.name)
+}
+
 func rebuildRevision(repo *git.Repository, branch database.BranchInfo) (string, error) {
-	if _, err := repo.ResolveRevision(branch.Name); err == nil {
+	if rebuildCommitExists(repo, branch.Name) {
 		return branch.Name, nil
 	}
-	if branch.LastAnalyzedSHA != "" {
-		if _, err := repo.ResolveRevision(branch.LastAnalyzedSHA); err == nil {
-			return branch.LastAnalyzedSHA, nil
-		}
+	if branch.LastAnalyzedSHA != "" && rebuildCommitExists(repo, branch.LastAnalyzedSHA) {
+		return branch.LastAnalyzedSHA, nil
 	}
-	return "", fmt.Errorf("tracked branch %q cannot be resolved", branch.Name)
+	return "", &unresolvableTrackedBranchError{name: branch.Name}
+}
+
+func rebuildCommitExists(repo *git.Repository, revision string) bool {
+	hash, err := repo.ResolveRevision(revision)
+	if err != nil {
+		return false
+	}
+	_, err = repo.CommitObject(*hash)
+	return err == nil
 }

--- a/cmd/database_upgrade.go
+++ b/cmd/database_upgrade.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/git-pkgs/internal/git"
+	"github.com/git-pkgs/git-pkgs/internal/indexer"
+)
+
+func openDatabaseForRepository(repo *git.Repository) (*database.DB, error) {
+	db, _, err := openRepositoryDatabase(repo, io.Discard, true)
+	return db, err
+}
+
+func prepareRepositoryDatabase(repo *git.Repository) error {
+	if !database.Exists(repo.DatabasePath()) {
+		return nil
+	}
+	db, err := openDatabaseForRepository(repo)
+	if err != nil {
+		return err
+	}
+	return db.Close()
+}
+
+func getDependenciesWithDB(
+	repo *git.Repository,
+	commitRef, branchName string,
+) ([]database.Dependency, *database.DB, error) {
+	if err := prepareRepositoryDatabase(repo); err != nil {
+		return nil, nil, err
+	}
+	return repo.GetDependenciesWithDB(commitRef, branchName)
+}
+
+func getDependencies(repo *git.Repository, commitRef, branchName string) ([]database.Dependency, error) {
+	if err := prepareRepositoryDatabase(repo); err != nil {
+		return nil, err
+	}
+	return repo.GetDependencies(commitRef, branchName)
+}
+
+func openRepositoryDatabase(
+	repo *git.Repository,
+	output io.Writer,
+	quiet bool,
+) (*database.DB, database.UpgradeResult, error) {
+	return database.OpenWithRebuild(repo.DatabasePath(), func(previous, replacement *database.DB) error {
+		branches, err := previous.GetBranches()
+		if err != nil {
+			return fmt.Errorf("reading tracked branches: %w", err)
+		}
+		if len(branches) == 0 {
+			branch, err := repo.CurrentBranch()
+			if err != nil {
+				return fmt.Errorf("finding a branch to rebuild: %w", err)
+			}
+			branches = []database.BranchInfo{{Name: branch}}
+		}
+
+		ecosystemFilter, err := repo.EcosystemFilter()
+		if err != nil {
+			return fmt.Errorf("loading ecosystem config: %w", err)
+		}
+
+		if !quiet {
+			_, _ = fmt.Fprintln(output, "Database index is out of date. Rebuilding it now...")
+		}
+		for _, branch := range branches {
+			revision, err := rebuildRevision(repo, branch)
+			if err != nil {
+				return err
+			}
+			idx := indexer.New(repo, replacement, indexer.Options{
+				Branch:          branch.Name,
+				Revision:        revision,
+				Output:          output,
+				Quiet:           quiet,
+				EcosystemFilter: ecosystemFilter,
+			})
+			if _, err := idx.Run(); err != nil {
+				return fmt.Errorf("reindexing branch %q: %w", branch.Name, err)
+			}
+		}
+		return nil
+	})
+}
+
+func rebuildRevision(repo *git.Repository, branch database.BranchInfo) (string, error) {
+	if _, err := repo.ResolveRevision(branch.Name); err == nil {
+		return branch.Name, nil
+	}
+	if branch.LastAnalyzedSHA != "" {
+		if _, err := repo.ResolveRevision(branch.LastAnalyzedSHA); err == nil {
+			return branch.LastAnalyzedSHA, nil
+		}
+	}
+	return "", fmt.Errorf("tracked branch %q cannot be resolved", branch.Name)
+}

--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -56,7 +56,7 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -156,12 +156,12 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 // diffBetweenCommits compares dependencies between two commits using on-demand indexing.
 func diffBetweenCommits(repo *git.Repository, fromRef, toRef, by, kind string) (*DiffResult, error) {
-	fromDeps, err := repo.GetDependencies(fromRef, "")
+	fromDeps, err := getDependencies(repo, fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
 	}
 
-	toDeps, err := repo.GetDependencies(toRef, "")
+	toDeps, err := getDependencies(repo, toRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", toRef, err)
 	}
@@ -171,7 +171,7 @@ func diffBetweenCommits(repo *git.Repository, fromRef, toRef, by, kind string) (
 
 // diffWithWorkingTree compares dependencies between a commit and the working tree.
 func diffWithWorkingTree(repo *git.Repository, fromRef string, includeSubmodules bool, by, kind string) (*DiffResult, error) {
-	fromDeps, err := repo.GetDependencies(fromRef, "")
+	fromDeps, err := getDependencies(repo, fromRef, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting deps at %s: %w", fromRef, err)
 	}

--- a/cmd/freshness.go
+++ b/cmd/freshness.go
@@ -83,7 +83,7 @@ func runFreshness(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/funding.go
+++ b/cmd/funding.go
@@ -71,7 +71,7 @@ func runFunding(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -92,7 +92,7 @@ func runHealth(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -35,7 +35,7 @@ func openDatabase() (*git.Repository, *database.DB, error) {
 		return nil, nil, fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -61,7 +61,7 @@ func runHistory(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -119,6 +119,7 @@ func outputInfoText(cmd *cobra.Command, info *database.DatabaseInfo) {
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Location: %s\n", info.Path)
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Size: %s\n", formatBytes(info.SizeBytes))
 	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Schema version: %d\n", info.SchemaVersion)
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Index version: %d\n", info.IndexVersion)
 	_, _ = fmt.Fprintln(cmd.OutOrStdout())
 
 	if info.BranchName != "" {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -42,7 +42,7 @@ func runInfo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -65,10 +65,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	dbPath := repo.DatabasePath()
 	if database.Exists(dbPath) && !force {
-		if !quiet {
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Database already exists. Use --force to recreate.")
-		}
-		return nil
+		return openExistingDatabase(cmd, repo, quiet)
 	}
 
 	db, err := database.Create(dbPath)
@@ -124,5 +121,28 @@ func runInit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	return nil
+}
+
+func openExistingDatabase(cmd *cobra.Command, repo *git.Repository, quiet bool) error {
+	db, result, err := openRepositoryDatabase(repo, cmd.OutOrStdout(), quiet)
+	if err != nil {
+		return fmt.Errorf("opening existing database: %w", err)
+	}
+	if err := db.Close(); err != nil {
+		return fmt.Errorf("closing existing database: %w", err)
+	}
+	if quiet {
+		return nil
+	}
+
+	switch {
+	case result.Rebuilt && result.FromSchemaVersion == result.ToSchemaVersion:
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Rebuilt existing database index.")
+	case result.Upgraded():
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgraded existing database from schema version %d to %d.\n", result.FromSchemaVersion, result.ToSchemaVersion)
+	default:
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Database already exists. Use --force to recreate.")
+	}
 	return nil
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -139,6 +139,8 @@ func openExistingDatabase(cmd *cobra.Command, repo *git.Repository, quiet bool) 
 	switch {
 	case result.Rebuilt && result.FromSchemaVersion == result.ToSchemaVersion:
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Rebuilt existing database index.")
+	case result.Rebuilt:
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgraded existing database from schema version %d to %d and rebuilt its index.\n", result.FromSchemaVersion, result.ToSchemaVersion)
 	case result.Upgraded():
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgraded existing database from schema version %d to %d.\n", result.FromSchemaVersion, result.ToSchemaVersion)
 	default:

--- a/cmd/integrity.go
+++ b/cmd/integrity.go
@@ -75,7 +75,7 @@ func runIntegrity(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -111,7 +111,7 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(opts.commit, opts.branchName)
+	deps, db, err := getDependenciesWithDB(repo, opts.commit, opts.branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -45,7 +45,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commitRef, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commitRef, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -51,7 +51,7 @@ func runLog(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/maintainers.go
+++ b/cmd/maintainers.go
@@ -89,7 +89,7 @@ func runMaintainers(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -62,7 +62,7 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/provenance.go
+++ b/cmd/provenance.go
@@ -95,7 +95,7 @@ func runProvenance(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, err := repo.GetDependencies(commit, branchName)
+	deps, err := getDependencies(repo, commit, branchName)
 	if err != nil {
 		return fmt.Errorf("loading dependencies: %w", err)
 	}

--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -38,7 +38,7 @@ func runReindex(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -58,7 +58,7 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -52,7 +52,7 @@ func runSchema(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -103,7 +103,7 @@ func getChangesForCommit(repo *git.Repository, commitRef string) ([]database.Cha
 	// Try database first
 	dbPath := repo.DatabasePath()
 	if database.Exists(dbPath) {
-		db, err := database.Open(dbPath)
+		db, err := openDatabaseForRepository(repo)
 		if err == nil {
 			defer func() { _ = db.Close() }()
 			changes, err := db.GetChangesForCommit(sha)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -5,17 +5,15 @@ import (
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/git-pkgs/git-pkgs/internal/git"
-	"github.com/git-pkgs/git-pkgs/internal/indexer"
 	"github.com/spf13/cobra"
 )
 
 func addUpgradeCmd(parent *cobra.Command) {
 	upgradeCmd := &cobra.Command{
 		Use:   "upgrade",
-		Short: "Upgrade database to latest schema version",
-		Long: `Upgrade the git-pkgs database to the latest schema version.
-This rebuilds the database from scratch if the schema has changed.`,
-		RunE: runUpgrade,
+		Short: "Upgrade the database schema and index",
+		Long:  "Upgrade the git-pkgs database schema and rebuild outdated indexed data.",
+		RunE:  runUpgrade,
 	}
 
 	parent.AddCommand(upgradeCmd)
@@ -34,62 +32,23 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, result, err := openRepositoryDatabase(repo, cmd.OutOrStdout(), quiet)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}
-
-	currentVersion, err := db.SchemaVersion()
-	if err != nil {
-		_ = db.Close()
-		return fmt.Errorf("reading schema version: %w", err)
-	}
-
-	if currentVersion == database.SchemaVersion {
-		_ = db.Close()
-		if !quiet {
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Database is already at schema version %d. No upgrade needed.\n", currentVersion)
-		}
-		return nil
-	}
-
-	if !quiet {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgrading database from schema v%d to v%d...\n", currentVersion, database.SchemaVersion)
-	}
-
-	// Get the branch name before closing
-	branchInfo, err := db.GetDefaultBranch()
-	if err != nil {
-		_ = db.Close()
-		return fmt.Errorf("getting branch info: %w", err)
-	}
-	branch := branchInfo.Name
-
 	if err := db.Close(); err != nil {
 		return fmt.Errorf("closing database: %w", err)
 	}
 
-	// Recreate the database
-	db, err = database.Create(dbPath)
-	if err != nil {
-		return fmt.Errorf("creating database: %w", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	idx := indexer.New(repo, db, indexer.Options{
-		Branch: branch,
-		Output: cmd.OutOrStdout(),
-		Quiet:  quiet,
-	})
-
-	result, err := idx.Run()
-	if err != nil {
-		return fmt.Errorf("indexing: %w", err)
-	}
-
 	if !quiet {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "\nUpgrade complete! Analyzed %d commits, found %d with dependency changes (%d total changes)\n",
-			result.CommitsAnalyzed, result.CommitsWithChanges, result.TotalChanges)
+		switch {
+		case result.Rebuilt && result.FromSchemaVersion == result.ToSchemaVersion:
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Rebuilt database index.")
+		case result.Upgraded():
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgraded database from schema version %d to %d.\n", result.FromSchemaVersion, result.ToSchemaVersion)
+		default:
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Database is already at schema version %d. No upgrade needed.\n", result.ToSchemaVersion)
+		}
 	}
 
 	return nil

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -44,6 +44,8 @@ func runUpgrade(cmd *cobra.Command, args []string) error {
 		switch {
 		case result.Rebuilt && result.FromSchemaVersion == result.ToSchemaVersion:
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Rebuilt database index.")
+		case result.Rebuilt:
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgraded database from schema version %d to %d and rebuilt its index.\n", result.FromSchemaVersion, result.ToSchemaVersion)
 		case result.Upgraded():
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Upgraded database from schema version %d to %d.\n", result.FromSchemaVersion, result.ToSchemaVersion)
 		default:

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -83,6 +84,71 @@ func TestCommandAutomaticallyRebuildsOutdatedIndex(t *testing.T) {
 	}
 	if len(branches) != 2 {
 		t.Errorf("expected 2 tracked branches, got %d", len(branches))
+	}
+	defaultBranch, err := db.GetDefaultBranch()
+	if err != nil {
+		t.Fatalf("reading default branch failed: %v", err)
+	}
+	if defaultBranch.Name != "main" {
+		t.Errorf("expected main to remain the default branch, got %q", defaultBranch.Name)
+	}
+}
+
+func TestBranchRemoveRecoversFromUnresolvableOutdatedBranch(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package manifest")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks", "--quiet"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	gitBranch(t, repoDir, "feature")
+	if _, _, err := runCmd(t, "branch", "add", "feature", "--quiet"); err != nil {
+		t.Fatalf("adding tracked branch failed: %v", err)
+	}
+
+	dbPath := filepath.Join(repoDir, ".git", "pkgs.sqlite3")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening database failed: %v", err)
+	}
+	if _, err := db.Exec(`
+		UPDATE branches SET last_analyzed_sha = '0000000000000000000000000000000000000000'
+		WHERE name = 'feature';
+		PRAGMA user_version = 2147483647;
+	`); err != nil {
+		t.Fatalf("preparing stale tracked branch failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing outdated database failed: %v", err)
+	}
+
+	deleteBranch := exec.Command("git", "branch", "-D", "feature")
+	deleteBranch.Dir = repoDir
+	if output, err := deleteBranch.CombinedOutput(); err != nil {
+		t.Fatalf("deleting Git branch failed: %v\n%s", err, output)
+	}
+
+	if _, _, err := runCmd(t, "branch", "remove", "feature"); err != nil {
+		t.Fatalf("removing unresolvable tracked branch failed: %v", err)
+	}
+
+	db, err = database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening rebuilt database failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.GetBranch("feature"); err != sql.ErrNoRows {
+		t.Fatalf("expected feature branch to be removed, got: %v", err)
+	}
+	defaultBranch, err := db.GetDefaultBranch()
+	if err != nil {
+		t.Fatalf("reading default branch failed: %v", err)
+	}
+	if defaultBranch.Name != "main" {
+		t.Errorf("expected main to remain the default branch, got %q", defaultBranch.Name)
 	}
 }
 

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -149,6 +150,151 @@ func TestBranchRemoveRecoversFromUnresolvableOutdatedBranch(t *testing.T) {
 	}
 	if defaultBranch.Name != "main" {
 		t.Errorf("expected main to remain the default branch, got %q", defaultBranch.Name)
+	}
+}
+
+func TestBranchRemoveRecoversFromMultipleUnresolvableOutdatedBranches(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package manifest")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks", "--quiet"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	for _, branch := range []string{"feature-one", "feature-two"} {
+		gitBranch(t, repoDir, branch)
+		if _, _, err := runCmd(t, "branch", "add", branch, "--quiet"); err != nil {
+			t.Fatalf("adding tracked branch %q failed: %v", branch, err)
+		}
+	}
+
+	dbPath := filepath.Join(repoDir, ".git", "pkgs.sqlite3")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening database failed: %v", err)
+	}
+	if _, err := db.Exec(`
+		UPDATE branches SET last_analyzed_sha = '0000000000000000000000000000000000000000'
+		WHERE name IN ('feature-one', 'feature-two');
+		PRAGMA user_version = 2147483647;
+	`); err != nil {
+		t.Fatalf("preparing stale tracked branches failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing outdated database failed: %v", err)
+	}
+
+	deleteBranches := exec.Command("git", "branch", "-D", "feature-one", "feature-two")
+	deleteBranches.Dir = repoDir
+	if output, err := deleteBranches.CombinedOutput(); err != nil {
+		t.Fatalf("deleting Git branches failed: %v\n%s", err, output)
+	}
+
+	if _, _, err := runCmd(t, "branch", "remove", "feature-one"); err != nil {
+		t.Fatalf("removing first unresolvable tracked branch failed: %v", err)
+	}
+
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("opening pending database failed: %v", err)
+	}
+	var firstCount, secondCount int
+	if err := rawDB.QueryRow("SELECT COUNT(*) FROM branches WHERE name = 'feature-one'").Scan(&firstCount); err != nil {
+		t.Fatalf("checking first removed branch failed: %v", err)
+	}
+	if err := rawDB.QueryRow("SELECT COUNT(*) FROM branches WHERE name = 'feature-two'").Scan(&secondCount); err != nil {
+		t.Fatalf("checking remaining branch failed: %v", err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("closing pending database failed: %v", err)
+	}
+	if firstCount != 0 || secondCount != 1 {
+		t.Fatalf("unexpected tracked branches after first removal: feature-one=%d, feature-two=%d", firstCount, secondCount)
+	}
+
+	if _, _, err := runCmd(t, "branch", "remove", "feature-two"); err != nil {
+		t.Fatalf("removing second unresolvable tracked branch failed: %v", err)
+	}
+
+	db, err = database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening rebuilt database failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	branches, err := db.GetBranches()
+	if err != nil {
+		t.Fatalf("reading rebuilt branches failed: %v", err)
+	}
+	if len(branches) != 1 || branches[0].Name != "main" {
+		t.Fatalf("expected only main to remain tracked, got: %+v", branches)
+	}
+}
+
+func TestRebuildKeepsPreviousDatabaseOnIndexingError(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package manifest")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks", "--quiet"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	dbPath := filepath.Join(repoDir, ".git", "pkgs.sqlite3")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening database failed: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO notes (purl, namespace, message) VALUES ('pkg:npm/express', 'test', 'keep me');
+		PRAGMA user_version = 2147483647;
+	`); err != nil {
+		t.Fatalf("preparing outdated database failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing outdated database failed: %v", err)
+	}
+
+	treeCommand := exec.Command("git", "rev-parse", "HEAD^{tree}")
+	treeCommand.Dir = repoDir
+	treeOutput, err := treeCommand.Output()
+	if err != nil {
+		t.Fatalf("resolving tree failed: %v", err)
+	}
+	treeHash := strings.TrimSpace(string(treeOutput))
+	if len(treeHash) != 40 {
+		t.Fatalf("unexpected tree hash %q", treeHash)
+	}
+	treePath := filepath.Join(repoDir, ".git", "objects", treeHash[:2], treeHash[2:])
+	if err := os.Remove(treePath); err != nil {
+		t.Fatalf("removing tree object failed: %v", err)
+	}
+
+	if _, _, err := runCmd(t, "list", "--format", "json"); err == nil {
+		t.Fatal("expected rebuild to fail when a Git tree cannot be loaded")
+	}
+
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("opening previous database failed: %v", err)
+	}
+	defer func() { _ = rawDB.Close() }()
+	var indexVersion int
+	if err := rawDB.QueryRow("PRAGMA user_version").Scan(&indexVersion); err != nil {
+		t.Fatalf("reading pending index version failed: %v", err)
+	}
+	if indexVersion == database.IndexVersion {
+		t.Fatal("expected the previous database to remain pending after the failed rebuild")
+	}
+	var note string
+	if err := rawDB.QueryRow("SELECT message FROM notes WHERE purl = 'pkg:npm/express'").Scan(&note); err != nil {
+		t.Fatalf("reading preserved note failed: %v", err)
+	}
+	if note != "keep me" {
+		t.Fatalf("expected previous note to remain, got %q", note)
 	}
 }
 

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1,0 +1,94 @@
+package cmd_test
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+)
+
+func TestCommandAutomaticallyRebuildsOutdatedIndex(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package manifest")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--no-hooks", "--quiet"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	gitBranch(t, repoDir, "feature")
+	if _, _, err := runCmd(t, "branch", "add", "feature", "--quiet"); err != nil {
+		t.Fatalf("adding tracked branch failed: %v", err)
+	}
+
+	dbPath := filepath.Join(repoDir, ".git", "pkgs.sqlite3")
+	db, err := database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening database failed: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO notes (purl, namespace, message) VALUES ('pkg:npm/express', 'test', 'keep me');
+		DELETE FROM dependency_snapshots;
+		PRAGMA user_version = 2147483647;
+	`); err != nil {
+		t.Fatalf("preparing outdated database failed: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("closing outdated database failed: %v", err)
+	}
+
+	stdout, _, err := runCmd(t, "list", "--format", "json")
+	if err != nil {
+		t.Fatalf("list failed: %v", err)
+	}
+	var dependencies []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &dependencies); err != nil {
+		t.Fatalf("expected clean JSON output after automatic upgrade, got %q: %v", stdout, err)
+	}
+	var foundExpress bool
+	for _, dependency := range dependencies {
+		if dependency.Name == "express" {
+			foundExpress = true
+			break
+		}
+	}
+	if !foundExpress {
+		t.Fatalf("expected rebuilt dependency data, got: %+v", dependencies)
+	}
+
+	db, err = database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("opening rebuilt database failed: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var note string
+	if err := db.QueryRow("SELECT message FROM notes WHERE purl = 'pkg:npm/express'").Scan(&note); err != nil {
+		t.Fatalf("reading preserved note failed: %v", err)
+	}
+	if note != "keep me" {
+		t.Errorf("expected preserved note, got %q", note)
+	}
+
+	branches, err := db.GetBranches()
+	if err != nil {
+		t.Fatalf("reading rebuilt branches failed: %v", err)
+	}
+	if len(branches) != 2 {
+		t.Errorf("expected 2 tracked branches, got %d", len(branches))
+	}
+}
+
+func gitBranch(t *testing.T, repoDir, name string) {
+	t.Helper()
+	cmd := exec.Command("git", "branch", name)
+	cmd.Dir = repoDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("creating branch failed: %v", err)
+	}
+}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -2,8 +2,10 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -81,6 +83,61 @@ func TestCommandAutomaticallyRebuildsOutdatedIndex(t *testing.T) {
 	}
 	if len(branches) != 2 {
 		t.Errorf("expected 2 tracked branches, got %d", len(branches))
+	}
+}
+
+func TestExplicitCommandsReportSchemaAndIndexUpgrade(t *testing.T) {
+	fromVersion := database.SchemaVersion - 1
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "upgrade",
+			args: []string{"upgrade"},
+			want: fmt.Sprintf("Upgraded database from schema version %d to %d and rebuilt its index.", fromVersion, database.SchemaVersion),
+		},
+		{
+			name: "existing init",
+			args: []string{"init", "--no-hooks"},
+			want: fmt.Sprintf("Upgraded existing database from schema version %d to %d and rebuilt its index.", fromVersion, database.SchemaVersion),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repoDir := createTestRepo(t)
+			addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package manifest")
+
+			cleanup := chdir(t, repoDir)
+			defer cleanup()
+
+			if _, _, err := runCmd(t, "init", "--no-hooks", "--quiet"); err != nil {
+				t.Fatalf("init failed: %v", err)
+			}
+			db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
+			if err != nil {
+				t.Fatalf("opening database failed: %v", err)
+			}
+			if _, err := db.Exec("UPDATE schema_info SET version = ?", fromVersion); err != nil {
+				t.Fatalf("marking database outdated failed: %v", err)
+			}
+			if _, err := db.Exec("PRAGMA user_version = 0"); err != nil {
+				t.Fatalf("marking database index outdated failed: %v", err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatalf("closing database failed: %v", err)
+			}
+
+			stdout, _, err := runCmd(t, test.args...)
+			if err != nil {
+				t.Fatalf("command failed: %v", err)
+			}
+			if !strings.Contains(stdout, test.want) {
+				t.Errorf("expected %q in output, got: %s", test.want, stdout)
+			}
+		})
 	}
 }
 

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -603,7 +603,7 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a git repository: %w", err)
 	}
 
-	deps, db, err := repo.GetDependenciesWithDB(commit, branchName)
+	deps, db, err := getDependenciesWithDB(repo, commit, branchName)
 	if db != nil {
 		defer func() { _ = db.Close() }()
 	}

--- a/cmd/why.go
+++ b/cmd/why.go
@@ -46,7 +46,7 @@ func runWhy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("database not found. Run 'git pkgs init' first")
 	}
 
-	db, err := database.Open(dbPath)
+	db, err := openDatabaseForRepository(repo)
 	if err != nil {
 		return fmt.Errorf("opening database: %w", err)
 	}

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -296,7 +296,7 @@ Cache the git-pkgs binary to speed up workflows:
           fi
 ```
 
-Cache the SQLite database to reuse enrichment metadata, including licenses, across workflow runs. A unique primary key lets each run save refreshed data, while the restore key selects the newest earlier cache:
+Cache the SQLite database to reuse enrichment metadata, including licenses, across workflow runs. A database restored from an older git-pkgs release is upgraded automatically when a command opens it; no separate upgrade step is needed. A unique primary key lets each run save refreshed data, while the restore key selects the newest earlier cache:
 
 ```yaml
 env:

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -104,7 +104,11 @@ The `BatchWriter` in `internal/database` buffers records and flushes them in tra
 
 ## Schema Upgrades
 
-The database stores its schema version in the `schema_info` table. When git-pkgs updates and the schema changes, commands detect the mismatch and prompt you to run `git pkgs upgrade`, which rebuilds the database from scratch.
+The database stores its schema version in `schema_info` and its indexed-data version in SQLite's `user_version`. Commands upgrade an older database when they open it, without prompting for input.
+
+Schema migrations run in one transaction. An indexed-data version change means the current parsers must process the Git history again. In that case, git-pkgs creates a database beside the existing file and reindexes every tracked branch. It copies notes and enrichment caches to the replacement, then swaps files after the rebuild succeeds. A failed rebuild leaves the existing database in place. `git pkgs upgrade` runs this path directly.
+
+Increment `SchemaVersion` and add a migration for schema changes. Increment `IndexVersion` when a parser or indexer change affects stored history, even if the schema stays the same. Keep parser-derived data out of schema migrations; the index rebuild supplies it.
 
 ## Point-in-Time Reconstruction
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -251,4 +251,4 @@ notes (standalone, keyed on purl + namespace)
 
 ## Schema Versioning
 
-The `schema_info` table stores the current schema version. When git-pkgs updates with schema changes, commands detect the mismatch and prompt you to run `git pkgs upgrade`, which rebuilds the database.
+The `schema_info` table stores the current schema version. SQLite's `user_version` records which indexer produced the derived history. Commands apply schema changes automatically. A change to parser-produced data rebuilds the index from Git while preserving notes and enrichment caches.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/git-pkgs/vulns v0.2.2
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-git/go-git/v5 v5.19.2
+	github.com/gofrs/flock v0.13.0
 	github.com/mattn/go-isatty v0.0.24
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -118,7 +119,6 @@ require (
 	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/godoc-lint/godoc-lint v0.11.2 // indirect
-	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golangci/asciicheck v0.5.0 // indirect

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -9,7 +9,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const SchemaVersion = 15
+const (
+	// SchemaVersion changes when the SQLite schema changes.
+	SchemaVersion = 15
+	// IndexVersion changes when existing Git history must be processed again,
+	// including parser changes and new derived data.
+	IndexVersion = 1
+)
 
 type DB struct {
 	*sql.DB
@@ -32,7 +38,7 @@ func Create(path string) (*DB, error) {
 		}
 	}
 
-	db, err := Open(path)
+	db, err := open(path)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +62,7 @@ func OpenOrCreate(path string) (*DB, bool, error) {
 		return nil, false, err
 	}
 
-	db, err := Open(path)
+	db, err := open(path)
 	if err != nil {
 		return nil, false, err
 	}
@@ -77,6 +83,26 @@ func ensureParentDir(path string) error {
 }
 
 func Open(path string) (*DB, error) {
+	db, _, err := OpenWithRebuild(path, nil)
+	return db, err
+}
+
+func openAndUpgrade(path string) (*DB, UpgradeResult, error) {
+	db, err := open(path)
+	if err != nil {
+		return nil, UpgradeResult{}, err
+	}
+
+	result, err := db.UpgradeSchema()
+	if err != nil {
+		_ = db.Close()
+		return nil, result, err
+	}
+
+	return db, result, nil
+}
+
+func open(path string) (*DB, error) {
 	sqlDB, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("opening database: %w", err)

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,8 +1,14 @@
 package database_test
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -173,6 +179,547 @@ func TestOpen(t *testing.T) {
 			t.Errorf("expected to find branch: %v", err)
 		}
 	})
+}
+
+func TestOpenUpgradesSchema(t *testing.T) {
+	t.Run("upgrades version 5 in place and preserves rows", testUpgradeVersion5Schema)
+	t.Run("rebuilds version 5 and preserves cached rows", testRebuildVersion5Schema)
+	t.Run("handles the origin column added without a version bump", testUpgradeVersion8Origin)
+	t.Run("adopts a current database created before index versioning", testAdoptLegacyCurrentIndex)
+	t.Run("rejects a schema created by a newer binary", testRejectNewerSchema)
+	t.Run("rejects an index created by a newer binary", testRejectNewerIndex)
+	t.Run("rolls back a failed migration", testMigrationRollback)
+	t.Run("keeps the previous database when a rebuild fails", testFailedRebuild)
+	t.Run("serializes concurrent upgrades", testConcurrentRebuild)
+	t.Run("preserves database file permissions", testRebuildPreservesPermissions)
+}
+
+func testAdoptLegacyCurrentIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 0"); err != nil {
+		t.Fatalf("failed to clear index version: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+
+	db, err = database.Open(dbPath)
+	if err != nil {
+		t.Fatalf("failed to adopt current database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var indexVersion int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&indexVersion); err != nil {
+		t.Fatalf("failed to read index version: %v", err)
+	}
+	if indexVersion != database.IndexVersion {
+		t.Errorf("expected index version %d, got %d", database.IndexVersion, indexVersion)
+	}
+}
+
+func testRebuildVersion5Schema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	createVersion5Database(t, dbPath)
+
+	db, result, err := database.OpenWithRebuild(dbPath, func(previous, replacement *database.DB) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to rebuild database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !result.Rebuilt {
+		t.Fatal("expected indexed data to be rebuilt")
+	}
+
+	var latestVersion, repositoryURL, packageSource string
+	if err := db.QueryRow(`
+		SELECT latest_version, repository_url, source
+		FROM packages WHERE purl = 'pkg:gem/rails'
+	`).Scan(&latestVersion, &repositoryURL, &packageSource); err != nil {
+		t.Fatalf("failed to read preserved package cache: %v", err)
+	}
+	if latestVersion != "8.0.0" || repositoryURL != "https://example.com/rails" || packageSource != "registry-cache" {
+		t.Errorf("unexpected preserved package cache: %q, %q, %q", latestVersion, repositoryURL, packageSource)
+	}
+
+	var versionLicense, versionIntegrity, versionSource string
+	if err := db.QueryRow(`
+		SELECT license, integrity, source
+		FROM versions WHERE purl = 'pkg:gem/rails@8.0.0'
+	`).Scan(&versionLicense, &versionIntegrity, &versionSource); err != nil {
+		t.Fatalf("failed to read preserved version cache: %v", err)
+	}
+	if versionLicense != "MIT" || versionIntegrity != "sha256-test" || versionSource != "registry-cache" {
+		t.Errorf("unexpected preserved version cache: %q, %q, %q", versionLicense, versionIntegrity, versionSource)
+	}
+
+	var summary, packageName string
+	if err := db.QueryRow("SELECT summary FROM vulnerabilities WHERE id = 'TEST-1'").Scan(&summary); err != nil {
+		t.Fatalf("failed to read preserved vulnerability: %v", err)
+	}
+	if err := db.QueryRow("SELECT package_name FROM vulnerability_packages WHERE vulnerability_id = 'TEST-1'").Scan(&packageName); err != nil {
+		t.Fatalf("failed to read preserved vulnerability package: %v", err)
+	}
+	if summary != "test vulnerability" || packageName != "rails" {
+		t.Errorf("unexpected preserved vulnerability cache: %q, %q", summary, packageName)
+	}
+}
+
+func testUpgradeVersion5Schema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	createVersion5Database(t, dbPath)
+
+	rebuildErr := errors.New("stop after schema migration")
+	_, result, err := database.OpenWithRebuild(dbPath, func(previous, replacement *database.DB) error {
+		return rebuildErr
+	})
+	if !errors.Is(err, rebuildErr) {
+		t.Fatalf("expected rebuild to stop after migration, got: %v", err)
+	}
+
+	if result.FromSchemaVersion != 5 || result.ToSchemaVersion != database.SchemaVersion {
+		t.Fatalf("unexpected upgrade result: %+v", result)
+	}
+	if !result.RequiresRebuild() {
+		t.Fatal("expected old indexed data to require a rebuild")
+	}
+
+	db := openRawDatabase(t, dbPath)
+	defer func() { _ = db.Close() }()
+
+	var version int
+	if err := db.QueryRow("SELECT version FROM schema_info LIMIT 1").Scan(&version); err != nil {
+		t.Fatalf("failed to read schema version: %v", err)
+	}
+	if version != database.SchemaVersion {
+		t.Fatalf("expected schema version %d, got %d", database.SchemaVersion, version)
+	}
+
+	var packageName string
+	if err := db.QueryRow("SELECT name FROM packages WHERE id = 1").Scan(&packageName); err != nil {
+		t.Fatalf("failed to read preserved package: %v", err)
+	}
+	if packageName != "rails" {
+		t.Errorf("expected preserved package, got %q", packageName)
+	}
+
+	var direct int
+	if err := db.QueryRow("SELECT direct FROM dependency_snapshots WHERE id = 1").Scan(&direct); err != nil {
+		t.Fatalf("failed to read migrated snapshot: %v", err)
+	}
+	if direct != 0 {
+		t.Errorf("expected migrated direct value 0, got %d", direct)
+	}
+
+	var indexSQL string
+	if err := db.QueryRow("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_snapshots_unique'").Scan(&indexSQL); err != nil {
+		t.Fatalf("failed to read snapshot index: %v", err)
+	}
+	if !strings.Contains(indexSQL, "requirement") {
+		t.Errorf("expected snapshot index to include requirement, got %q", indexSQL)
+	}
+
+	if _, err := db.Exec("INSERT INTO notes (purl, namespace) VALUES (?, ?)", "pkg:gem/rails", "test"); err != nil {
+		t.Fatalf("failed to insert migrated note: %v", err)
+	}
+	var origin string
+	if err := db.QueryRow("SELECT origin FROM notes WHERE purl = ?", "pkg:gem/rails").Scan(&origin); err != nil {
+		t.Fatalf("failed to read migrated note: %v", err)
+	}
+	if origin != "git-pkgs" {
+		t.Errorf("expected default note origin, got %q", origin)
+	}
+}
+
+func testUpgradeVersion8Origin(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	createVersion8DatabaseWithOrigin(t, dbPath)
+
+	db, result, err := database.OpenWithRebuild(dbPath, func(previous, replacement *database.DB) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if !result.Rebuilt {
+		t.Fatal("expected indexed data to be rebuilt")
+	}
+
+	var origin string
+	if err := db.QueryRow("SELECT origin FROM notes WHERE id = 1").Scan(&origin); err != nil {
+		t.Fatalf("failed to read preserved note: %v", err)
+	}
+	if origin != "extension" {
+		t.Errorf("expected preserved origin, got %q", origin)
+	}
+}
+
+func testRejectNewerSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if _, err := db.Exec("UPDATE schema_info SET version = ?", database.SchemaVersion+1); err != nil {
+		t.Fatalf("failed to set newer schema version: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+
+	_, err = database.Open(dbPath)
+	if err == nil {
+		t.Fatal("expected newer schema to be rejected")
+	}
+	if !strings.Contains(err.Error(), "newer than supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func testRejectNewerIndex(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", database.IndexVersion+1)); err != nil {
+		t.Fatalf("failed to set newer index version: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+
+	_, err = database.Open(dbPath)
+	if err == nil {
+		t.Fatal("expected newer index to be rejected")
+	}
+	if !strings.Contains(err.Error(), "index version") || !strings.Contains(err.Error(), "newer than supported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func testMigrationRollback(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	rawDB := openRawDatabase(t, dbPath)
+	if _, err := rawDB.Exec(`
+			CREATE TABLE schema_info (version INTEGER NOT NULL);
+			INSERT INTO schema_info (version) VALUES (14);
+			CREATE TABLE sentinel (value TEXT);
+			INSERT INTO sentinel (value) VALUES ('preserved');
+		`); err != nil {
+		t.Fatalf("failed to create incomplete database: %v", err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("failed to close incomplete database: %v", err)
+	}
+
+	_, err := database.Open(dbPath)
+	if err == nil {
+		t.Fatal("expected migration to fail")
+	}
+
+	rawDB = openRawDatabase(t, dbPath)
+	defer func() { _ = rawDB.Close() }()
+	var version int
+	if err := rawDB.QueryRow("SELECT version FROM schema_info").Scan(&version); err != nil {
+		t.Fatalf("failed to read rolled back schema version: %v", err)
+	}
+	if version != 14 {
+		t.Errorf("expected schema version 14 after rollback, got %d", version)
+	}
+	var value string
+	if err := rawDB.QueryRow("SELECT value FROM sentinel").Scan(&value); err != nil {
+		t.Fatalf("failed to read preserved row: %v", err)
+	}
+	if value != "preserved" {
+		t.Errorf("expected preserved row, got %q", value)
+	}
+}
+
+func testFailedRebuild(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if _, err := db.Exec(`
+			INSERT INTO notes (purl, namespace, message) VALUES ('pkg:gem/rails', 'test', 'keep me');
+			PRAGMA user_version = 2147483647;
+		`); err != nil {
+		t.Fatalf("failed to prepare database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+
+	rebuildErr := errors.New("rebuild failed")
+	_, _, err = database.OpenWithRebuild(dbPath, func(previous, replacement *database.DB) error {
+		return rebuildErr
+	})
+	if !errors.Is(err, rebuildErr) {
+		t.Fatalf("expected rebuild error, got %v", err)
+	}
+
+	rawDB := openRawDatabase(t, dbPath)
+	defer func() { _ = rawDB.Close() }()
+	var indexVersion int
+	if err := rawDB.QueryRow("PRAGMA user_version").Scan(&indexVersion); err != nil {
+		t.Fatalf("failed to read pending index version: %v", err)
+	}
+	if indexVersion == database.IndexVersion {
+		t.Fatal("expected failed rebuild to remain pending")
+	}
+
+	var message string
+	if err := rawDB.QueryRow("SELECT message FROM notes WHERE purl = 'pkg:gem/rails'").Scan(&message); err != nil {
+		t.Fatalf("failed to read preserved note: %v", err)
+	}
+	if message != "keep me" {
+		t.Errorf("expected preserved note, got %q", message)
+	}
+}
+
+func testConcurrentRebuild(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+	rawDB := openRawDatabase(t, dbPath)
+	const rebuildRequiredVersion = 2_147_483_647
+	if _, err := rawDB.Exec("PRAGMA user_version = " + fmt.Sprint(rebuildRequiredVersion)); err != nil {
+		t.Fatalf("failed to mark database for rebuild: %v", err)
+	}
+	if err := rawDB.Close(); err != nil {
+		t.Fatalf("failed to close raw database: %v", err)
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var rebuilds int
+	var wg sync.WaitGroup
+	var rebuildMu sync.Mutex
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			db, _, err := database.OpenWithRebuild(dbPath, func(previous, replacement *database.DB) error {
+				rebuildMu.Lock()
+				rebuilds++
+				rebuildMu.Unlock()
+				return nil
+			})
+			if db != nil {
+				_ = db.Close()
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("concurrent open failed: %v", err)
+		}
+	}
+	if rebuilds != 1 {
+		t.Errorf("expected one rebuild, got %d", rebuilds)
+	}
+}
+
+func testRebuildPreservesPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows only supports changing a file's writable bit")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "pkgs.sqlite3")
+	db, err := database.Create(dbPath)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA user_version = 2147483647"); err != nil {
+		t.Fatalf("failed to mark database for rebuild: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close database: %v", err)
+	}
+	if err := os.Chmod(dbPath, 0o640); err != nil {
+		t.Fatalf("failed to set database permissions: %v", err)
+	}
+
+	db, _, err = database.OpenWithRebuild(dbPath, func(previous, replacement *database.DB) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to rebuild database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close rebuilt database: %v", err)
+	}
+
+	info, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("failed to read rebuilt database permissions: %v", err)
+	}
+	if info.Mode().Perm() != 0o640 {
+		t.Errorf("expected permissions 0640, got %04o", info.Mode().Perm())
+	}
+}
+
+func openRawDatabase(t *testing.T, path string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("failed to open raw database: %v", err)
+	}
+	return db
+}
+
+func createVersion5Database(t *testing.T, path string) {
+	t.Helper()
+	db := openRawDatabase(t, path)
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`
+		CREATE TABLE schema_info (version INTEGER NOT NULL);
+		INSERT INTO schema_info (version) VALUES (5);
+		CREATE TABLE branch_commits (
+			id INTEGER PRIMARY KEY,
+			branch_id INTEGER,
+			commit_id INTEGER,
+			position INTEGER
+		);
+		CREATE TABLE dependency_snapshots (
+			id INTEGER PRIMARY KEY,
+			commit_id INTEGER,
+			manifest_id INTEGER,
+			name TEXT NOT NULL,
+			ecosystem TEXT,
+			purl TEXT,
+			requirement TEXT,
+			dependency_type TEXT,
+			integrity TEXT,
+			created_at DATETIME,
+			updated_at DATETIME
+		);
+		CREATE UNIQUE INDEX idx_snapshots_unique ON dependency_snapshots(commit_id, manifest_id, name);
+		CREATE TABLE dependency_changes (
+			id INTEGER PRIMARY KEY,
+			commit_id INTEGER,
+			manifest_id INTEGER,
+			name TEXT NOT NULL,
+			ecosystem TEXT,
+			purl TEXT,
+			change_type TEXT NOT NULL,
+			requirement TEXT,
+			previous_requirement TEXT,
+			dependency_type TEXT,
+			created_at DATETIME,
+			updated_at DATETIME
+		);
+		CREATE TABLE packages (
+			id INTEGER PRIMARY KEY,
+			purl TEXT NOT NULL,
+			ecosystem TEXT NOT NULL,
+			name TEXT NOT NULL,
+			latest_version TEXT,
+			license TEXT,
+			description TEXT,
+			homepage TEXT,
+			repository_url TEXT,
+			supplier_name TEXT,
+			supplier_type TEXT,
+			source TEXT,
+			enriched_at DATETIME,
+			vulns_synced_at DATETIME,
+			created_at DATETIME,
+			updated_at DATETIME
+		);
+		CREATE TABLE versions (
+			id INTEGER PRIMARY KEY,
+			purl TEXT NOT NULL,
+			package_purl TEXT NOT NULL,
+			license TEXT,
+			published_at DATETIME,
+			integrity TEXT,
+			source TEXT,
+			enriched_at DATETIME,
+			created_at DATETIME,
+			updated_at DATETIME
+		);
+		CREATE TABLE vulnerabilities (
+			id TEXT PRIMARY KEY,
+			aliases TEXT,
+			severity TEXT,
+			cvss_score REAL,
+			cvss_vector TEXT,
+			refs TEXT,
+			summary TEXT,
+			details TEXT,
+			published_at DATETIME,
+			withdrawn_at DATETIME,
+			modified_at DATETIME,
+			fetched_at DATETIME NOT NULL
+		);
+		CREATE TABLE vulnerability_packages (
+			id INTEGER PRIMARY KEY,
+			vulnerability_id TEXT NOT NULL REFERENCES vulnerabilities(id),
+			ecosystem TEXT NOT NULL,
+			package_name TEXT NOT NULL,
+			affected_versions TEXT,
+			fixed_versions TEXT
+		);
+		INSERT INTO branch_commits (id, branch_id, commit_id, position) VALUES (1, 1, 1, 0);
+		INSERT INTO dependency_snapshots (id, commit_id, manifest_id, name, requirement) VALUES (1, 1, 1, 'rails', '8.0.0');
+		INSERT INTO dependency_changes (id, name, change_type) VALUES (1, 'rails', 'added');
+		INSERT INTO packages (
+			id, purl, ecosystem, name, latest_version, license, description, homepage,
+			repository_url, supplier_name, supplier_type, source
+		) VALUES (
+			1, 'pkg:gem/rails', 'rubygems', 'rails', '8.0.0', 'MIT', 'web framework',
+			'https://rubyonrails.org', 'https://example.com/rails', 'Rails team', 'organization',
+			'registry-cache'
+		);
+		INSERT INTO versions (id, purl, package_purl, license, integrity, source)
+		VALUES (1, 'pkg:gem/rails@8.0.0', 'pkg:gem/rails', 'MIT', 'sha256-test', 'registry-cache');
+		INSERT INTO vulnerabilities (id, summary, fetched_at)
+		VALUES ('TEST-1', 'test vulnerability', '2026-01-01');
+		INSERT INTO vulnerability_packages (id, vulnerability_id, ecosystem, package_name)
+		VALUES (1, 'TEST-1', 'rubygems', 'rails');
+	`); err != nil {
+		t.Fatalf("failed to create version 5 database: %v", err)
+	}
+}
+
+func createVersion8DatabaseWithOrigin(t *testing.T, path string) {
+	t.Helper()
+	db, err := database.Create(path)
+	if err != nil {
+		t.Fatalf("failed to create database: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO notes (id, purl, origin) VALUES (1, 'pkg:gem/rails', 'extension');
+		UPDATE schema_info SET version = 8;
+		PRAGMA user_version = 0;
+	`); err != nil {
+		t.Fatalf("failed to prepare version 8 database: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("failed to close version 8 database: %v", err)
+	}
 }
 
 func TestMultipleVersionsSamePackage(t *testing.T) {

--- a/internal/database/migrations.go
+++ b/internal/database/migrations.go
@@ -1,0 +1,308 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+const (
+	oldestSchemaVersion            = 5
+	indexVersionIntroducedAtSchema = 15
+	initialIndexVersion            = 1
+	rebuildRequiredIndexVersion    = 2_147_483_647
+	migrationBusyTimeoutMS         = 60_000
+	migrationTypeText              = "TEXT"
+	migrationTypeInteger           = "INTEGER"
+)
+
+// UpgradeResult describes schema and indexed-data changes made while opening a database.
+type UpgradeResult struct {
+	FromSchemaVersion int
+	ToSchemaVersion   int
+	FromIndexVersion  int
+	ToIndexVersion    int
+	Rebuilt           bool
+}
+
+// Upgraded reports whether the schema changed or the index was rebuilt.
+func (r UpgradeResult) Upgraded() bool {
+	return r.FromSchemaVersion != r.ToSchemaVersion || r.Rebuilt
+}
+
+// RequiresRebuild reports whether Git history must be indexed again.
+func (r UpgradeResult) RequiresRebuild() bool {
+	return r.ToIndexVersion != IndexVersion
+}
+
+type schemaMigration func(context.Context, *sql.Conn) error
+
+var schemaMigrations = map[int]schemaMigration{
+	5:  migrateSchema5To6,
+	6:  migrateSchema6To7,
+	7:  migrateSchema7To8,
+	8:  migrateSchema8To9,
+	9:  migrateSchema9To10,
+	10: migrateSchema10To11,
+	11: migrateSchema11To12,
+	12: migrateSchema12To13,
+	13: migrateSchema13To14,
+	14: migrateSchema14To15,
+}
+
+// UpgradeSchema applies all pending schema migrations in one transaction.
+func (db *DB) UpgradeSchema() (result UpgradeResult, err error) {
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return result, fmt.Errorf("getting database connection: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("PRAGMA busy_timeout = %d", migrationBusyTimeoutMS)); err != nil {
+		return result, fmt.Errorf("setting migration lock timeout: %w", err)
+	}
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return result, fmt.Errorf("locking database for schema upgrade: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	currentVersion, err := schemaVersion(ctx, conn)
+	if err != nil {
+		return result, fmt.Errorf("reading schema version: %w", err)
+	}
+	startingVersion := currentVersion
+	currentIndexVersion, err := indexVersion(ctx, conn)
+	if err != nil {
+		return result, fmt.Errorf("reading index version: %w", err)
+	}
+	result = UpgradeResult{
+		FromSchemaVersion: currentVersion,
+		ToSchemaVersion:   currentVersion,
+		FromIndexVersion:  currentIndexVersion,
+		ToIndexVersion:    currentIndexVersion,
+	}
+
+	if currentVersion > SchemaVersion {
+		return result, fmt.Errorf(
+			"database schema version %d is newer than supported version %d; upgrade git-pkgs",
+			currentVersion,
+			SchemaVersion,
+		)
+	}
+	if currentVersion < oldestSchemaVersion {
+		return result, fmt.Errorf(
+			"database schema version %d is too old to upgrade automatically; run 'git pkgs init --force'",
+			currentVersion,
+		)
+	}
+	if currentIndexVersion > IndexVersion && currentIndexVersion != rebuildRequiredIndexVersion {
+		return result, fmt.Errorf(
+			"database index version %d is newer than supported version %d; upgrade git-pkgs",
+			currentIndexVersion,
+			IndexVersion,
+		)
+	}
+
+	for currentVersion < SchemaVersion {
+		migration, ok := schemaMigrations[currentVersion]
+		if !ok {
+			return result, fmt.Errorf("no schema migration from version %d", currentVersion)
+		}
+		if err := migration(ctx, conn); err != nil {
+			return result, fmt.Errorf("upgrading database schema from version %d: %w", currentVersion, err)
+		}
+		currentVersion++
+		if _, err := conn.ExecContext(ctx, "UPDATE schema_info SET version = ?", currentVersion); err != nil {
+			return result, fmt.Errorf("setting schema version to %d: %w", currentVersion, err)
+		}
+		result.ToSchemaVersion = currentVersion
+	}
+
+	if startingVersion >= indexVersionIntroducedAtSchema &&
+		IndexVersion == initialIndexVersion &&
+		currentIndexVersion == 0 {
+		currentIndexVersion = IndexVersion
+	} else if startingVersion < SchemaVersion && currentIndexVersion == 0 {
+		currentIndexVersion = rebuildRequiredIndexVersion
+	}
+	if currentIndexVersion != result.ToIndexVersion {
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", currentIndexVersion)); err != nil {
+			return result, fmt.Errorf("setting index version to %d: %w", currentIndexVersion, err)
+		}
+		result.ToIndexVersion = currentIndexVersion
+	}
+
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return result, fmt.Errorf("committing schema upgrade: %w", err)
+	}
+	return result, nil
+}
+
+func schemaVersion(ctx context.Context, conn *sql.Conn) (int, error) {
+	var version int
+	err := conn.QueryRowContext(ctx, "SELECT version FROM schema_info LIMIT 1").Scan(&version)
+	return version, err
+}
+
+func indexVersion(ctx context.Context, conn *sql.Conn) (int, error) {
+	var version int
+	err := conn.QueryRowContext(ctx, "PRAGMA user_version").Scan(&version)
+	return version, err
+}
+
+func migrateSchema5To6(ctx context.Context, conn *sql.Conn) error {
+	if err := execMigrationStatements(ctx, conn,
+		"CREATE INDEX IF NOT EXISTS idx_branch_commits_position ON branch_commits(branch_id, position DESC)",
+	); err != nil {
+		return err
+	}
+	return addColumn(ctx, conn, "packages", "registry_url", migrationTypeText)
+}
+
+func migrateSchema6To7(ctx context.Context, conn *sql.Conn) error {
+	return execMigrationStatements(ctx, conn,
+		"DROP INDEX IF EXISTS idx_snapshots_unique",
+		"CREATE UNIQUE INDEX idx_snapshots_unique ON dependency_snapshots(commit_id, manifest_id, name, requirement)",
+	)
+}
+
+func migrateSchema7To8(ctx context.Context, conn *sql.Conn) error {
+	return execMigrationStatements(ctx, conn, `
+		CREATE TABLE IF NOT EXISTS notes (
+			id INTEGER PRIMARY KEY,
+			purl TEXT NOT NULL,
+			namespace TEXT NOT NULL DEFAULT '',
+			message TEXT,
+			metadata TEXT,
+			created_at DATETIME,
+			updated_at DATETIME
+		)`,
+		"CREATE UNIQUE INDEX IF NOT EXISTS idx_notes_purl_namespace ON notes(purl, namespace)",
+		"CREATE INDEX IF NOT EXISTS idx_notes_namespace ON notes(namespace)",
+	)
+}
+
+func migrateSchema8To9(ctx context.Context, conn *sql.Conn) error {
+	if err := addColumn(ctx, conn, "notes", "origin", "TEXT NOT NULL DEFAULT 'git-pkgs'"); err != nil {
+		return err
+	}
+	return addColumn(ctx, conn, "dependency_changes", "previous_dependency_type", migrationTypeText)
+}
+
+func migrateSchema9To10(ctx context.Context, conn *sql.Conn) error {
+	for _, column := range []struct {
+		name       string
+		definition string
+	}{
+		{name: "status", definition: migrationTypeText},
+		{name: "status_checked_at", definition: "DATETIME"},
+		{name: "metadata", definition: migrationTypeText},
+	} {
+		if err := addColumn(ctx, conn, "versions", column.name, column.definition); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func migrateSchema10To11(ctx context.Context, conn *sql.Conn) error {
+	if err := addColumn(ctx, conn, "packages", "funding_links", migrationTypeText); err != nil {
+		return err
+	}
+	return addColumn(ctx, conn, "packages", "funding_synced_at", "DATETIME")
+}
+
+func migrateSchema11To12(ctx context.Context, conn *sql.Conn) error {
+	if err := addColumn(ctx, conn, "packages", "maintainers", migrationTypeText); err != nil {
+		return err
+	}
+	return addColumn(ctx, conn, "packages", "maintainers_synced_at", "DATETIME")
+}
+
+func migrateSchema12To13(ctx context.Context, conn *sql.Conn) error {
+	for _, column := range []struct {
+		name       string
+		definition string
+	}{
+		{name: "downloads", definition: migrationTypeInteger},
+		{name: "downloads_period", definition: migrationTypeText},
+		{name: "dependent_packages_count", definition: migrationTypeInteger},
+		{name: "dependent_repos_count", definition: migrationTypeInteger},
+		{name: "health_synced_at", definition: "DATETIME"},
+	} {
+		if err := addColumn(ctx, conn, "packages", column.name, column.definition); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func migrateSchema13To14(ctx context.Context, conn *sql.Conn) error {
+	if err := addColumn(ctx, conn, "versions", "integrity_checked_at", "DATETIME"); err != nil {
+		return err
+	}
+	return execMigrationStatements(ctx, conn, `
+		CREATE TABLE IF NOT EXISTS version_lists (
+			package_purl TEXT PRIMARY KEY,
+			synced_at DATETIME NOT NULL
+		)`,
+	)
+}
+
+func migrateSchema14To15(ctx context.Context, conn *sql.Conn) error {
+	return addColumn(ctx, conn, "dependency_snapshots", "direct", "INTEGER NOT NULL DEFAULT 0")
+}
+
+func execMigrationStatements(ctx context.Context, conn *sql.Conn, statements ...string) error {
+	for _, statement := range statements {
+		if _, err := conn.ExecContext(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func addColumn(ctx context.Context, conn *sql.Conn, table, column, definition string) error {
+	exists, err := columnExists(ctx, conn, table, column)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+
+	statement := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, definition)
+	_, err = conn.ExecContext(ctx, statement)
+	return err
+}
+
+func columnExists(ctx context.Context, conn *sql.Conn, table, column string) (bool, error) {
+	rows, err := conn.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			columnID     int
+			name         string
+			columnType   string
+			notNull      int
+			defaultValue sql.NullString
+			primaryKey   int
+		)
+		if err := rows.Scan(&columnID, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
+			return false, err
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}

--- a/internal/database/migrations_internal_test.go
+++ b/internal/database/migrations_internal_test.go
@@ -1,0 +1,11 @@
+package database
+
+import "testing"
+
+func TestSchemaMigrationsCoverSupportedVersions(t *testing.T) {
+	for version := oldestSchemaVersion; version < SchemaVersion; version++ {
+		if _, ok := schemaMigrations[version]; !ok {
+			t.Errorf("missing schema migration from version %d", version)
+		}
+	}
+}

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -690,6 +690,7 @@ type DatabaseInfo struct {
 	Path            string           `json:"path"`
 	SizeBytes       int64            `json:"size_bytes"`
 	SchemaVersion   int              `json:"schema_version"`
+	IndexVersion    int              `json:"index_version"`
 	BranchName      string           `json:"branch_name"`
 	LastAnalyzedSHA string           `json:"last_analyzed_sha"`
 	RowCounts       map[string]int   `json:"row_counts"`
@@ -708,6 +709,9 @@ func (db *DB) GetDatabaseInfo() (*DatabaseInfo, error) {
 		return nil, err
 	}
 	info.SchemaVersion = version
+	if err := db.QueryRow("PRAGMA user_version").Scan(&info.IndexVersion); err != nil {
+		return nil, err
+	}
 
 	// Get branch info
 	branchInfo, err := db.GetDefaultBranch()

--- a/internal/database/rebuild.go
+++ b/internal/database/rebuild.go
@@ -1,0 +1,268 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gofrs/flock"
+)
+
+// Add new user-owned or cache tables here. Git-derived tables are rebuilt.
+var preservedTables = []string{
+	"packages",
+	"versions",
+	"version_lists",
+	"vulnerabilities",
+	"vulnerability_packages",
+	"notes",
+}
+
+// RebuildFunc populates Git-derived tables in a fresh replacement database.
+type RebuildFunc func(previous, replacement *DB) error
+
+// RebuildRequiredError is returned when derived data is out of date and no
+// rebuild function was supplied.
+type RebuildRequiredError struct {
+	CurrentVersion int
+	TargetVersion  int
+}
+
+func (e *RebuildRequiredError) Error() string {
+	return fmt.Sprintf(
+		"database index version %d must be rebuilt for version %d",
+		e.CurrentVersion,
+		e.TargetVersion,
+	)
+}
+
+// OpenWithRebuild upgrades a database and uses rebuild when its derived data is
+// out of date. The existing file is replaced only after rebuild succeeds.
+func OpenWithRebuild(path string, rebuild RebuildFunc) (*DB, UpgradeResult, error) {
+	return openWithDatabaseLock(path, func() (*DB, UpgradeResult, error) {
+		previous, result, err := openAndUpgrade(path)
+		if err != nil {
+			return nil, result, err
+		}
+		if !result.RequiresRebuild() {
+			return previous, result, nil
+		}
+		if rebuild == nil {
+			_ = previous.Close()
+			return nil, result, &RebuildRequiredError{
+				CurrentVersion: result.ToIndexVersion,
+				TargetVersion:  IndexVersion,
+			}
+		}
+
+		replacementPath, err := createReplacementPath(path)
+		if err != nil {
+			_ = previous.Close()
+			return nil, result, err
+		}
+		defer func() { _ = os.Remove(replacementPath) }()
+
+		replacement, err := Create(replacementPath)
+		if err != nil {
+			_ = previous.Close()
+			return nil, result, fmt.Errorf("creating replacement database: %w", err)
+		}
+
+		if err := rebuild(previous, replacement); err != nil {
+			_ = replacement.Close()
+			_ = previous.Close()
+			return nil, result, err
+		}
+		if err := copyPreservedData(previous, replacement); err != nil {
+			_ = replacement.Close()
+			_ = previous.Close()
+			return nil, result, fmt.Errorf("preserving database data: %w", err)
+		}
+		if err := closeForReplacement(previous, replacement); err != nil {
+			return nil, result, err
+		}
+		if err := preserveDatabaseMode(path, replacementPath); err != nil {
+			return nil, result, err
+		}
+		if err := replaceDatabase(path, replacementPath); err != nil {
+			return nil, result, err
+		}
+
+		upgraded, finalResult, err := openAndUpgrade(path)
+		if err != nil {
+			return nil, result, fmt.Errorf("opening rebuilt database: %w", err)
+		}
+		result.ToSchemaVersion = finalResult.ToSchemaVersion
+		result.ToIndexVersion = finalResult.ToIndexVersion
+		result.Rebuilt = true
+		return upgraded, result, nil
+	})
+}
+
+func openWithDatabaseLock(
+	path string,
+	operation func() (*DB, UpgradeResult, error),
+) (db *DB, result UpgradeResult, err error) {
+	upgradeLock := flock.New(path + ".upgrade.lock")
+	if err := upgradeLock.Lock(); err != nil {
+		return nil, result, fmt.Errorf("locking database upgrade: %w", err)
+	}
+	defer func() {
+		if closeErr := upgradeLock.Close(); err == nil && closeErr != nil {
+			if db != nil {
+				_ = db.Close()
+				db = nil
+			}
+			err = fmt.Errorf("unlocking database upgrade: %w", closeErr)
+		}
+	}()
+
+	return operation()
+}
+
+func createReplacementPath(path string) (string, error) {
+	file, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".upgrade-*")
+	if err != nil {
+		return "", fmt.Errorf("creating replacement database path: %w", err)
+	}
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		return "", fmt.Errorf("closing replacement database file: %w", err)
+	}
+	return name, nil
+}
+
+func copyPreservedData(previous, replacement *DB) (err error) {
+	ctx := context.Background()
+	conn, err := replacement.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.ExecContext(ctx, "ATTACH DATABASE ? AS previous", previous.path); err != nil {
+		return err
+	}
+	defer func() { _, _ = conn.ExecContext(ctx, "DETACH DATABASE previous") }()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_, _ = conn.ExecContext(ctx, "ROLLBACK")
+		}
+	}()
+
+	for _, table := range preservedTables {
+		columns, err := tableColumns(ctx, conn, table)
+		if err != nil {
+			return fmt.Errorf("reading %s columns: %w", table, err)
+		}
+		quotedColumns := make([]string, len(columns))
+		for i, column := range columns {
+			quotedColumns[i] = quoteIdentifier(column)
+		}
+		columnList := strings.Join(quotedColumns, ", ")
+		quotedTable := quoteIdentifier(table)
+		statement := fmt.Sprintf(
+			"INSERT OR REPLACE INTO main.%s (%s) SELECT %s FROM previous.%s",
+			quotedTable,
+			columnList,
+			columnList,
+			quotedTable,
+		)
+		if _, err := conn.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("copying %s: %w", table, err)
+		}
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func tableColumns(ctx context.Context, conn *sql.Conn, table string) ([]string, error) {
+	rows, err := conn.QueryContext(ctx, "SELECT name FROM pragma_table_info(?) ORDER BY cid", table)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var columns []string
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return nil, err
+		}
+		columns = append(columns, column)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(columns) == 0 {
+		return nil, fmt.Errorf("table has no columns")
+	}
+	return columns, nil
+}
+
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+func closeForReplacement(previous, replacement *DB) error {
+	if _, err := replacement.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		return fmt.Errorf("checkpointing replacement database: %w", err)
+	}
+	if err := replacement.Close(); err != nil {
+		return fmt.Errorf("closing replacement database: %w", err)
+	}
+	if _, err := previous.Exec("PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		_ = previous.Close()
+		return fmt.Errorf("checkpointing previous database: %w", err)
+	}
+	if err := previous.Close(); err != nil {
+		return fmt.Errorf("closing previous database: %w", err)
+	}
+	return nil
+}
+
+func preserveDatabaseMode(path, replacementPath string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("reading database permissions: %w", err)
+	}
+	if err := os.Chmod(replacementPath, info.Mode().Perm()); err != nil {
+		return fmt.Errorf("preserving database permissions: %w", err)
+	}
+	return nil
+}
+
+func replaceDatabase(path, replacementPath string) error {
+	backupFile, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".backup-*")
+	if err != nil {
+		return fmt.Errorf("creating database backup path: %w", err)
+	}
+	backupPath := backupFile.Name()
+	if err := backupFile.Close(); err != nil {
+		return fmt.Errorf("closing database backup file: %w", err)
+	}
+	if err := os.Remove(backupPath); err != nil {
+		return fmt.Errorf("preparing database backup path: %w", err)
+	}
+
+	if err := os.Rename(path, backupPath); err != nil {
+		return fmt.Errorf("backing up previous database: %w", err)
+	}
+	if err := os.Rename(replacementPath, path); err != nil {
+		if restoreErr := os.Rename(backupPath, path); restoreErr != nil {
+			return fmt.Errorf("installing replacement database: %w; restoring previous database: %v", err, restoreErr)
+		}
+		return fmt.Errorf("installing replacement database: %w", err)
+	}
+	_ = os.Remove(backupPath)
+	return nil
+}

--- a/internal/database/schema.go
+++ b/internal/database/schema.go
@@ -195,6 +195,9 @@ func (db *DB) CreateSchema() error {
 	if _, err := db.Exec("INSERT INTO schema_info (version) VALUES (?)", SchemaVersion); err != nil {
 		return fmt.Errorf("setting schema version: %w", err)
 	}
+	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", IndexVersion)); err != nil {
+		return fmt.Errorf("setting index version: %w", err)
+	}
 
 	return db.OptimizeForReads()
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -15,15 +15,16 @@ import (
 )
 
 type Options struct {
-	Branch           string
-	Revision         string
-	Since            string
-	Output           io.Writer
-	Quiet            bool
-	Incremental      bool // Use existing branch and continue from last SHA
-	BatchSize        int  // Commits to buffer before flushing (default 500)
-	SnapshotInterval int  // Store snapshot every N commits with changes (default 50)
-	EcosystemFilter  config.EcosystemFilter
+	Branch            string
+	Revision          string
+	Since             string
+	Output            io.Writer
+	Quiet             bool
+	FailOnCommitError bool // Stop instead of skipping commits that cannot be loaded or analyzed
+	Incremental       bool // Use existing branch and continue from last SHA
+	BatchSize         int  // Commits to buffer before flushing (default 500)
+	SnapshotInterval  int  // Store snapshot every N commits with changes (default 50)
+	EcosystemFilter   config.EcosystemFilter
 }
 
 type Result struct {
@@ -181,11 +182,17 @@ func (idx *Indexer) Run() (*Result, error) {
 
 			commit, err := idx.repo.CommitObject(hash)
 			if err != nil {
+				if idx.opts.FailOnCommitError {
+					return nil, fmt.Errorf("loading commit %s: %w", hash, err)
+				}
 				continue
 			}
 
 			analysisResult, err := idx.analyzer.AnalyzeCommit(commit, snapshot)
 			if err != nil {
+				if idx.opts.FailOnCommitError {
+					return nil, fmt.Errorf("analyzing commit %s: %w", hash, err)
+				}
 				continue
 			}
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -16,6 +16,7 @@ import (
 
 type Options struct {
 	Branch           string
+	Revision         string
 	Since            string
 	Output           io.Writer
 	Quiet            bool
@@ -132,7 +133,11 @@ func (idx *Indexer) Run() (*Result, error) {
 		sinceSHA = idx.opts.Since
 	}
 
-	commits, err := idx.collectCommits(branch, sinceSHA)
+	revision := idx.opts.Revision
+	if revision == "" {
+		revision = branch
+	}
+	commits, err := idx.collectCommits(revision, sinceSHA)
 	if err != nil {
 		return nil, fmt.Errorf("collecting commits: %w", err)
 	}


### PR DESCRIPTION
Upgrade existing databases when commands open them. Schema changes run in one transaction. Parser and indexer changes can bump `IndexVersion` to rebuild every tracked branch into a replacement database while preserving notes and enrichment caches. `git pkgs info` reports the stored schema and index versions.

The automatic path is serialized across processes, keeps command output clean for hooks and CI, and leaves the existing database in place if rebuilding fails.