### PR TITLE
Add structured JSON output for changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,11 +337,13 @@ Checks exact installed versions for registry attestation metadata. Verified trus
 
 ```bash
 git pkgs changelog lodash -e npm --from 4.17.20 --to 4.17.21
+git pkgs changelog lodash -e npm --from 4.17.20 --to 4.17.21 --format json
 git pkgs changelog pkg:cargo/serde --from 1.0.0 --to 1.0.200
 git pkgs changelog express -e npm   # all entries up to latest
 ```
 
 Fetches the upstream changelog for a package and shows entries between two versions. Uses [ecosyste.ms](https://packages.ecosyste.ms/) to find the repository and changelog file, then parses it with [git-pkgs/changelog](https://github.com/git-pkgs/changelog). Supports GitHub and GitLab repositories.
+Text output remains the default; use `--format json` for package metadata and structured per-version entries.
 
 ### Manage dependencies
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -32,7 +33,23 @@ Examples:
 	changelogCmd.Flags().String("to", "", "Target/new version (defaults to latest)")
 	changelogCmd.Flags().StringP("ecosystem", "e", "", "Filter by ecosystem")
 	changelogCmd.Flags().StringP("manager", "m", "", "Override package manager (for ecosystem detection)")
+	changelogCmd.Flags().StringP("format", "f", "text", "Output format: text, json")
 	parent.AddCommand(changelogCmd)
+}
+
+type ChangelogEntry struct {
+	Version string `json:"version"`
+	Content string `json:"content"`
+}
+
+type ChangelogResult struct {
+	Package           string           `json:"package"`
+	Ecosystem         string           `json:"ecosystem"`
+	From              string           `json:"from"`
+	To                string           `json:"to"`
+	Repository        string           `json:"repository"`
+	ChangelogFilename string           `json:"changelog_filename"`
+	Entries           []ChangelogEntry `json:"entries"`
 }
 
 func runChangelog(cmd *cobra.Command, args []string) error {
@@ -40,6 +57,10 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 	fromVersion, _ := cmd.Flags().GetString("from")
 	toVersion, _ := cmd.Flags().GetString("to")
 	managerFlag, _ := cmd.Flags().GetString("manager")
+	format, err := getFormatFlag(cmd, formatText, formatJSON)
+	if err != nil {
+		return err
+	}
 
 	ecosystem, pkg, _, err := ParsePackageArg(args[0], ecosystemFlag)
 	if err != nil {
@@ -94,6 +115,19 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("fetching changelog: %w", err)
 	}
 
+	if format == formatJSON {
+		result := buildChangelogResult(
+			parser,
+			pkg,
+			ecosystem,
+			fromVersion,
+			toVersion,
+			pkgInfo.Repository,
+			pkgInfo.ChangelogFilename,
+		)
+		return outputChangelogJSON(cmd, result)
+	}
+
 	if fromVersion != "" || toVersion != "" {
 		between, ok := parser.Between(fromVersion, toVersion)
 		if !ok {
@@ -126,6 +160,50 @@ func runChangelog(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func buildChangelogResult(
+	parser *changelog.Parser,
+	packageName string,
+	ecosystem string,
+	fromVersion string,
+	toVersion string,
+	repository string,
+	changelogFilename string,
+) *ChangelogResult {
+	result := &ChangelogResult{
+		Package:           packageName,
+		Ecosystem:         ecosystem,
+		From:              fromVersion,
+		To:                toVersion,
+		Repository:        repository,
+		ChangelogFilename: changelogFilename,
+		Entries:           []ChangelogEntry{},
+	}
+
+	versions := parser.Versions()
+	if fromVersion != "" || toVersion != "" {
+		versions = parser.VersionsBetween(fromVersion, toVersion)
+	}
+
+	for _, version := range versions {
+		entry, ok := parser.Entry(version)
+		if !ok {
+			continue
+		}
+		result.Entries = append(result.Entries, ChangelogEntry{
+			Version: version,
+			Content: entry.Content,
+		})
+	}
+
+	return result
+}
+
+func outputChangelogJSON(cmd *cobra.Command, result *ChangelogResult) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
 }
 
 func detectEcosystem(managerFlag string) (string, error) {

--- a/cmd/changelog_internal_test.go
+++ b/cmd/changelog_internal_test.go
@@ -1,8 +1,104 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
+
+	"github.com/git-pkgs/changelog"
+	"github.com/spf13/cobra"
 )
+
+func TestBuildChangelogResult(t *testing.T) {
+	parser := changelog.Parse("## [3.0.0]\n\nThird\n\n## [2.0.0]\n\nSecond\n\n## [1.0.0]\n\nFirst\n")
+
+	t.Run("all entries", func(t *testing.T) {
+		result := buildChangelogResult(
+			parser,
+			"example",
+			"npm",
+			"",
+			"",
+			"https://github.com/example/example",
+			"CHANGELOG.md",
+		)
+		if result.Package != "example" || result.Ecosystem != "npm" {
+			t.Fatalf("result metadata = %+v", result)
+		}
+		if result.Repository != "https://github.com/example/example" ||
+			result.ChangelogFilename != "CHANGELOG.md" {
+			t.Fatalf("result source metadata = %+v", result)
+		}
+		if len(result.Entries) != 3 {
+			t.Fatalf("entries = %+v, want three", result.Entries)
+		}
+		if result.Entries[0].Version != "3.0.0" || result.Entries[0].Content != "Third" {
+			t.Errorf("first entry = %+v", result.Entries[0])
+		}
+	})
+
+	t.Run("bounded entries", func(t *testing.T) {
+		result := buildChangelogResult(
+			parser,
+			"example",
+			"npm",
+			"1.0.0",
+			"3.0.0",
+			"https://github.com/example/example",
+			"CHANGELOG.md",
+		)
+		if result.From != "1.0.0" || result.To != "3.0.0" {
+			t.Fatalf("range = %q..%q", result.From, result.To)
+		}
+		if len(result.Entries) != 2 ||
+			result.Entries[0].Version != "3.0.0" ||
+			result.Entries[1].Version != "2.0.0" {
+			t.Fatalf("entries = %+v, want 3.0.0 and 2.0.0", result.Entries)
+		}
+	})
+
+	t.Run("bounds between headings", func(t *testing.T) {
+		result := buildChangelogResult(
+			parser,
+			"example",
+			"npm",
+			"1.5.0",
+			"2.5.0",
+			"https://github.com/example/example",
+			"CHANGELOG.md",
+		)
+		if len(result.Entries) != 1 || result.Entries[0].Version != "2.0.0" {
+			t.Fatalf("entries = %+v, want 2.0.0", result.Entries)
+		}
+	})
+}
+
+func TestOutputChangelogJSONUsesEmptyArray(t *testing.T) {
+	command := &cobra.Command{}
+	var output bytes.Buffer
+	command.SetOut(&output)
+	result := &ChangelogResult{
+		Package:           "example",
+		Ecosystem:         "npm",
+		Repository:        "https://github.com/example/example",
+		ChangelogFilename: "CHANGELOG.md",
+		Entries:           []ChangelogEntry{},
+	}
+
+	if err := outputChangelogJSON(command, result); err != nil {
+		t.Fatalf("outputChangelogJSON: %v", err)
+	}
+
+	var decoded struct {
+		Entries []ChangelogEntry `json:"entries"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+		t.Fatalf("decoding JSON: %v", err)
+	}
+	if decoded.Entries == nil || len(decoded.Entries) != 0 {
+		t.Fatalf("entries = %#v, want empty non-nil array", decoded.Entries)
+	}
+}
 
 func TestDetectEcosystem(t *testing.T) {
 	t.Run("known manager flag without detection", func(t *testing.T) {

--- a/cmd/format_test.go
+++ b/cmd/format_test.go
@@ -18,6 +18,7 @@ func TestUnsupportedFormatValuesAreRejected(t *testing.T) {
 		{name: "sbom", args: []string{"sbom", "--format", "yaml"}, formats: "json, xml"},
 		{name: "licenses", args: []string{"licenses", "--format", "xml"}, formats: "text, json, csv"},
 		{name: "provenance", args: []string{"provenance", "--format", "yaml"}, formats: "text, json"},
+		{name: "changelog", args: []string{"changelog", "lodash", "--format", "yaml"}, formats: "text, json"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #261

## Summary

- add `--format text|json` support to `git pkgs changelog`
- keep text output as the default
- return package and changelog source metadata in JSON
- return changelog content as structured per-version entries
- validate unsupported formats before ecosystem detection or network requests
- ensure empty JSON results contain `"entries": []`

## JSON Format

```json
{
  "package": "lodash",
  "ecosystem": "npm",
  "from": "4.17.20",
  "to": "4.17.21",
  "repository": "https://github.com/lodash/lodash",
  "changelog_filename": "CHANGELOG.md",
  "entries": [
    {
      "version": "4.17.21",
      "content": "..."
    }
  ]
}
```
Version ranges use changelog.Parser.VersionsBetween, with an exclusive lower bound and inclusive upper bound. This also supports bounds that do not exactly match changelog headings.

## Testing

Added regression coverage for:

- complete structured changelog results
- bounded version ranges
- bounds between existing version headings
- package and source metadata
- empty entries encoded as a JSON array
- unsupported format validation before network access

## Verification

- go build ./...
- go mod tidy -diff
- go test ./... -count=1
- go test -race ./... -count=1
- go tool golangci-lint run ./...
- git diff --check