### PR TITLE
Use Go 1.26.6 toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/git-pkgs/git-pkgs
 
 go 1.26.5
 
+toolchain go1.26.6
+
 require (
 	github.com/git-pkgs/changelog v0.2.0
 	github.com/git-pkgs/enrichment v0.6.5


### PR DESCRIPTION
Keep the existing minimum Go version while selecting Go 1.26.6 as the preferred toolchain for development and CI.