### PR TITLE
Add source status metadata to network-backed JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ git pkgs vulns show CVE-2024-1234  # details about a specific CVE
 
 Output formats: `text` (default), `json`, and `sarif`. SARIF integrates with GitHub Advanced Security:
 
-The JSON output from `licenses`, `outdated`, `deprecated`, and `vulns scan` is an object with `results` and `sources` arrays. Each source reports its ecosystem, upstream, and `ok`, `error`, or `unsupported` status; partial source failures are retained in `warnings`. Commands return success when at least one source succeeds, allowing consumers to retain partial results.
+The standard JSON output from `licenses` (without `--drift`), `outdated`, `deprecated`, and `vulns scan` is an object with `results` and `sources` arrays. Each source reports its ecosystem, upstream, and `ok`, `error`, or `unsupported` status; partial source failures are retained in `warnings`. Commands return success when at least one source succeeds, allowing consumers to retain partial results.
 
 ```yaml
 - run: git pkgs vulns -f sarif > results.sarif

--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ git pkgs vulns show CVE-2024-1234  # details about a specific CVE
 
 Output formats: `text` (default), `json`, and `sarif`. SARIF integrates with GitHub Advanced Security:
 
+The JSON output from `licenses`, `outdated`, `deprecated`, and `vulns scan` is an object with `results` and `sources` arrays. Each source reports its ecosystem, upstream, and `ok`, `error`, or `unsupported` status; partial source failures are retained in `warnings`. Commands return success when at least one source succeeds, allowing consumers to retain partial results.
+
 ```yaml
 - run: git pkgs vulns -f sarif > results.sarif
 - uses: github/codeql-action/upload-sarif@v3

--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -79,12 +79,11 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(resolved) == 0 {
-		sources = newSourceTracker()
 		if format == formatJSON {
 			if err := outputDeprecatedJSON(cmd, nil, sources); err != nil {
 				return err
 			}
-			return nil
+			return sources.unavailableError()
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No resolved dependencies found.")
 		return nil
@@ -245,7 +244,7 @@ func fetchDeprecatedVersions(
 		if parseErr != nil {
 			continue
 		}
-		ecosystem := parsed.Type
+		ecosystem := canonicalSourceEcosystem(parsed.Type)
 		upstream, _ := registrySource(ecosystem)
 		if result.err != nil {
 			sources.markError(ecosystem, upstream, result.err)
@@ -263,7 +262,7 @@ func fetchDeprecatedVersions(
 			continue
 		}
 		if parsed, err := purl.Parse(purlStr); err == nil {
-			ecosystem := parsed.Type
+			ecosystem := canonicalSourceEcosystem(parsed.Type)
 			upstream, _ := registrySource(ecosystem)
 			sources.markError(ecosystem, upstream, ctx.Err())
 		}
@@ -303,8 +302,11 @@ func cachedDeprecatedVersionDataWithTimes(
 				Status:      registries.VersionStatus(cached.Status),
 				Metadata:    cached.Metadata,
 			}
-			if parsed, err := purl.Parse(cached.PURL); err == nil && cached.StatusCheckedAt.After(checkedAt[parsed.Type]) {
-				checkedAt[parsed.Type] = cached.StatusCheckedAt
+			if parsed, err := purl.Parse(cached.PURL); err == nil {
+				ecosystem := canonicalSourceEcosystem(parsed.Type)
+				if cached.StatusCheckedAt.After(checkedAt[ecosystem]) {
+					checkedAt[ecosystem] = cached.StatusCheckedAt
+				}
 			}
 		}
 	}

--- a/cmd/deprecated.go
+++ b/cmd/deprecated.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/git-pkgs/git-pkgs/internal/database"
@@ -65,6 +65,11 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, ecosystem)
+	sources := newSourceTracker()
+	for _, ecosystem := range ecosystemsFromDependencies(deps) {
+		upstream, supported := registrySource(ecosystem)
+		sources.consider(ecosystem, upstream, supported)
+	}
 
 	var resolved []database.Dependency
 	for _, d := range deps {
@@ -74,8 +79,12 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(resolved) == 0 {
+		sources = newSourceTracker()
 		if format == formatJSON {
-			return outputDeprecatedJSON(cmd, []DeprecatedPackage{})
+			if err := outputDeprecatedJSON(cmd, nil, sources); err != nil {
+				return err
+			}
+			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No resolved dependencies found.")
 		return nil
@@ -84,8 +93,13 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 	versionedPURLs := make([]string, 0, len(resolved))
 	purlToDeps := make(map[string][]database.Dependency)
 	for _, dep := range resolved {
+		if _, supported := registrySource(dep.Ecosystem); !supported {
+			continue
+		}
 		purlStr := versionedPURLForDependency(dep)
 		if purlStr == "" {
+			upstream, _ := registrySource(dep.Ecosystem)
+			sources.markError(dep.Ecosystem, upstream, fmt.Errorf("could not build versioned package URL for %s", dep.Name))
 			continue
 		}
 		if len(purlToDeps[purlStr]) == 0 {
@@ -94,11 +108,17 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 		purlToDeps[purlStr] = append(purlToDeps[purlStr], dep)
 	}
 
-	versionData := fetchDeprecatedVersionData(db, versionedPURLs)
+	versionData := fetchDeprecatedVersionData(db, versionedPURLs, sources)
 	deprecated := deprecatedPackages(purlToDeps, versionData)
 	if len(deprecated) == 0 {
 		if format == formatJSON {
-			return outputDeprecatedJSON(cmd, []DeprecatedPackage{})
+			if err := outputDeprecatedJSON(cmd, nil, sources); err != nil {
+				return err
+			}
+			return sources.unavailableError()
+		}
+		if err := sources.unavailableError(); err != nil {
+			return err
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No deprecated or withdrawn dependencies found.")
 		return nil
@@ -106,8 +126,14 @@ func runDeprecated(cmd *cobra.Command, args []string) error {
 
 	switch format {
 	case formatJSON:
-		return outputDeprecatedJSON(cmd, deprecated)
+		if err := outputDeprecatedJSON(cmd, deprecated, sources); err != nil {
+			return err
+		}
+		return sources.unavailableError()
 	default:
+		if err := sources.unavailableError(); err != nil {
+			return err
+		}
 		outputDeprecatedText(cmd, deprecated)
 		return nil
 	}
@@ -137,12 +163,21 @@ func isDefaultCargoIndex(purlType, registryURL string) bool {
 	return registryURL == "https://github.com/rust-lang/crates.io-index" || registryURL == "https://index.crates.io"
 }
 
-func fetchDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[string]*registries.Version {
+func fetchDeprecatedVersionData(
+	db *database.DB,
+	versionedPURLs []string,
+	trackers ...*sourceTracker,
+) map[string]*registries.Version {
+	sources := sourceTrackerOrNew(trackers)
 	if len(versionedPURLs) == 0 {
 		return map[string]*registries.Version{}
 	}
 
-	versionData := cachedDeprecatedVersionData(db, versionedPURLs)
+	versionData, cachedAt := cachedDeprecatedVersionDataWithTimes(db, versionedPURLs)
+	for ecosystem, checkedAt := range cachedAt {
+		upstream, _ := registrySource(ecosystem)
+		sources.markOK(ecosystem, upstream, checkedAt)
+	}
 	misses := missingVersionedPURLs(versionedPURLs, versionData)
 	if len(misses) == 0 {
 		return versionData
@@ -152,7 +187,7 @@ func fetchDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[st
 	ctx, cancel := context.WithTimeout(context.Background(), deprecatedLookupTimeout)
 	defer cancel()
 
-	fetched := registries.BulkFetchVersions(ctx, misses, registries.NewClient().WithUserAgent(userAgent))
+	fetched := fetchDeprecatedVersions(ctx, misses, registries.NewClient().WithUserAgent(userAgent), sources)
 	for purlStr, version := range fetched {
 		versionData[purlStr] = version
 	}
@@ -161,10 +196,94 @@ func fetchDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[st
 	return versionData
 }
 
+type deprecatedVersionResult struct {
+	purl    string
+	version *registries.Version
+	err     error
+}
+
+func fetchDeprecatedVersions(
+	ctx context.Context,
+	versionedPURLs []string,
+	client *registries.Client,
+	sources *sourceTracker,
+) map[string]*registries.Version {
+	const concurrency = 15
+	workers := min(concurrency, len(versionedPURLs))
+	jobs := make(chan string)
+	results := make(chan deprecatedVersionResult, len(versionedPURLs))
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for purlStr := range jobs {
+				version, err := registries.FetchVersionFromPURL(ctx, purlStr, client)
+				results <- deprecatedVersionResult{purl: purlStr, version: version, err: err}
+			}
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, purlStr := range versionedPURLs {
+			select {
+			case jobs <- purlStr:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	close(results)
+
+	fetched := make(map[string]*registries.Version)
+	seen := make(map[string]bool)
+	for result := range results {
+		seen[result.purl] = true
+		parsed, parseErr := purl.Parse(result.purl)
+		if parseErr != nil {
+			continue
+		}
+		ecosystem := parsed.Type
+		upstream, _ := registrySource(ecosystem)
+		if result.err != nil {
+			sources.markError(ecosystem, upstream, result.err)
+			continue
+		}
+		if result.version == nil {
+			sources.markError(ecosystem, upstream, fmt.Errorf("no version metadata returned for %s", result.purl))
+			continue
+		}
+		fetched[result.purl] = result.version
+		sources.markOK(ecosystem, upstream, time.Now().UTC())
+	}
+	for _, purlStr := range versionedPURLs {
+		if seen[purlStr] {
+			continue
+		}
+		if parsed, err := purl.Parse(purlStr); err == nil {
+			ecosystem := parsed.Type
+			upstream, _ := registrySource(ecosystem)
+			sources.markError(ecosystem, upstream, ctx.Err())
+		}
+	}
+	return fetched
+}
+
 func cachedDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[string]*registries.Version {
+	result, _ := cachedDeprecatedVersionDataWithTimes(db, versionedPURLs)
+	return result
+}
+
+func cachedDeprecatedVersionDataWithTimes(
+	db *database.DB,
+	versionedPURLs []string,
+) (map[string]*registries.Version, map[string]time.Time) {
 	result := make(map[string]*registries.Version)
+	checkedAt := make(map[string]time.Time)
 	if db == nil {
-		return result
+		return result, checkedAt
 	}
 
 	staleThreshold := time.Now().Add(-enrichmentCacheTTL)
@@ -184,10 +303,13 @@ func cachedDeprecatedVersionData(db *database.DB, versionedPURLs []string) map[s
 				Status:      registries.VersionStatus(cached.Status),
 				Metadata:    cached.Metadata,
 			}
+			if parsed, err := purl.Parse(cached.PURL); err == nil && cached.StatusCheckedAt.After(checkedAt[parsed.Type]) {
+				checkedAt[parsed.Type] = cached.StatusCheckedAt
+			}
 		}
 	}
 
-	return result
+	return result, checkedAt
 }
 
 func missingVersionedPURLs(versionedPURLs []string, versionData map[string]*registries.Version) []string {
@@ -315,10 +437,9 @@ func stringMetadata(value any) (string, bool) {
 	}
 }
 
-func outputDeprecatedJSON(cmd *cobra.Command, deprecated []DeprecatedPackage) error {
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(deprecated)
+func outputDeprecatedJSON(cmd *cobra.Command, deprecated []DeprecatedPackage, trackers ...*sourceTracker) error {
+	sources := sourceTrackerOrNew(trackers)
+	return outputResultEnvelope(cmd, resultEnvelope(sources, deprecated, time.Now().UTC()))
 }
 
 func outputDeprecatedText(cmd *cobra.Command, deprecated []DeprecatedPackage) {

--- a/cmd/deprecated_test.go
+++ b/cmd/deprecated_test.go
@@ -187,7 +187,7 @@ func TestCachedDeprecatedVersionDataIgnoresUncheckedStatus(t *testing.T) {
 	}
 }
 
-func TestOutputDeprecatedJSONEmptySlice(t *testing.T) {
+func TestOutputDeprecatedJSONEmptyEnvelope(t *testing.T) {
 	var out bytes.Buffer
 	cmd := &cobra.Command{}
 	cmd.SetOut(&out)
@@ -195,7 +195,7 @@ func TestOutputDeprecatedJSONEmptySlice(t *testing.T) {
 	if err := outputDeprecatedJSON(cmd, []DeprecatedPackage{}); err != nil {
 		t.Fatalf("output json: %v", err)
 	}
-	if got := strings.TrimSpace(out.String()); got != "[]" {
-		t.Fatalf("json output = %q, want []", got)
+	if got := strings.TrimSpace(out.String()); got != "{\n  \"results\": [],\n  \"sources\": []\n}" {
+		t.Fatalf("json output = %q, want empty result envelope", got)
 	}
 }

--- a/cmd/enrichment.go
+++ b/cmd/enrichment.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/git-pkgs/enrichment"
 )
@@ -25,6 +27,24 @@ var NewEnrichmentClient = enrichment.NewClient
 // applied consistently.
 func newEnrichmentClient() (enrichment.Client, error) {
 	return NewEnrichmentClient(enrichmentOptions()...)
+}
+
+func enrichmentDirectMode() bool {
+	if value := os.Getenv("GIT_PKGS_DIRECT"); value != "" {
+		return isTruthy(value)
+	}
+
+	output, err := exec.Command("git", "config", "--get", "pkgs.direct").Output()
+	return err == nil && isTruthy(string(output))
+}
+
+func isTruthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 func enrichmentOptions() []enrichment.Option {

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -120,6 +120,7 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, opts.ecosystem)
+	sources := newSourceTracker()
 
 	if opts.driftOnly {
 		return runLicenseDrift(cmd, db, deps, opts.format, opts.offline)
@@ -127,21 +128,43 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 
 	directDeps := directLicenseDependencies(deps)
 	if len(directDeps) == 0 {
+		sources = newSourceTracker()
 		if opts.format == formatJSON {
-			return outputLicensesJSON(cmd, nil)
+			if err := outputLicensesJSON(cmd, nil, sources); err != nil {
+				return err
+			}
+			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No direct dependencies found.")
 		return nil
 	}
 
 	purls, purlToDep := licensePackageLookups(directDeps)
-	packageData, err := getLicenseData(db, purls, opts.offline)
+	for _, dep := range directDeps {
+		lookupPURL := dep.PURL
+		if lookupPURL == "" {
+			lookupPURL = purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+		}
+		if lookupPURL == "" {
+			sources.markError(dep.Ecosystem, licenseUpstreamForDependency(dep), fmt.Errorf("could not build package URL for %s", dep.Name))
+		}
+	}
+	packageData, err := getLicenseData(db, purls, opts.offline, sources)
 	if err != nil {
 		return fmt.Errorf("looking up packages: %w", err)
 	}
 	resolvedVersionPURLs, resolvedDeps, ambiguousVersions := resolvedLicenseVersions(purlToDep, deps)
-	versionLicenses, versionLicenseErr := loadLicenseVersionLicenses(db, resolvedDeps, opts.offline)
+	versionLicenses, versionLookupErrors, versionLicenseErr := loadLicenseVersionLicensesWithReport(db, resolvedDeps, opts.offline)
+	for _, lookupErr := range versionLookupErrors {
+		ecosystem := ecosystemFromPURL(lookupErr.VersionedPURL)
+		sources.markError(ecosystem, licenseUpstreamForPURL(lookupErr.VersionedPURL), lookupErr.Err)
+	}
 	if versionLicenseErr != nil {
+		if len(versionLookupErrors) == 0 {
+			for _, dep := range resolvedDeps {
+				sources.markError(dep.Ecosystem, licenseUpstreamForDependency(dep), versionLicenseErr)
+			}
+		}
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
 			"Warning: version license lookup failed; using package metadata where version data is unavailable: %v\n",
 			versionLicenseErr,
@@ -158,7 +181,10 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 	)
 	warnAmbiguousLicenseFallbacks(cmd, result.ambiguousFallbacks)
 
-	if err := outputLicenses(cmd, result.infos, opts.format, opts.groupBy); err != nil {
+	if err := outputLicenses(cmd, result.infos, opts.format, opts.groupBy, sources); err != nil {
+		return err
+	}
+	if err := sources.unavailableError(); err != nil {
 		return err
 	}
 	if result.hasViolations {
@@ -394,10 +420,17 @@ func warnAmbiguousLicenseFallbacks(cmd *cobra.Command, fallbacks []string) {
 	)
 }
 
-func outputLicenses(cmd *cobra.Command, infos []LicenseInfo, format string, groupBy bool) error {
+func outputLicenses(
+	cmd *cobra.Command,
+	infos []LicenseInfo,
+	format string,
+	groupBy bool,
+	trackers ...*sourceTracker,
+) error {
+	sources := sourceTrackerOrNew(trackers)
 	switch format {
 	case formatJSON:
-		return outputLicensesJSON(cmd, infos)
+		return outputLicensesJSON(cmd, infos, sources)
 	case formatCSV:
 		return outputLicensesCSV(cmd, infos)
 	default:
@@ -441,28 +474,92 @@ type licenseData struct {
 	Name          string
 	Ecosystem     string
 	LatestVersion string
+	RegistryURL   string
+	Source        string
+	FetchedAt     time.Time
+}
+
+const licenseDefaultUpstream = "packages.ecosyste.ms"
+
+func licenseUpstreamForDependency(dep database.Dependency) string {
+	purlStr := dep.PURL
+	if purlStr == "" {
+		purlStr = purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+	}
+	return licenseUpstreamForPURL(purlStr)
+}
+
+func licenseUpstreamForPURL(purlStr string) string {
+	parsed, err := purl.Parse(purlStr)
+	if err == nil {
+		if repositoryURL := parsed.RepositoryURL(); repositoryURL != "" {
+			return sourceHostname(repositoryURL)
+		}
+	}
+	return licenseDefaultUpstream
+}
+
+func licenseUpstreamForData(purlStr string, data *licenseData) string {
+	if data == nil {
+		return licenseUpstreamForPURL(purlStr)
+	}
+	switch data.Source {
+	case "registries":
+		if data.RegistryURL != "" {
+			return sourceHostname(data.RegistryURL)
+		}
+		if upstream, supported := registrySource(data.Ecosystem); supported {
+			return upstream
+		}
+	case "depsdev":
+		return "api.deps.dev"
+	}
+	return licenseDefaultUpstream
+}
+
+func ecosystemFromPURL(purlStr string) string {
+	parsed, err := purl.Parse(purlStr)
+	if err != nil {
+		return ""
+	}
+	return parsed.Type
+}
+
+func markLicenseDataSources(sources *sourceTracker, data map[string]*licenseData) {
+	for purlStr, packageData := range data {
+		ecosystem := ecosystemFromPURL(purlStr)
+		upstream := licenseUpstreamForData(purlStr, packageData)
+		sources.consider(ecosystem, upstream, true)
+		sources.markOK(ecosystem, upstream, packageData.FetchedAt)
+	}
 }
 
 func getLicenseData(
 	db *database.DB,
 	purls []string,
 	offline bool,
+	sources *sourceTracker,
 ) (map[string]*licenseData, error) {
 	result, uncachedPURLs, err := cachedLicenseData(db, purls, offline)
 	if err != nil {
 		return nil, err
 	}
+	markLicenseDataSources(sources, result)
 	if offline && len(uncachedPURLs) > 0 {
-		return nil, fmt.Errorf(
-			"offline mode: license metadata is not cached for %d package(s); run 'git pkgs licenses' without --offline to populate the cache",
-			len(uncachedPURLs),
-		)
+		for _, purlStr := range uncachedPURLs {
+			sources.markError(
+				ecosystemFromPURL(purlStr),
+				licenseUpstreamForPURL(purlStr),
+				fmt.Errorf("offline mode: license metadata is not cached for %s", purlStr),
+			)
+		}
+		return result, nil
 	}
 	if len(uncachedPURLs) == 0 {
 		return result, nil
 	}
 
-	fetched, err := fetchLicenseData(db, uncachedPURLs)
+	fetched, err := fetchLicenseData(db, uncachedPURLs, sources)
 	if err != nil {
 		return nil, err
 	}
@@ -499,6 +596,9 @@ func cachedLicenseData(
 			Name:          pkg.Name,
 			Ecosystem:     pkg.Ecosystem,
 			LatestVersion: pkg.LatestVersion,
+			RegistryURL:   pkg.RegistryURL,
+			Source:        pkg.Source,
+			FetchedAt:     pkg.EnrichedAt,
 		}
 	}
 	uncached := make([]string, 0, len(purls)-len(cached))
@@ -510,26 +610,57 @@ func cachedLicenseData(
 	return result, uncached, nil
 }
 
-func fetchLicenseData(db *database.DB, purls []string) (map[string]*licenseData, error) {
+func fetchLicenseData(
+	db *database.DB,
+	purls []string,
+	sources *sourceTracker,
+) (map[string]*licenseData, error) {
 	client, err := newEnrichmentClient()
 	if err != nil {
-		return nil, err
+		for _, purlStr := range purls {
+			sources.markError(ecosystemFromPURL(purlStr), licenseUpstreamForPURL(purlStr), err)
+		}
+		return map[string]*licenseData{}, nil
 	}
 
 	const licensesTimeout = 5 * time.Minute
 	ctx, cancel := context.WithTimeout(context.Background(), licensesTimeout)
 	defer cancel()
 
-	packages, err := client.BulkLookup(ctx, purls)
-	if err != nil {
-		return nil, wrapEcosystemsError(err)
+	result := make(map[string]*licenseData)
+	purlsBySource := make(map[sourceKey][]string)
+	for _, purlStr := range purls {
+		key := sourceKey{ecosystem: ecosystemFromPURL(purlStr), upstream: licenseUpstreamForPURL(purlStr)}
+		purlsBySource[key] = append(purlsBySource[key], purlStr)
 	}
-
-	result := make(map[string]*licenseData, len(packages))
-	for purl, pkg := range packages {
-		result[purl] = licenseDataFromPackage(pkg)
-		if db != nil && pkg != nil {
-			_ = db.SavePackageEnrichment(purl, pkg.Ecosystem, pkg.Name, pkg.LatestVersion, pkg.License, pkg.RegistryURL, pkg.Source)
+	for key, sourcePURLs := range purlsBySource {
+		packages, lookupErr := client.BulkLookup(ctx, sourcePURLs)
+		if lookupErr != nil {
+			sources.markError(key.ecosystem, key.upstream, wrapEcosystemsError(lookupErr))
+			continue
+		}
+		fetchedAt := time.Now().UTC()
+		for _, purlStr := range sourcePURLs {
+			pkg := packages[purlStr]
+			if pkg == nil {
+				sources.markError(key.ecosystem, key.upstream, fmt.Errorf("no package metadata returned for %s", purlStr))
+				continue
+			}
+			data := licenseDataFromPackage(pkg)
+			data.FetchedAt = fetchedAt
+			result[purlStr] = data
+			sources.markOK(key.ecosystem, licenseUpstreamForData(purlStr, data), fetchedAt)
+			if db != nil {
+				_ = db.SavePackageEnrichment(
+					purlStr,
+					pkg.Ecosystem,
+					pkg.Name,
+					pkg.LatestVersion,
+					pkg.License,
+					pkg.RegistryURL,
+					pkg.Source,
+				)
+			}
 		}
 	}
 	return result, nil
@@ -544,6 +675,8 @@ func licenseDataFromPackage(pkg *enrichment.PackageInfo) *licenseData {
 	data.Ecosystem = pkg.Ecosystem
 	data.LatestVersion = pkg.LatestVersion
 	data.License = normalizeLicenseString(pkg.License)
+	data.RegistryURL = pkg.RegistryURL
+	data.Source = pkg.Source
 	return data
 }
 
@@ -688,7 +821,7 @@ func computeLicenseDrift(db *database.DB, deps []database.Dependency, offline bo
 		}
 	}
 
-	packageLicenses, err := getLicenseData(db, packagePURLs, offline)
+	packageLicenses, err := getLicenseData(db, packagePURLs, offline, newSourceTracker())
 	if err != nil {
 		return nil, fmt.Errorf("looking up package licenses: %w", err)
 	}
@@ -762,6 +895,15 @@ func licensePackagePURLForDependency(dep database.Dependency) string {
 }
 
 func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, offline bool) (map[string]string, error) {
+	result, _, err := loadLicenseVersionLicensesWithReport(db, deps, offline)
+	return result, err
+}
+
+func loadLicenseVersionLicensesWithReport(
+	db *database.DB,
+	deps []database.Dependency,
+	offline bool,
+) (map[string]string, []licenseVersionLookupError, error) {
 	needed := make(map[string]map[string]bool)
 	for _, dep := range deps {
 		versionedPURL := versionedPURLForDependency(dep)
@@ -790,10 +932,10 @@ func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, off
 		}
 	}
 	if len(missing) == 0 {
-		return result, nil
+		return result, nil, nil
 	}
 	if offline {
-		return result, fmt.Errorf(
+		return result, nil, fmt.Errorf(
 			"offline mode: license metadata is not cached for %d package version(s); rerun without --offline to populate the cache",
 			len(missing),
 		)
@@ -801,7 +943,7 @@ func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, off
 
 	client, err := newEnrichmentClient()
 	if err != nil {
-		return result, err
+		return result, nil, err
 	}
 
 	const licenseDriftLookupTimeout = 5 * time.Minute
@@ -817,11 +959,15 @@ func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, off
 		result[fetchedVersion.VersionedPURL] = normalizeLicenseString(fetchedVersion.Version.License)
 	}
 	if len(fetchErrors) == len(missing) {
-		return result, fmt.Errorf("fetching license version metadata failed for all %d uncached versions: %w",
-			len(missing), wrapEcosystemsError(errors.Join(fetchErrors...)))
+		joined := make([]error, 0, len(fetchErrors))
+		for _, fetchErr := range fetchErrors {
+			joined = append(joined, fetchErr.Err)
+		}
+		return result, fetchErrors, fmt.Errorf("fetching license version metadata failed for all %d uncached versions: %w",
+			len(missing), wrapEcosystemsError(errors.Join(joined...)))
 	}
 
-	return result, nil
+	return result, fetchErrors, nil
 }
 
 type licenseDriftVersionLookup struct {
@@ -834,11 +980,16 @@ type fetchedLicenseDriftVersion struct {
 	Version *enrichment.VersionInfo
 }
 
+type licenseVersionLookupError struct {
+	licenseDriftVersionLookup
+	Err error
+}
+
 func fetchLicenseDriftVersions(
 	ctx context.Context,
 	client enrichment.Client,
 	missing []licenseDriftVersionLookup,
-) ([]fetchedLicenseDriftVersion, []error) {
+) ([]fetchedLicenseDriftVersion, []licenseVersionLookupError) {
 	const licenseDriftLookupConcurrency = 8
 
 	workers := licenseDriftLookupConcurrency
@@ -847,7 +998,7 @@ func fetchLicenseDriftVersions(
 	}
 	jobs := make(chan licenseDriftVersionLookup)
 	results := make(chan fetchedLicenseDriftVersion, len(missing))
-	errorsCh := make(chan error, len(missing))
+	errorsCh := make(chan licenseVersionLookupError, len(missing))
 
 	var wg sync.WaitGroup
 	wg.Add(workers)
@@ -857,7 +1008,10 @@ func fetchLicenseDriftVersions(
 			for lookup := range jobs {
 				versionInfo, err := client.GetVersion(ctx, lookup.VersionedPURL)
 				if err != nil {
-					errorsCh <- fmt.Errorf("%s: %w", lookup.VersionedPURL, err)
+					errorsCh <- licenseVersionLookupError{
+						licenseDriftVersionLookup: lookup,
+						Err:                       fmt.Errorf("%s: %w", lookup.VersionedPURL, err),
+					}
 					continue
 				}
 				results <- fetchedLicenseDriftVersion{
@@ -880,7 +1034,7 @@ func fetchLicenseDriftVersions(
 	for result := range results {
 		fetched = append(fetched, result)
 	}
-	var fetchErrors []error
+	var fetchErrors []licenseVersionLookupError
 	for err := range errorsCh {
 		fetchErrors = append(fetchErrors, err)
 	}
@@ -1015,10 +1169,9 @@ func outputLicenseDriftText(cmd *cobra.Command, result *LicenseDriftResult) {
 	}
 }
 
-func outputLicensesJSON(cmd *cobra.Command, infos []LicenseInfo) error {
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(nonNilSlice(infos))
+func outputLicensesJSON(cmd *cobra.Command, infos []LicenseInfo, trackers ...*sourceTracker) error {
+	sources := sourceTrackerOrNew(trackers)
+	return outputResultEnvelope(cmd, resultEnvelope(sources, infos, time.Now().UTC()))
 }
 
 func outputLicensesCSV(cmd *cobra.Command, infos []LicenseInfo) error {

--- a/cmd/licenses.go
+++ b/cmd/licenses.go
@@ -121,19 +121,21 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 
 	deps = filterByEcosystem(deps, opts.ecosystem)
 	sources := newSourceTracker()
+	directMode := enrichmentDirectMode()
 
 	if opts.driftOnly {
-		return runLicenseDrift(cmd, db, deps, opts.format, opts.offline)
+		return runLicenseDrift(cmd, db, deps, opts.format, opts.offline, directMode)
 	}
+
+	considerLicenseSources(sources, deps, directMode)
 
 	directDeps := directLicenseDependencies(deps)
 	if len(directDeps) == 0 {
-		sources = newSourceTracker()
 		if opts.format == formatJSON {
 			if err := outputLicensesJSON(cmd, nil, sources); err != nil {
 				return err
 			}
-			return nil
+			return sources.unavailableError()
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No direct dependencies found.")
 		return nil
@@ -146,23 +148,28 @@ func runLicenses(cmd *cobra.Command, args []string) error {
 			lookupPURL = purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 		}
 		if lookupPURL == "" {
-			sources.markError(dep.Ecosystem, licenseUpstreamForDependency(dep), fmt.Errorf("could not build package URL for %s", dep.Name))
+			sources.markError(dep.Ecosystem, licenseUpstreamForDependency(dep, directMode), fmt.Errorf("could not build package URL for %s", dep.Name))
 		}
 	}
-	packageData, err := getLicenseData(db, purls, opts.offline, sources)
+	packageData, err := getLicenseData(db, purls, opts.offline, sources, directMode)
 	if err != nil {
 		return fmt.Errorf("looking up packages: %w", err)
 	}
 	resolvedVersionPURLs, resolvedDeps, ambiguousVersions := resolvedLicenseVersions(purlToDep, deps)
-	versionLicenses, versionLookupErrors, versionLicenseErr := loadLicenseVersionLicensesWithReport(db, resolvedDeps, opts.offline)
+	versionLicenses, versionLookupErrors, versionLookupSuccesses, versionLicenseErr := loadLicenseVersionLicensesWithReport(db, resolvedDeps, opts.offline)
+	versionFetchedAt := time.Now().UTC()
+	for _, versionedPURL := range versionLookupSuccesses {
+		ecosystem := ecosystemFromPURL(versionedPURL)
+		sources.markOK(ecosystem, licenseUpstreamForPURL(versionedPURL, directMode), versionFetchedAt)
+	}
 	for _, lookupErr := range versionLookupErrors {
 		ecosystem := ecosystemFromPURL(lookupErr.VersionedPURL)
-		sources.markError(ecosystem, licenseUpstreamForPURL(lookupErr.VersionedPURL), lookupErr.Err)
+		sources.markError(ecosystem, licenseUpstreamForPURL(lookupErr.VersionedPURL, directMode), lookupErr.Err)
 	}
 	if versionLicenseErr != nil {
 		if len(versionLookupErrors) == 0 {
 			for _, dep := range resolvedDeps {
-				sources.markError(dep.Ecosystem, licenseUpstreamForDependency(dep), versionLicenseErr)
+				sources.markError(dep.Ecosystem, licenseUpstreamForDependency(dep, directMode), versionLicenseErr)
 			}
 		}
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
@@ -481,27 +488,59 @@ type licenseData struct {
 
 const licenseDefaultUpstream = "packages.ecosyste.ms"
 
-func licenseUpstreamForDependency(dep database.Dependency) string {
+func considerLicenseSources(sources *sourceTracker, deps []database.Dependency, directMode bool) {
+	directEcosystems := make(map[string]bool)
+	for _, dep := range deps {
+		if dep.ManifestKind != manifestKindManifest {
+			continue
+		}
+		directEcosystems[canonicalSourceEcosystem(dep.Ecosystem)] = true
+	}
+	for _, ecosystem := range ecosystemsFromDependencies(deps) {
+		if directEcosystems[canonicalSourceEcosystem(ecosystem)] {
+			continue
+		}
+		upstream := licenseDefaultUpstream
+		if directMode {
+			if registryUpstream, supported := registrySource(ecosystem); supported {
+				upstream = registryUpstream
+			}
+		}
+		sources.consider(ecosystem, upstream, true)
+	}
+}
+
+func licenseUpstreamForDependency(dep database.Dependency, directMode bool) string {
 	purlStr := dep.PURL
 	if purlStr == "" {
 		purlStr = purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 	}
-	return licenseUpstreamForPURL(purlStr)
+	return licenseUpstreamForPURL(purlStr, directMode)
 }
 
-func licenseUpstreamForPURL(purlStr string) string {
+func licenseUpstreamForPURL(purlStr string, directMode bool) string {
 	parsed, err := purl.Parse(purlStr)
 	if err == nil {
 		if repositoryURL := parsed.RepositoryURL(); repositoryURL != "" {
+			if isDefaultCargoIndex(parsed.Type, repositoryURL) {
+				if upstream, supported := registrySource(parsed.Type); supported {
+					return upstream
+				}
+			}
 			return sourceHostname(repositoryURL)
+		}
+		if directMode {
+			if upstream, supported := registrySource(parsed.Type); supported {
+				return upstream
+			}
 		}
 	}
 	return licenseDefaultUpstream
 }
 
-func licenseUpstreamForData(purlStr string, data *licenseData) string {
+func licenseUpstreamForData(purlStr string, data *licenseData, directMode bool) string {
 	if data == nil {
-		return licenseUpstreamForPURL(purlStr)
+		return licenseUpstreamForPURL(purlStr, directMode)
 	}
 	switch data.Source {
 	case "registries":
@@ -513,8 +552,10 @@ func licenseUpstreamForData(purlStr string, data *licenseData) string {
 		}
 	case "depsdev":
 		return "api.deps.dev"
+	case "ecosystems":
+		return licenseDefaultUpstream
 	}
-	return licenseDefaultUpstream
+	return licenseUpstreamForPURL(purlStr, directMode)
 }
 
 func ecosystemFromPURL(purlStr string) string {
@@ -522,13 +563,13 @@ func ecosystemFromPURL(purlStr string) string {
 	if err != nil {
 		return ""
 	}
-	return parsed.Type
+	return canonicalSourceEcosystem(parsed.Type)
 }
 
-func markLicenseDataSources(sources *sourceTracker, data map[string]*licenseData) {
+func markLicenseDataSources(sources *sourceTracker, data map[string]*licenseData, directMode bool) {
 	for purlStr, packageData := range data {
 		ecosystem := ecosystemFromPURL(purlStr)
-		upstream := licenseUpstreamForData(purlStr, packageData)
+		upstream := licenseUpstreamForData(purlStr, packageData, directMode)
 		sources.consider(ecosystem, upstream, true)
 		sources.markOK(ecosystem, upstream, packageData.FetchedAt)
 	}
@@ -539,17 +580,18 @@ func getLicenseData(
 	purls []string,
 	offline bool,
 	sources *sourceTracker,
+	directMode bool,
 ) (map[string]*licenseData, error) {
 	result, uncachedPURLs, err := cachedLicenseData(db, purls, offline)
 	if err != nil {
 		return nil, err
 	}
-	markLicenseDataSources(sources, result)
+	markLicenseDataSources(sources, result, directMode)
 	if offline && len(uncachedPURLs) > 0 {
 		for _, purlStr := range uncachedPURLs {
 			sources.markError(
 				ecosystemFromPURL(purlStr),
-				licenseUpstreamForPURL(purlStr),
+				licenseUpstreamForPURL(purlStr, directMode),
 				fmt.Errorf("offline mode: license metadata is not cached for %s", purlStr),
 			)
 		}
@@ -559,7 +601,7 @@ func getLicenseData(
 		return result, nil
 	}
 
-	fetched, err := fetchLicenseData(db, uncachedPURLs, sources)
+	fetched, err := fetchLicenseData(db, uncachedPURLs, sources, directMode)
 	if err != nil {
 		return nil, err
 	}
@@ -614,27 +656,27 @@ func fetchLicenseData(
 	db *database.DB,
 	purls []string,
 	sources *sourceTracker,
+	directMode bool,
 ) (map[string]*licenseData, error) {
 	client, err := newEnrichmentClient()
 	if err != nil {
 		for _, purlStr := range purls {
-			sources.markError(ecosystemFromPURL(purlStr), licenseUpstreamForPURL(purlStr), err)
+			sources.markError(ecosystemFromPURL(purlStr), licenseUpstreamForPURL(purlStr, directMode), err)
 		}
 		return map[string]*licenseData{}, nil
 	}
 
-	const licensesTimeout = 5 * time.Minute
-	ctx, cancel := context.WithTimeout(context.Background(), licensesTimeout)
-	defer cancel()
-
 	result := make(map[string]*licenseData)
 	purlsBySource := make(map[sourceKey][]string)
 	for _, purlStr := range purls {
-		key := sourceKey{ecosystem: ecosystemFromPURL(purlStr), upstream: licenseUpstreamForPURL(purlStr)}
+		key := newSourceKey(ecosystemFromPURL(purlStr), licenseUpstreamForPURL(purlStr, directMode))
 		purlsBySource[key] = append(purlsBySource[key], purlStr)
 	}
 	for key, sourcePURLs := range purlsBySource {
+		const licensesTimeout = 5 * time.Minute
+		ctx, cancel := context.WithTimeout(context.Background(), licensesTimeout)
 		packages, lookupErr := client.BulkLookup(ctx, sourcePURLs)
+		cancel()
 		if lookupErr != nil {
 			sources.markError(key.ecosystem, key.upstream, wrapEcosystemsError(lookupErr))
 			continue
@@ -649,7 +691,7 @@ func fetchLicenseData(
 			data := licenseDataFromPackage(pkg)
 			data.FetchedAt = fetchedAt
 			result[purlStr] = data
-			sources.markOK(key.ecosystem, licenseUpstreamForData(purlStr, data), fetchedAt)
+			sources.markOK(key.ecosystem, licenseUpstreamForData(purlStr, data, directMode), fetchedAt)
 			if db != nil {
 				_ = db.SavePackageEnrichment(
 					purlStr,
@@ -771,7 +813,14 @@ func licenseDependencyLocation(dep database.Dependency) string {
 	return strings.ToLower(dep.Ecosystem) + "\x00" + strings.ToLower(dep.Name) + "\x00" + path.Dir(dep.ManifestPath)
 }
 
-func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Dependency, format string, offline bool) error {
+func runLicenseDrift(
+	cmd *cobra.Command,
+	db *database.DB,
+	deps []database.Dependency,
+	format string,
+	offline bool,
+	directMode bool,
+) error {
 	resolved := make([]database.Dependency, 0, len(deps))
 	for _, dep := range deps {
 		if isResolvedDependency(dep) {
@@ -788,7 +837,7 @@ func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Depend
 		return nil
 	}
 
-	result, err := computeLicenseDrift(db, resolved, offline)
+	result, err := computeLicenseDrift(db, resolved, offline, directMode)
 	if err != nil {
 		return err
 	}
@@ -804,7 +853,12 @@ func runLicenseDrift(cmd *cobra.Command, db *database.DB, deps []database.Depend
 	}
 }
 
-func computeLicenseDrift(db *database.DB, deps []database.Dependency, offline bool) (*LicenseDriftResult, error) {
+func computeLicenseDrift(
+	db *database.DB,
+	deps []database.Dependency,
+	offline bool,
+	directMode bool,
+) (*LicenseDriftResult, error) {
 	result := emptyLicenseDriftResult()
 	result.Summary.TotalDependencies = len(deps)
 
@@ -821,8 +875,12 @@ func computeLicenseDrift(db *database.DB, deps []database.Dependency, offline bo
 		}
 	}
 
-	packageLicenses, err := getLicenseData(db, packagePURLs, offline, newSourceTracker())
+	sources := newSourceTracker()
+	packageLicenses, err := getLicenseData(db, packagePURLs, offline, sources, directMode)
 	if err != nil {
+		return nil, fmt.Errorf("looking up package licenses: %w", err)
+	}
+	if err := sources.observedError(); err != nil {
 		return nil, fmt.Errorf("looking up package licenses: %w", err)
 	}
 
@@ -895,7 +953,7 @@ func licensePackagePURLForDependency(dep database.Dependency) string {
 }
 
 func loadLicenseVersionLicenses(db *database.DB, deps []database.Dependency, offline bool) (map[string]string, error) {
-	result, _, err := loadLicenseVersionLicensesWithReport(db, deps, offline)
+	result, _, _, err := loadLicenseVersionLicensesWithReport(db, deps, offline)
 	return result, err
 }
 
@@ -903,7 +961,7 @@ func loadLicenseVersionLicensesWithReport(
 	db *database.DB,
 	deps []database.Dependency,
 	offline bool,
-) (map[string]string, []licenseVersionLookupError, error) {
+) (map[string]string, []licenseVersionLookupError, []string, error) {
 	needed := make(map[string]map[string]bool)
 	for _, dep := range deps {
 		versionedPURL := versionedPURLForDependency(dep)
@@ -932,10 +990,10 @@ func loadLicenseVersionLicensesWithReport(
 		}
 	}
 	if len(missing) == 0 {
-		return result, nil, nil
+		return result, nil, nil, nil
 	}
 	if offline {
-		return result, nil, fmt.Errorf(
+		return result, nil, nil, fmt.Errorf(
 			"offline mode: license metadata is not cached for %d package version(s); rerun without --offline to populate the cache",
 			len(missing),
 		)
@@ -943,7 +1001,7 @@ func loadLicenseVersionLicensesWithReport(
 
 	client, err := newEnrichmentClient()
 	if err != nil {
-		return result, nil, err
+		return result, nil, nil, err
 	}
 
 	const licenseDriftLookupTimeout = 5 * time.Minute
@@ -951,9 +1009,14 @@ func loadLicenseVersionLicensesWithReport(
 	defer cancel()
 
 	fetched, fetchErrors := fetchLicenseDriftVersions(ctx, client, missing)
+	successfulPURLs := make([]string, 0, len(fetched))
 	for _, fetchedVersion := range fetched {
 		saveLicenseDriftVersion(db, fetchedVersion.PackagePURL, fetchedVersion.VersionedPURL, fetchedVersion.Version)
-		if fetchedVersion.Version == nil || fetchedVersion.Version.License == "" {
+		if fetchedVersion.Version == nil {
+			continue
+		}
+		successfulPURLs = append(successfulPURLs, fetchedVersion.VersionedPURL)
+		if fetchedVersion.Version.License == "" {
 			continue
 		}
 		result[fetchedVersion.VersionedPURL] = normalizeLicenseString(fetchedVersion.Version.License)
@@ -963,11 +1026,11 @@ func loadLicenseVersionLicensesWithReport(
 		for _, fetchErr := range fetchErrors {
 			joined = append(joined, fetchErr.Err)
 		}
-		return result, fetchErrors, fmt.Errorf("fetching license version metadata failed for all %d uncached versions: %w",
+		return result, fetchErrors, successfulPURLs, fmt.Errorf("fetching license version metadata failed for all %d uncached versions: %w",
 			len(missing), wrapEcosystemsError(errors.Join(joined...)))
 	}
 
-	return result, fetchErrors, nil
+	return result, fetchErrors, successfulPURLs, nil
 }
 
 type licenseDriftVersionLookup struct {

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -26,6 +26,7 @@ type mockEnrichmentClient struct {
 	getVersionsCalls int
 	getVersionCalls  int
 	bulkLookupCalls  int
+	bulkLookupErr    error
 	getVersionErr    error
 }
 
@@ -33,6 +34,9 @@ func (m *mockEnrichmentClient) BulkLookup(_ context.Context, purls []string) (ma
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.bulkLookupCalls++
+	if m.bulkLookupErr != nil {
+		return nil, m.bulkLookupErr
+	}
 
 	result := make(map[string]*enrichment.PackageInfo)
 	for _, p := range purls {
@@ -749,6 +753,40 @@ func TestLicensesCommand(t *testing.T) {
 		mock.mu.Unlock()
 		if bulkLookupCalls != 0 || getVersionCalls != 0 {
 			t.Fatalf("offline drift made network calls: BulkLookup=%d GetVersion=%d", bulkLookupCalls, getVersionCalls)
+		}
+	})
+
+	t.Run("drift propagates package metadata lookup failures", func(t *testing.T) {
+		mock, restore := setMockEnrichmentClient(&mockEnrichmentClient{
+			packages:      map[string]*enrichment.PackageInfo{},
+			bulkLookupErr: errors.New("package source unavailable"),
+		})
+		defer restore()
+
+		repoDir := createTestRepo(t)
+		addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add lockfile")
+
+		cleanup := chdir(t, repoDir)
+		defer cleanup()
+
+		rootCmd := cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"init"})
+		if err := rootCmd.Execute(); err != nil {
+			t.Fatalf("init failed: %v", err)
+		}
+
+		rootCmd = cmd.NewRootCmd()
+		rootCmd.SetArgs([]string{"licenses", "--drift", "--format", "json"})
+		err := rootCmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), "package source unavailable") {
+			t.Fatalf("licenses --drift error = %v, want package lookup failure", err)
+		}
+
+		mock.mu.Lock()
+		calls := mock.bulkLookupCalls
+		mock.mu.Unlock()
+		if calls == 0 {
+			t.Fatal("expected package metadata lookup")
 		}
 	})
 

--- a/cmd/licenses_test.go
+++ b/cmd/licenses_test.go
@@ -301,10 +301,11 @@ func TestLicensesCommand(t *testing.T) {
 				t.Fatalf("version lookup warning = %v, want %v; stderr: %s", gotWarning, tt.wantWarning, stderr)
 			}
 
-			var result []cmd.LicenseInfo
-			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+			var envelope cmd.ResultEnvelope[cmd.LicenseInfo]
+			if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
 				t.Fatalf("parse licenses output: %v\nOutput: %s", err, stdout)
 			}
+			result := envelope.Results
 			if len(result) != 1 {
 				t.Fatalf("license entries = %d, want 1", len(result))
 			}
@@ -357,10 +358,11 @@ func TestLicensesCommand(t *testing.T) {
 			t.Fatalf("missing ambiguity warning: %s", stderr)
 		}
 
-		var result []cmd.LicenseInfo
-		if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		var envelope cmd.ResultEnvelope[cmd.LicenseInfo]
+		if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
 			t.Fatalf("parse licenses output: %v\nOutput: %s", err, stdout)
 		}
+		result := envelope.Results
 		if len(result) != 1 {
 			t.Fatalf("license entries = %d, want 1", len(result))
 		}
@@ -446,10 +448,11 @@ func TestLicensesCommand(t *testing.T) {
 			t.Fatal("expected JSON output, got empty string")
 		}
 
-		var result []map[string]interface{}
-		if err := json.Unmarshal([]byte(output), &result); err != nil {
+		var envelope cmd.ResultEnvelope[map[string]interface{}]
+		if err := json.Unmarshal([]byte(output), &envelope); err != nil {
 			t.Fatalf("failed to parse JSON output: %v\nOutput: %s", err, output)
 		}
+		result := envelope.Results
 
 		if len(result) == 0 {
 			t.Fatal("expected at least one license entry")
@@ -937,10 +940,11 @@ services:
 		t.Fatal("expected JSON output, got empty string")
 	}
 
-	var results []cmd.LicenseInfo
-	if err := json.Unmarshal([]byte(output), &results); err != nil {
+	var envelope cmd.ResultEnvelope[cmd.LicenseInfo]
+	if err := json.Unmarshal([]byte(output), &envelope); err != nil {
 		t.Fatalf("failed to parse JSON: %v\nOutput: %s", err, output)
 	}
+	results := envelope.Results
 
 	for _, r := range results {
 		if strings.Contains(r.PURL, "docker") {

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -85,12 +85,11 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
-		sources = newSourceTracker()
 		if format == formatJSON {
 			if err := outputOutdatedJSON(cmd, nil, sources); err != nil {
 				return err
 			}
-			return nil
+			return sources.unavailableError()
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
 		return nil
@@ -256,10 +255,6 @@ func getPackageData(
 			return result, nil
 		}
 
-		const outdatedTimeout = 60 * time.Second
-		ctx, cancel := context.WithTimeout(context.Background(), outdatedTimeout)
-		defer cancel()
-
 		var toSave []database.PackageEnrichmentData
 		purlsByEcosystem := make(map[string][]string)
 		for _, purlStr := range uncachedPurls {
@@ -267,8 +262,11 @@ func getPackageData(
 			purlsByEcosystem[dep.Ecosystem] = append(purlsByEcosystem[dep.Ecosystem], purlStr)
 		}
 		for ecosystem, ecosystemPURLs := range purlsByEcosystem {
+			const outdatedTimeout = 60 * time.Second
+			ctx, cancel := context.WithTimeout(context.Background(), outdatedTimeout)
 			upstream, _ := registrySource(ecosystem)
 			packages, lookupErr := client.BulkLookup(ctx, ecosystemPURLs)
+			cancel()
 			if lookupErr != nil {
 				sources.markError(ecosystem, upstream, wrapEcosystemsError(lookupErr))
 				continue

--- a/cmd/outdated.go
+++ b/cmd/outdated.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -71,6 +70,11 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, ecosystem)
+	sources := newSourceTracker()
+	for _, ecosystem := range ecosystemsFromDependencies(deps) {
+		upstream, supported := registrySource(ecosystem)
+		sources.consider(ecosystem, upstream, supported)
+	}
 
 	// Filter to resolved dependencies (lockfiles and Go modules)
 	var lockfileDeps []database.Dependency
@@ -81,8 +85,12 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
+		sources = newSourceTracker()
 		if format == formatJSON {
-			return outputOutdatedJSON(cmd, nil)
+			if err := outputOutdatedJSON(cmd, nil, sources); err != nil {
+				return err
+			}
+			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found.")
 		return nil
@@ -92,11 +100,17 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	purls := make([]string, 0, len(lockfileDeps))
 	purlToDep := make(map[string]database.Dependency)
 	for _, d := range lockfileDeps {
+		if _, supported := registrySource(d.Ecosystem); !supported {
+			continue
+		}
 		// Build PURL without version for cache lookup
 		purlStr := purl.MakePURLString(d.Ecosystem, d.Name, "")
 		if purlStr != "" {
 			purls = append(purls, purlStr)
 			purlToDep[purlStr] = d
+		} else {
+			upstream, _ := registrySource(d.Ecosystem)
+			sources.markError(d.Ecosystem, upstream, fmt.Errorf("could not build package URL for %s", d.Name))
 		}
 	}
 
@@ -110,7 +124,7 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get package data (from cache or API)
-	packageData, err := getPackageData(db, purls, purlToDep)
+	packageData, err := getPackageData(db, purls, purlToDep, sources)
 	if err != nil {
 		return fmt.Errorf("looking up packages: %w", err)
 	}
@@ -165,7 +179,13 @@ func runOutdated(cmd *cobra.Command, args []string) error {
 	}
 
 	if format == formatJSON {
-		return outputOutdatedJSON(cmd, outdated)
+		if err := outputOutdatedJSON(cmd, outdated, sources); err != nil {
+			return err
+		}
+		return sources.unavailableError()
+	}
+	if err := sources.unavailableError(); err != nil {
+		return err
 	}
 	if len(outdated) == 0 {
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "All dependencies are up to date.")
@@ -184,7 +204,12 @@ type packageInfo struct {
 	Source        string
 }
 
-func getPackageData(db *database.DB, purls []string, purlToDep map[string]database.Dependency) (map[string]*packageInfo, error) {
+func getPackageData(
+	db *database.DB,
+	purls []string,
+	purlToDep map[string]database.Dependency,
+	sources *sourceTracker,
+) (map[string]*packageInfo, error) {
 	result := make(map[string]*packageInfo)
 	var uncachedPurls []string
 
@@ -196,16 +221,22 @@ func getPackageData(db *database.DB, purls []string, purlToDep map[string]databa
 		}
 
 		for purl, cp := range cached {
+			dep := purlToDep[purl]
+			upstream, _ := registrySource(dep.Ecosystem)
+			if cp.LatestVersion == "" {
+				continue
+			}
 			result[purl] = &packageInfo{
 				Ecosystem:     cp.Ecosystem,
 				Name:          cp.Name,
 				LatestVersion: cp.LatestVersion,
 				License:       cp.License,
 			}
+			sources.markOK(dep.Ecosystem, upstream, cp.EnrichedAt)
 		}
 		// Find uncached PURLs
 		for _, purl := range purls {
-			if _, ok := cached[purl]; !ok {
+			if cp, ok := cached[purl]; !ok || cp.LatestVersion == "" {
 				uncachedPurls = append(uncachedPurls, purl)
 			}
 		}
@@ -217,52 +248,82 @@ func getPackageData(db *database.DB, purls []string, purlToDep map[string]databa
 	if len(uncachedPurls) > 0 {
 		client, err := newEnrichmentClient()
 		if err != nil {
-			return nil, err
+			for _, purlStr := range uncachedPurls {
+				dep := purlToDep[purlStr]
+				upstream, _ := registrySource(dep.Ecosystem)
+				sources.markError(dep.Ecosystem, upstream, err)
+			}
+			return result, nil
 		}
 
 		const outdatedTimeout = 60 * time.Second
 		ctx, cancel := context.WithTimeout(context.Background(), outdatedTimeout)
 		defer cancel()
 
-		packages, err := client.BulkLookup(ctx, uncachedPurls)
-		if err != nil {
-			return nil, wrapEcosystemsError(err)
-		}
-
 		var toSave []database.PackageEnrichmentData
-		for purl, pkg := range packages {
-			if pkg == nil {
+		purlsByEcosystem := make(map[string][]string)
+		for _, purlStr := range uncachedPurls {
+			dep := purlToDep[purlStr]
+			purlsByEcosystem[dep.Ecosystem] = append(purlsByEcosystem[dep.Ecosystem], purlStr)
+		}
+		for ecosystem, ecosystemPURLs := range purlsByEcosystem {
+			upstream, _ := registrySource(ecosystem)
+			packages, lookupErr := client.BulkLookup(ctx, ecosystemPURLs)
+			if lookupErr != nil {
+				sources.markError(ecosystem, upstream, wrapEcosystemsError(lookupErr))
 				continue
 			}
+			fetchedAt := time.Now().UTC()
+			for _, purlStr := range ecosystemPURLs {
+				pkg := packages[purlStr]
+				if pkg == nil || pkg.LatestVersion == "" {
+					sources.markError(ecosystem, upstream, fmt.Errorf("latest version unavailable for %s", purlStr))
+					continue
+				}
+				info := &packageInfo{
+					Ecosystem:     pkg.Ecosystem,
+					Name:          pkg.Name,
+					LatestVersion: pkg.LatestVersion,
+					License:       pkg.License,
+					RegistryURL:   pkg.RegistryURL,
+					Source:        pkg.Source,
+				}
+				result[purlStr] = info
+				sources.markOK(ecosystem, upstream, fetchedAt)
 
-			info := &packageInfo{
-				Ecosystem:     pkg.Ecosystem,
-				Name:          pkg.Name,
-				LatestVersion: pkg.LatestVersion,
-				License:       pkg.License,
-				RegistryURL:   pkg.RegistryURL,
-				Source:        pkg.Source,
-			}
-			result[purl] = info
-
-			// Collect for batch save
-			if db != nil {
-				dep := purlToDep[purl]
-				toSave = append(toSave, database.PackageEnrichmentData{
-					PURL:          purl,
-					Ecosystem:     dep.Ecosystem,
-					Name:          dep.Name,
-					LatestVersion: info.LatestVersion,
-					License:       info.License,
-					RegistryURL:   info.RegistryURL,
-					Source:        info.Source,
-				})
+				if db != nil {
+					dep := purlToDep[purlStr]
+					toSave = append(toSave, database.PackageEnrichmentData{
+						PURL:          purlStr,
+						Ecosystem:     dep.Ecosystem,
+						Name:          dep.Name,
+						LatestVersion: info.LatestVersion,
+						License:       info.License,
+						RegistryURL:   info.RegistryURL,
+						Source:        info.Source,
+					})
+				}
 			}
 		}
 
 		// Batch save to cache
 		if db != nil && len(toSave) > 0 {
 			_ = db.SavePackageEnrichmentBatch(toSave)
+		}
+	}
+
+	if db != nil {
+		seen := make(map[string]bool)
+		for purlStr := range result {
+			ecosystem := purlToDep[purlStr].Ecosystem
+			if seen[ecosystem] {
+				continue
+			}
+			seen[ecosystem] = true
+			if syncedAt, ok := db.EcosystemSyncedAt(ecosystem); ok {
+				upstream, _ := registrySource(ecosystem)
+				sources.markOK(ecosystem, upstream, syncedAt)
+			}
 		}
 	}
 
@@ -363,10 +424,9 @@ func classifyUpdate(current, latest string) string {
 	return ""
 }
 
-func outputOutdatedJSON(cmd *cobra.Command, outdated []OutdatedPackage) error {
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(nonNilSlice(outdated))
+func outputOutdatedJSON(cmd *cobra.Command, outdated []OutdatedPackage, trackers ...*sourceTracker) error {
+	sources := sourceTrackerOrNew(trackers)
+	return outputResultEnvelope(cmd, resultEnvelope(sources, outdated, time.Now().UTC()))
 }
 
 func outputOutdatedText(cmd *cobra.Command, outdated []OutdatedPackage) {

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -340,7 +340,8 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 		{name: "notes namespaces", args: []string{"notes", "namespaces", "--format", "json"}},
 		{name: "blame", args: []string{"blame", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "tree", args: []string{"tree", "--ecosystem", "definitely-not-present", "--format", "json"}},
-		{name: "outdated", args: []string{"outdated", "--format", "json"}},
+		{name: "outdated", args: []string{"outdated", "--ecosystem", "definitely-not-present", "--format", "json"}},
+		{name: "deprecated", args: []string{"deprecated", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "stale", args: []string{"stale", "--format", "json"}},
 		{name: "show", args: []string{"show", "HEAD", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "where", args: []string{"where", "definitely-not-present", "--format", "json"}},
@@ -349,7 +350,7 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 		{name: "integrity", args: []string{"integrity", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "integrity drift", args: []string{"integrity", "--drift", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "vulns no lockfile deps", args: []string{"vulns", "scan", "--ecosystem", "definitely-not-present", "--format", "json"}},
-		{name: "vulns no results", args: []string{"vulns", "scan", "--no-sync", "--format", "json"}},
+		{name: "vulns no results", args: []string{"vulns", "scan", "--no-sync", "--ecosystem", "definitely-not-present", "--format", "json"}},
 		{name: "vulns blame", args: []string{"vulns", "blame", "--format", "json"}},
 		{name: "vulns history", args: []string{"vulns", "history", "definitely-not-present", "--format", "json"}},
 		{name: "vulns exposure", args: []string{"vulns", "exposure", "--format", "json"}},
@@ -364,7 +365,7 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 			}
 
 			switch tt.name {
-			case "outdated", "licenses", "vulns no lockfile deps", "vulns no results":
+			case "outdated", "deprecated", "licenses", "vulns no lockfile deps", "vulns no results":
 				var envelope struct {
 					Results []any              `json:"results"`
 					Sources []cmd.SourceStatus `json:"sources"`
@@ -385,6 +386,73 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMetadataJSONPreservesSourcesWithoutResolvedDependencies(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	for _, args := range [][]string{
+		{"outdated", "--format", "json"},
+		{"deprecated", "--format", "json"},
+		{"vulns", "scan", "--format", "json"},
+	} {
+		stdout, _, err := runCmd(t, args...)
+		if err == nil {
+			t.Fatalf("%s succeeded without resolved dependencies", strings.Join(args, " "))
+		}
+
+		var envelope struct {
+			Results []any              `json:"results"`
+			Sources []cmd.SourceStatus `json:"sources"`
+		}
+		if decodeErr := json.Unmarshal([]byte(stdout), &envelope); decodeErr != nil {
+			t.Fatalf("decode %s output: %v\n%s", strings.Join(args, " "), decodeErr, stdout)
+		}
+		if len(envelope.Results) != 0 || len(envelope.Sources) != 1 {
+			t.Fatalf("%s envelope = %+v", strings.Join(args, " "), envelope)
+		}
+		if envelope.Sources[0].Ecosystem != "npm" || envelope.Sources[0].Status != "error" {
+			t.Fatalf("%s source = %+v, want npm error", strings.Join(args, " "), envelope.Sources[0])
+		}
+	}
+}
+
+func TestLicensesJSONPreservesSourcesWithoutDirectDependencies(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add package-lock.json")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	stdout, _, err := runCmd(t, "licenses", "--format", "json")
+	if err == nil {
+		t.Fatal("licenses succeeded without direct dependencies")
+	}
+	var envelope struct {
+		Results []any              `json:"results"`
+		Sources []cmd.SourceStatus `json:"sources"`
+	}
+	if decodeErr := json.Unmarshal([]byte(stdout), &envelope); decodeErr != nil {
+		t.Fatalf("decode licenses output: %v\n%s", decodeErr, stdout)
+	}
+	if len(envelope.Results) != 0 || len(envelope.Sources) != 1 {
+		t.Fatalf("licenses envelope = %+v", envelope)
+	}
+	if envelope.Sources[0].Ecosystem != "npm" || envelope.Sources[0].Status != "error" {
+		t.Fatalf("licenses source = %+v, want npm error", envelope.Sources[0])
 	}
 }
 

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -363,12 +363,26 @@ func TestEmptyResultsRespectJSONFormat(t *testing.T) {
 				t.Fatalf("command failed: %v", err)
 			}
 
-			var result []any
-			if err := json.Unmarshal([]byte(stdout), &result); err != nil {
-				t.Fatalf("expected JSON array, got %q: %v", stdout, err)
-			}
-			if len(result) != 0 {
-				t.Fatalf("expected empty JSON array, got %v", result)
+			switch tt.name {
+			case "outdated", "licenses", "vulns no lockfile deps", "vulns no results":
+				var envelope struct {
+					Results []any              `json:"results"`
+					Sources []cmd.SourceStatus `json:"sources"`
+				}
+				if err := json.Unmarshal([]byte(stdout), &envelope); err != nil {
+					t.Fatalf("expected JSON envelope, got %q: %v", stdout, err)
+				}
+				if len(envelope.Results) != 0 {
+					t.Fatalf("expected empty JSON results, got %v", envelope.Results)
+				}
+			default:
+				var result []any
+				if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+					t.Fatalf("expected JSON array, got %q: %v", stdout, err)
+				}
+				if len(result) != 0 {
+					t.Fatalf("expected empty JSON array, got %v", result)
+				}
 			}
 		})
 	}

--- a/cmd/source_status.go
+++ b/cmd/source_status.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/git-pkgs/git-pkgs/internal/database"
+	"github.com/git-pkgs/purl"
+	"github.com/git-pkgs/registries"
+	"github.com/spf13/cobra"
+)
+
+const (
+	sourceStatusOK          = "ok"
+	sourceStatusError       = "error"
+	sourceStatusUnsupported = "unsupported"
+)
+
+// SourceStatus describes the outcome of consulting one upstream for an ecosystem.
+type SourceStatus struct {
+	Ecosystem       string    `json:"ecosystem"`
+	Upstream        string    `json:"upstream"`
+	Status          string    `json:"status"`
+	FetchedAt       time.Time `json:"fetched_at,omitzero"`
+	CacheAgeSeconds int64     `json:"cache_age_seconds,omitempty"`
+	Error           string    `json:"error,omitempty"`
+}
+
+// ResultEnvelope adds source health to command result rows.
+type ResultEnvelope[T any] struct {
+	Results  []T            `json:"results"`
+	Sources  []SourceStatus `json:"sources"`
+	Warnings []string       `json:"warnings,omitempty"`
+}
+
+type sourceKey struct {
+	ecosystem string
+	upstream  string
+}
+
+type sourceObservation struct {
+	unsupported bool
+	fetchedAt   time.Time
+	errors      []error
+}
+
+type sourceTracker struct {
+	observations map[sourceKey]*sourceObservation
+}
+
+func newSourceTracker() *sourceTracker {
+	return &sourceTracker{observations: make(map[sourceKey]*sourceObservation)}
+}
+
+func sourceTrackerOrNew(trackers []*sourceTracker) *sourceTracker {
+	if len(trackers) > 0 && trackers[0] != nil {
+		return trackers[0]
+	}
+	return newSourceTracker()
+}
+
+func (t *sourceTracker) consider(ecosystem, upstream string, supported bool) {
+	key := sourceKey{ecosystem: ecosystem, upstream: upstream}
+	observation := t.observation(key)
+	if !supported {
+		observation.unsupported = true
+	}
+}
+
+func (t *sourceTracker) markOK(ecosystem, upstream string, fetchedAt time.Time) {
+	observation := t.observation(sourceKey{ecosystem: ecosystem, upstream: upstream})
+	if fetchedAt.IsZero() {
+		fetchedAt = time.Now().UTC()
+	}
+	fetchedAt = fetchedAt.UTC()
+	if observation.fetchedAt.IsZero() || fetchedAt.After(observation.fetchedAt) {
+		observation.fetchedAt = fetchedAt
+	}
+}
+
+func (t *sourceTracker) markError(ecosystem, upstream string, err error) {
+	if err == nil {
+		return
+	}
+	observation := t.observation(sourceKey{ecosystem: ecosystem, upstream: upstream})
+	observation.errors = append(observation.errors, err)
+}
+
+func (t *sourceTracker) observation(key sourceKey) *sourceObservation {
+	observation := t.observations[key]
+	if observation == nil {
+		observation = &sourceObservation{}
+		t.observations[key] = observation
+	}
+	return observation
+}
+
+func resultEnvelope[T any](t *sourceTracker, results []T, now time.Time) ResultEnvelope[T] {
+	sources, warnings := t.statuses(now)
+	return ResultEnvelope[T]{
+		Results:  nonNilSlice(results),
+		Sources:  nonNilSlice(sources),
+		Warnings: warnings,
+	}
+}
+
+func (t *sourceTracker) statuses(now time.Time) ([]SourceStatus, []string) {
+	keys := make([]sourceKey, 0, len(t.observations))
+	for key := range t.observations {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ecosystem != keys[j].ecosystem {
+			return keys[i].ecosystem < keys[j].ecosystem
+		}
+		return keys[i].upstream < keys[j].upstream
+	})
+
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	var warnings []string
+	sources := make([]SourceStatus, 0, len(keys))
+	for _, key := range keys {
+		observation := t.observations[key]
+		errorMessages := observationErrorMessages(observation)
+		status := SourceStatus{Ecosystem: key.ecosystem, Upstream: key.upstream}
+		switch {
+		case observation.unsupported:
+			status.Status = sourceStatusUnsupported
+		case !observation.fetchedAt.IsZero():
+			status.Status = sourceStatusOK
+			status.FetchedAt = observation.fetchedAt.UTC()
+			age := now.Sub(status.FetchedAt)
+			if age > 0 {
+				status.CacheAgeSeconds = int64(age / time.Second)
+			}
+			for _, message := range errorMessages {
+				warnings = append(warnings, sourceWarning(key, errors.New(message)))
+			}
+		case len(errorMessages) > 0:
+			status.Status = sourceStatusError
+			status.Error = errorMessages[0]
+		default:
+			status.Status = sourceStatusError
+			status.Error = "no source data was returned"
+		}
+		sources = append(sources, status)
+	}
+	return sources, warnings
+}
+
+func observationErrorMessages(observation *sourceObservation) []string {
+	seen := make(map[string]bool)
+	messages := make([]string, 0, len(observation.errors))
+	for _, err := range observation.errors {
+		if err == nil || seen[err.Error()] {
+			continue
+		}
+		seen[err.Error()] = true
+		messages = append(messages, err.Error())
+	}
+	sort.Strings(messages)
+	return messages
+}
+
+func (t *sourceTracker) allUnavailable() bool {
+	if len(t.observations) == 0 {
+		return false
+	}
+	for _, observation := range t.observations {
+		if !observation.fetchedAt.IsZero() && !observation.unsupported {
+			return false
+		}
+	}
+	return true
+}
+
+func (t *sourceTracker) unavailableError() error {
+	if !t.allUnavailable() {
+		return nil
+	}
+	sources, _ := t.statuses(time.Now().UTC())
+	var errs []error
+	for _, source := range sources {
+		if source.Status != sourceStatusError {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%s (%s): %s", source.Ecosystem, source.Upstream, source.Error))
+	}
+	if len(errs) == 0 {
+		return fmt.Errorf("no supported sources available")
+	}
+	return fmt.Errorf("all sources failed: %w", errors.Join(errs...))
+}
+
+func sourceWarning(key sourceKey, err error) string {
+	if key.upstream == "" {
+		return fmt.Sprintf("%s: %v", key.ecosystem, err)
+	}
+	return fmt.Sprintf("%s (%s): %v", key.ecosystem, key.upstream, err)
+}
+
+func outputResultEnvelope[T any](cmd *cobra.Command, envelope ResultEnvelope[T]) error {
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetIndent("", "  ")
+	return enc.Encode(envelope)
+}
+
+func registrySource(ecosystem string) (string, bool) {
+	purlType := purl.EcosystemToPURLType(ecosystem)
+	for _, supported := range registries.SupportedEcosystems() {
+		if supported == purlType {
+			return sourceHostname(registries.DefaultURL(purlType)), true
+		}
+	}
+	return "", false
+}
+
+func sourceHostname(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err == nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(rawURL, "https://"), "/")
+}
+
+func ecosystemsFromDependencies(deps []database.Dependency) []string {
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		if dep.Ecosystem != "" {
+			seen[dep.Ecosystem] = true
+		}
+	}
+	ecosystems := make([]string, 0, len(seen))
+	for ecosystem := range seen {
+		ecosystems = append(ecosystems, ecosystem)
+	}
+	sort.Strings(ecosystems)
+	return ecosystems
+}

--- a/cmd/source_status.go
+++ b/cmd/source_status.go
@@ -27,7 +27,7 @@ type SourceStatus struct {
 	Upstream        string    `json:"upstream"`
 	Status          string    `json:"status"`
 	FetchedAt       time.Time `json:"fetched_at,omitzero"`
-	CacheAgeSeconds int64     `json:"cache_age_seconds,omitempty"`
+	CacheAgeSeconds *int64    `json:"cache_age_seconds,omitempty"`
 	Error           string    `json:"error,omitempty"`
 }
 
@@ -65,7 +65,7 @@ func sourceTrackerOrNew(trackers []*sourceTracker) *sourceTracker {
 }
 
 func (t *sourceTracker) consider(ecosystem, upstream string, supported bool) {
-	key := sourceKey{ecosystem: ecosystem, upstream: upstream}
+	key := newSourceKey(ecosystem, upstream)
 	observation := t.observation(key)
 	if !supported {
 		observation.unsupported = true
@@ -73,7 +73,7 @@ func (t *sourceTracker) consider(ecosystem, upstream string, supported bool) {
 }
 
 func (t *sourceTracker) markOK(ecosystem, upstream string, fetchedAt time.Time) {
-	observation := t.observation(sourceKey{ecosystem: ecosystem, upstream: upstream})
+	observation := t.observation(newSourceKey(ecosystem, upstream))
 	if fetchedAt.IsZero() {
 		fetchedAt = time.Now().UTC()
 	}
@@ -87,8 +87,21 @@ func (t *sourceTracker) markError(ecosystem, upstream string, err error) {
 	if err == nil {
 		return
 	}
-	observation := t.observation(sourceKey{ecosystem: ecosystem, upstream: upstream})
+	observation := t.observation(newSourceKey(ecosystem, upstream))
 	observation.errors = append(observation.errors, err)
+}
+
+func newSourceKey(ecosystem, upstream string) sourceKey {
+	return sourceKey{ecosystem: canonicalSourceEcosystem(ecosystem), upstream: upstream}
+}
+
+func canonicalSourceEcosystem(ecosystem string) string {
+	purlType := purl.EcosystemToPURLType(ecosystem)
+	canonical := purl.PURLTypeToEcosystem(purlType)
+	if canonical != "" {
+		return canonical
+	}
+	return ecosystem
 }
 
 func (t *sourceTracker) observation(key sourceKey) *sourceObservation {
@@ -136,10 +149,11 @@ func (t *sourceTracker) statuses(now time.Time) ([]SourceStatus, []string) {
 		case !observation.fetchedAt.IsZero():
 			status.Status = sourceStatusOK
 			status.FetchedAt = observation.fetchedAt.UTC()
-			age := now.Sub(status.FetchedAt)
-			if age > 0 {
-				status.CacheAgeSeconds = int64(age / time.Second)
+			ageSeconds := int64(0)
+			if age := now.Sub(status.FetchedAt); age > 0 {
+				ageSeconds = int64(age / time.Second)
 			}
+			status.CacheAgeSeconds = &ageSeconds
 			for _, message := range errorMessages {
 				warnings = append(warnings, sourceWarning(key, errors.New(message)))
 			}
@@ -199,6 +213,29 @@ func (t *sourceTracker) unavailableError() error {
 	return fmt.Errorf("all sources failed: %w", errors.Join(errs...))
 }
 
+func (t *sourceTracker) observedError() error {
+	keys := make([]sourceKey, 0, len(t.observations))
+	for key := range t.observations {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].ecosystem != keys[j].ecosystem {
+			return keys[i].ecosystem < keys[j].ecosystem
+		}
+		return keys[i].upstream < keys[j].upstream
+	})
+
+	var errs []error
+	for _, key := range keys {
+		for _, err := range t.observations[key].errors {
+			if err != nil {
+				errs = append(errs, errors.New(sourceWarning(key, err)))
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func sourceWarning(key sourceKey, err error) string {
 	if key.upstream == "" {
 		return fmt.Sprintf("%s: %v", key.ecosystem, err)
@@ -215,7 +252,7 @@ func outputResultEnvelope[T any](cmd *cobra.Command, envelope ResultEnvelope[T])
 func registrySource(ecosystem string) (string, bool) {
 	purlType := purl.EcosystemToPURLType(ecosystem)
 	for _, supported := range registries.SupportedEcosystems() {
-		if supported == purlType {
+		if purl.EcosystemToPURLType(supported) == purlType {
 			return sourceHostname(registries.DefaultURL(purlType)), true
 		}
 	}

--- a/cmd/source_status_test.go
+++ b/cmd/source_status_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/git-pkgs/git-pkgs/internal/database"
 	"github.com/spf13/cobra"
 )
 
@@ -34,8 +35,8 @@ func TestSourceTrackerStatuses(t *testing.T) {
 	if sources[1].Ecosystem != "npm" || sources[1].Status != sourceStatusOK {
 		t.Fatalf("npm source = %+v, want ok", sources[1])
 	}
-	if sources[1].CacheAgeSeconds != 90 {
-		t.Fatalf("npm cache age = %d, want 90", sources[1].CacheAgeSeconds)
+	if sources[1].CacheAgeSeconds == nil || *sources[1].CacheAgeSeconds != 90 {
+		t.Fatalf("npm cache age = %v, want 90", sources[1].CacheAgeSeconds)
 	}
 	if sources[2].Ecosystem != "swift" || sources[2].Status != sourceStatusUnsupported {
 		t.Fatalf("swift source = %+v, want unsupported", sources[2])
@@ -60,6 +61,106 @@ func TestSourceTrackerAllUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "registry unavailable") {
 		t.Fatalf("unavailableError = %q", err)
+	}
+}
+
+func TestSourceTrackerCanonicalizesEcosystemAliases(t *testing.T) {
+	now := time.Now().UTC()
+	tracker := newSourceTracker()
+	tracker.consider("rubygems", "rubygems.org", true)
+	tracker.markOK("gem", "rubygems.org", now)
+
+	sources, _ := tracker.statuses(now)
+	if len(sources) != 1 {
+		t.Fatalf("sources = %+v, want one canonical source", sources)
+	}
+	if sources[0].Ecosystem != "rubygems" || sources[0].Status != sourceStatusOK {
+		t.Fatalf("source = %+v, want successful rubygems source", sources[0])
+	}
+}
+
+func TestSourceStatusJSONIncludesZeroCacheAgeOnlyForSuccess(t *testing.T) {
+	now := time.Now().UTC()
+	tracker := newSourceTracker()
+	tracker.markOK("npm", "registry.npmjs.org", now)
+	tracker.markError("cargo", "crates.io", errors.New("unavailable"))
+
+	envelope := resultEnvelope(tracker, []string{}, now)
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	var output struct {
+		Sources []map[string]any `json:"sources"`
+	}
+	if err := json.Unmarshal(encoded, &output); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if len(output.Sources) != 2 {
+		t.Fatalf("sources = %v, want two", output.Sources)
+	}
+	for _, source := range output.Sources {
+		_, hasAge := source["cache_age_seconds"]
+		switch source["status"] {
+		case sourceStatusOK:
+			if !hasAge || source["cache_age_seconds"] != float64(0) {
+				t.Fatalf("successful source omitted zero cache age: %v", source)
+			}
+		case sourceStatusError:
+			if hasAge {
+				t.Fatalf("error source included cache age: %v", source)
+			}
+		}
+	}
+}
+
+func TestRegistrySourceAcceptsCanonicalAlias(t *testing.T) {
+	upstream, supported := registrySource("rubygems")
+	if !supported || upstream != "rubygems.org" {
+		t.Fatalf("registrySource(rubygems) = %q, %v; want rubygems.org, true", upstream, supported)
+	}
+}
+
+func TestLicenseUpstreamRouting(t *testing.T) {
+	tests := []struct {
+		name       string
+		purl       string
+		directMode bool
+		want       string
+	}{
+		{name: "public hybrid", purl: "pkg:npm/example", want: licenseDefaultUpstream},
+		{name: "public direct", purl: "pkg:npm/example", directMode: true, want: "registry.npmjs.org"},
+		{name: "private registry", purl: "pkg:npm/example?repository_url=https:%2F%2Fregistry.example.test", want: "registry.example.test"},
+		{name: "default cargo index", purl: "pkg:cargo/example?repository_url=https:%2F%2Fgithub.com%2Frust-lang%2Fcrates.io-index", want: "crates.io"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := licenseUpstreamForPURL(tt.purl, tt.directMode); got != tt.want {
+				t.Fatalf("licenseUpstreamForPURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsiderLicenseSourcesSeedsOnlyLockfileEcosystems(t *testing.T) {
+	tracker := newSourceTracker()
+	considerLicenseSources(tracker, []database.Dependency{
+		{Ecosystem: "npm", Name: "example", ManifestKind: manifestKindManifest},
+		{
+			Ecosystem:    "cargo",
+			Name:         "example",
+			ManifestKind: "lockfile",
+		},
+	}, false)
+
+	sources, _ := tracker.statuses(time.Now().UTC())
+	if len(sources) != 1 {
+		t.Fatalf("sources = %+v, want one lockfile-only source", sources)
+	}
+	if sources[0].Ecosystem != "cargo" || sources[0].Upstream != licenseDefaultUpstream {
+		t.Fatalf("source = %+v, want cargo via %s", sources[0], licenseDefaultUpstream)
 	}
 }
 

--- a/cmd/source_status_test.go
+++ b/cmd/source_status_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func TestSourceTrackerStatuses(t *testing.T) {
+	now := time.Date(2026, time.August, 22, 12, 0, 0, 0, time.UTC)
+	tracker := newSourceTracker()
+	tracker.consider("swift", "", false)
+	tracker.consider("npm", "registry.npmjs.org", true)
+	tracker.markOK("npm", "registry.npmjs.org", now.Add(-90*time.Second))
+	tracker.markError("npm", "registry.npmjs.org", errors.New("one package timed out"))
+	tracker.consider("cargo", "crates.io", true)
+	tracker.markError("cargo", "crates.io", errors.New("registry unavailable"))
+
+	sources, warnings := tracker.statuses(now)
+	if len(sources) != 3 {
+		t.Fatalf("sources = %d, want 3", len(sources))
+	}
+	if sources[0].Ecosystem != "cargo" || sources[0].Status != sourceStatusError {
+		t.Fatalf("cargo source = %+v, want error", sources[0])
+	}
+	if sources[0].Error != "registry unavailable" {
+		t.Fatalf("cargo error = %q", sources[0].Error)
+	}
+	if sources[1].Ecosystem != "npm" || sources[1].Status != sourceStatusOK {
+		t.Fatalf("npm source = %+v, want ok", sources[1])
+	}
+	if sources[1].CacheAgeSeconds != 90 {
+		t.Fatalf("npm cache age = %d, want 90", sources[1].CacheAgeSeconds)
+	}
+	if sources[2].Ecosystem != "swift" || sources[2].Status != sourceStatusUnsupported {
+		t.Fatalf("swift source = %+v, want unsupported", sources[2])
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "one package timed out") {
+		t.Fatalf("warnings = %q, want partial npm error", warnings)
+	}
+	if tracker.allUnavailable() {
+		t.Fatal("tracker with an ok source reported all unavailable")
+	}
+}
+
+func TestSourceTrackerAllUnavailable(t *testing.T) {
+	tracker := newSourceTracker()
+	tracker.consider("cargo", "crates.io", true)
+	tracker.markError("cargo", "crates.io", errors.New("registry unavailable"))
+	tracker.consider("swift", "", false)
+
+	err := tracker.unavailableError()
+	if err == nil {
+		t.Fatal("unavailableError = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "registry unavailable") {
+		t.Fatalf("unavailableError = %q", err)
+	}
+}
+
+func TestMetadataJSONOutputsUseResultEnvelope(t *testing.T) {
+	tracker := newSourceTracker()
+	tracker.consider("npm", "registry.npmjs.org", true)
+	tracker.markOK("npm", "registry.npmjs.org", time.Now().UTC())
+
+	tests := []struct {
+		name   string
+		output func(*cobra.Command) error
+	}{
+		{
+			name: "outdated",
+			output: func(cmd *cobra.Command) error {
+				return outputOutdatedJSON(cmd, []OutdatedPackage{{Name: "example"}}, tracker)
+			},
+		},
+		{
+			name: "deprecated",
+			output: func(cmd *cobra.Command) error {
+				return outputDeprecatedJSON(cmd, []DeprecatedPackage{{Name: "example"}}, tracker)
+			},
+		},
+		{
+			name: "licenses",
+			output: func(cmd *cobra.Command) error {
+				return outputLicensesJSON(cmd, []LicenseInfo{{Name: "example"}}, tracker)
+			},
+		},
+		{
+			name: "vulns",
+			output: func(cmd *cobra.Command) error {
+				return outputVulnsJSON(cmd, []VulnResult{{Package: "example"}}, tracker)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&output)
+			if err := tt.output(cmd); err != nil {
+				t.Fatalf("output: %v", err)
+			}
+
+			var envelope struct {
+				Results []json.RawMessage `json:"results"`
+				Sources []SourceStatus    `json:"sources"`
+			}
+			if err := json.Unmarshal(output.Bytes(), &envelope); err != nil {
+				t.Fatalf("decode envelope: %v\n%s", err, output.String())
+			}
+			if len(envelope.Results) != 1 || len(envelope.Sources) != 1 {
+				t.Fatalf("envelope = %+v, want one result and source", envelope)
+			}
+		})
+	}
+}

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -613,6 +613,13 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 
 	// Filter by ecosystem
 	deps = filterByEcosystem(deps, ecosystem)
+	source := osv.New(osv.WithUserAgent(userAgent))
+	sources := newSourceTracker()
+	for _, dep := range deps {
+		packagePURL := purl.MakePURL(dep.Ecosystem, dep.Name, dep.Requirement)
+		_, supported, _ := osvEcosystemForPURLType(packagePURL.Type)
+		sources.consider(dep.Ecosystem, vulnerabilitySourceUpstream(source), supported)
+	}
 
 	// Filter to lockfile deps (or Go deps which have pinned versions)
 	var lockfileDeps []database.Dependency
@@ -623,19 +630,15 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
+		sources = newSourceTracker()
 		if format == formatJSON {
-			return outputVulnsJSON(cmd, nil)
+			if err := outputVulnsJSON(cmd, nil, sources); err != nil {
+				return err
+			}
+			return nil
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found to scan.")
 		return nil
-	}
-
-	// Auto-sync before cached scan (skip for --live and --no-sync)
-	if !live && !noSync && db != nil {
-		source := osv.New(osv.WithUserAgent(userAgent))
-		if err := syncVulnerabilitiesForDeps(db, source, lockfileDeps, false, false, cmd.OutOrStdout()); err != nil {
-			return fmt.Errorf("syncing vulnerabilities: %w", err)
-		}
 	}
 
 	var vulnResults []VulnResult
@@ -647,20 +650,56 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if live || db == nil {
-		// Live query mode - use OSV API directly
-		var skipped []database.Dependency
-		vulnResults, skipped, err = scanLive(lockfileDeps, minSeverity)
-		if err != nil {
-			return err
+	resolvedByEcosystem := make(map[string][]database.Dependency)
+	for _, dep := range lockfileDeps {
+		resolvedByEcosystem[dep.Ecosystem] = append(resolvedByEcosystem[dep.Ecosystem], dep)
+	}
+	for ecosystem, ecosystemDeps := range resolvedByEcosystem {
+		packagePURL := purl.MakePURL(ecosystem, ecosystemDeps[0].Name, ecosystemDeps[0].Requirement)
+		if _, supported, _ := osvEcosystemForPURLType(packagePURL.Type); !supported {
+			reportSkippedOSVDependencies(cmd.ErrOrStderr(), ecosystemDeps)
+			continue
 		}
-		reportSkippedOSVDependencies(cmd.ErrOrStderr(), skipped)
-	} else {
-		// Cached mode - use stored vulnerability data
-		vulnResults, err = scanCached(db, lockfileDeps, minSeverity)
-		if err != nil {
-			return err
+		upstream := vulnerabilitySourceUpstream(source)
+
+		if live || db == nil {
+			ecosystemResults, skipped, scanErr := scanLiveWithSource(source, ecosystemDeps, minSeverity)
+			reportSkippedOSVDependencies(cmd.ErrOrStderr(), skipped)
+			if scanErr != nil {
+				sources.markError(ecosystem, upstream, scanErr)
+				continue
+			}
+			sources.markOK(ecosystem, upstream, time.Now().UTC())
+			vulnResults = append(vulnResults, ecosystemResults...)
+			continue
 		}
+
+		if !noSync {
+			quietSync := format == formatJSON || format == formatSARIF
+			if syncErr := syncVulnerabilitiesForDeps(
+				db,
+				source,
+				ecosystemDeps,
+				false,
+				quietSync,
+				cmd.OutOrStdout(),
+			); syncErr != nil {
+				sources.markError(ecosystem, upstream, fmt.Errorf("syncing vulnerabilities: %w", syncErr))
+			} else if syncedAt, ok := db.EcosystemVulnsSyncedAt(ecosystem); ok {
+				sources.markOK(ecosystem, upstream, syncedAt)
+			} else {
+				sources.markOK(ecosystem, upstream, time.Now().UTC())
+			}
+		} else {
+			markCachedVulnerabilitySource(db, ecosystemDeps, sources, upstream)
+		}
+
+		ecosystemResults, scanErr := scanCached(db, ecosystemDeps, minSeverity)
+		if scanErr != nil {
+			sources.markError(ecosystem, upstream, scanErr)
+			continue
+		}
+		vulnResults = append(vulnResults, ecosystemResults...)
 	}
 
 	// Sort by severity, then package name
@@ -673,7 +712,13 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 
 	if len(vulnResults) == 0 {
 		if format == formatJSON {
-			return outputVulnsJSON(cmd, vulnResults)
+			if err := outputVulnsJSON(cmd, vulnResults, sources); err != nil {
+				return err
+			}
+			return sources.unavailableError()
+		}
+		if err := sources.unavailableError(); err != nil {
+			return err
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No vulnerabilities found.")
 		return nil
@@ -681,18 +726,52 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 
 	switch format {
 	case formatJSON:
-		return outputVulnsJSON(cmd, vulnResults)
+		if err := outputVulnsJSON(cmd, vulnResults, sources); err != nil {
+			return err
+		}
+		return sources.unavailableError()
 	case "sarif":
-		return outputVulnsSARIF(cmd, vulnResults)
+		if err := outputVulnsSARIF(cmd, vulnResults); err != nil {
+			return err
+		}
+		return sources.unavailableError()
 	default:
 		outputVulnsText(cmd, vulnResults)
-		return nil
+		return sources.unavailableError()
 	}
 }
 
-func scanLive(deps []database.Dependency, minSeverity int) ([]VulnResult, []database.Dependency, error) {
-	source := osv.New(osv.WithUserAgent(userAgent))
-	return scanLiveWithSource(source, deps, minSeverity)
+func markCachedVulnerabilitySource(
+	db *database.DB,
+	deps []database.Dependency,
+	sources *sourceTracker,
+	upstream string,
+) {
+	seen := make(map[string]bool)
+	for _, dep := range deps {
+		packagePURL := purl.MakePURLString(dep.Ecosystem, dep.Name, "")
+		if packagePURL == "" || seen[packagePURL] {
+			continue
+		}
+		seen[packagePURL] = true
+		syncedAt, err := db.GetVulnsSyncedAt(packagePURL)
+		if err != nil {
+			sources.markError(dep.Ecosystem, upstream, err)
+			continue
+		}
+		if syncedAt.IsZero() {
+			sources.markError(dep.Ecosystem, upstream, fmt.Errorf("vulnerability data is not cached for %s", packagePURL))
+			continue
+		}
+		sources.markOK(dep.Ecosystem, upstream, syncedAt)
+	}
+}
+
+func vulnerabilitySourceUpstream(source vulns.Source) string {
+	if source.Name() == "osv" {
+		return "osv.dev"
+	}
+	return source.Name()
 }
 
 func scanLiveWithSource(source vulns.Source, deps []database.Dependency, minSeverity int) ([]VulnResult, []database.Dependency, error) {
@@ -815,10 +894,9 @@ func scanCached(db *database.DB, deps []database.Dependency, minSeverity int) ([
 	return vulnResults, nil
 }
 
-func outputVulnsJSON(cmd *cobra.Command, results []VulnResult) error {
-	enc := json.NewEncoder(cmd.OutOrStdout())
-	enc.SetIndent("", "  ")
-	return enc.Encode(nonNilSlice(results))
+func outputVulnsJSON(cmd *cobra.Command, results []VulnResult, trackers ...*sourceTracker) error {
+	sources := sourceTrackerOrNew(trackers)
+	return outputResultEnvelope(cmd, resultEnvelope(sources, results, time.Now().UTC()))
 }
 
 func outputVulnsText(cmd *cobra.Command, results []VulnResult) {

--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -393,6 +394,7 @@ func syncVulnerabilitiesForDeps(db *database.DB, source vulns.Source, lockfileDe
 
 	// Fetch all unique vulnerability details concurrently
 	fetchedVulns := make(map[string]*vulns.Vulnerability)
+	detailErrors := make(map[string]error)
 	var mu sync.Mutex
 
 	isTTY := false
@@ -416,7 +418,12 @@ func syncVulnerabilitiesForDeps(db *database.DB, source vulns.Source, lockfileDe
 			mu.Lock()
 			defer mu.Unlock()
 			fetchCount++
-			if err == nil && fullVuln != nil {
+			switch {
+			case err != nil:
+				detailErrors[id] = fmt.Errorf("fetching %s: %w", id, err)
+			case fullVuln == nil:
+				detailErrors[id] = fmt.Errorf("fetching %s: no vulnerability details returned", id)
+			default:
 				fetchedVulns[id] = fullVuln
 			}
 			if isTTY && !quiet {
@@ -435,9 +442,19 @@ func syncVulnerabilitiesForDeps(db *database.DB, source vulns.Source, lockfileDe
 	now := time.Now().Format(time.RFC3339)
 	seenVulns := make(map[string]bool)
 	totalVulns := 0
+	failedPackages := make(map[string]bool)
 
 	for i, batchVulns := range results {
 		dep := queries[i].dependency
+		for _, vulnerability := range batchVulns {
+			if _, failed := detailErrors[vulnerability.ID]; failed {
+				failedPackages[queries[i].purl.String()] = true
+				break
+			}
+		}
+		if failedPackages[queries[i].purl.String()] {
+			continue
+		}
 
 		// Clear existing vulns for this package
 		if err := db.DeleteVulnerabilitiesForPackage(dep.Ecosystem, dep.Name); err != nil {
@@ -520,15 +537,32 @@ func syncVulnerabilitiesForDeps(db *database.DB, source vulns.Source, lockfileDe
 	}
 
 	// Mark packages as synced
+	syncedPackages := 0
 	for _, query := range queries {
+		if failedPackages[query.purl.String()] {
+			continue
+		}
 		dep := query.dependency
 		if err := db.SetVulnsSyncedAt(query.purl.String(), dep.Ecosystem, dep.Name); err != nil {
 			return fmt.Errorf("recording sync time for %s/%s: %w", dep.Ecosystem, dep.Name, err)
 		}
+		syncedPackages++
 	}
 
 	if !quiet {
-		_, _ = fmt.Fprintf(w, "Synced %d vulnerabilities for %d packages.\n", totalVulns, len(queries))
+		_, _ = fmt.Fprintf(w, "Synced %d vulnerabilities for %d packages.\n", totalVulns, syncedPackages)
+	}
+	if len(detailErrors) > 0 {
+		ids := make([]string, 0, len(detailErrors))
+		for id := range detailErrors {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		errs := make([]error, 0, len(ids))
+		for _, id := range ids {
+			errs = append(errs, detailErrors[id])
+		}
+		return fmt.Errorf("fetching vulnerability details: %w", errors.Join(errs...))
 	}
 
 	return nil
@@ -630,12 +664,11 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(lockfileDeps) == 0 {
-		sources = newSourceTracker()
 		if format == formatJSON {
 			if err := outputVulnsJSON(cmd, nil, sources); err != nil {
 				return err
 			}
-			return nil
+			return sources.unavailableError()
 		}
 		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No lockfile dependencies found to scan.")
 		return nil
@@ -676,28 +709,29 @@ func runVulnsScan(cmd *cobra.Command, args []string) error {
 
 		if !noSync {
 			quietSync := format == formatJSON || format == formatSARIF
-			if syncErr := syncVulnerabilitiesForDeps(
+			syncErr := syncVulnerabilitiesForDeps(
 				db,
 				source,
 				ecosystemDeps,
 				false,
 				quietSync,
 				cmd.OutOrStdout(),
-			); syncErr != nil {
+			)
+			if syncErr != nil {
 				sources.markError(ecosystem, upstream, fmt.Errorf("syncing vulnerabilities: %w", syncErr))
-			} else if syncedAt, ok := db.EcosystemVulnsSyncedAt(ecosystem); ok {
-				sources.markOK(ecosystem, upstream, syncedAt)
-			} else {
-				sources.markOK(ecosystem, upstream, time.Now().UTC())
+			}
+			if cacheErr := markCachedVulnerabilitySource(db, ecosystemDeps, sources, upstream); cacheErr != nil {
+				return cacheErr
 			}
 		} else {
-			markCachedVulnerabilitySource(db, ecosystemDeps, sources, upstream)
+			if cacheErr := markCachedVulnerabilitySource(db, ecosystemDeps, sources, upstream); cacheErr != nil {
+				return cacheErr
+			}
 		}
 
 		ecosystemResults, scanErr := scanCached(db, ecosystemDeps, minSeverity)
 		if scanErr != nil {
-			sources.markError(ecosystem, upstream, scanErr)
-			continue
+			return fmt.Errorf("scanning cached vulnerabilities for %s: %w", ecosystem, scanErr)
 		}
 		vulnResults = append(vulnResults, ecosystemResults...)
 	}
@@ -746,7 +780,7 @@ func markCachedVulnerabilitySource(
 	deps []database.Dependency,
 	sources *sourceTracker,
 	upstream string,
-) {
+) error {
 	seen := make(map[string]bool)
 	for _, dep := range deps {
 		packagePURL := purl.MakePURLString(dep.Ecosystem, dep.Name, "")
@@ -756,8 +790,7 @@ func markCachedVulnerabilitySource(
 		seen[packagePURL] = true
 		syncedAt, err := db.GetVulnsSyncedAt(packagePURL)
 		if err != nil {
-			sources.markError(dep.Ecosystem, upstream, err)
-			continue
+			return fmt.Errorf("reading vulnerability cache status for %s: %w", packagePURL, err)
 		}
 		if syncedAt.IsZero() {
 			sources.markError(dep.Ecosystem, upstream, fmt.Errorf("vulnerability data is not cached for %s", packagePURL))
@@ -765,6 +798,7 @@ func markCachedVulnerabilitySource(
 		}
 		sources.markOK(dep.Ecosystem, upstream, syncedAt)
 	}
+	return nil
 }
 
 func vulnerabilitySourceUpstream(source vulns.Source) string {

--- a/cmd/vulns_test.go
+++ b/cmd/vulns_test.go
@@ -23,7 +23,8 @@ import (
 // mockSource implements vulns.Source for testing.
 type mockSource struct {
 	vulns      map[string]*vulns.Vulnerability // ID -> full vuln
-	batchRes   [][]vulns.Vulnerability         // QueryBatch results
+	getErrs    map[string]error
+	batchRes   [][]vulns.Vulnerability // QueryBatch results
 	batchErr   error
 	batchErrs  []error
 	batchPURLs []*purl.PURL
@@ -49,10 +50,46 @@ func (m *mockSource) QueryBatch(_ context.Context, purls []*purl.PURL) ([][]vuln
 
 func (m *mockSource) Get(_ context.Context, id string) (*vulns.Vulnerability, error) {
 	m.getCalls.Add(1)
+	if err := m.getErrs[id]; err != nil {
+		return nil, err
+	}
 	if v, ok := m.vulns[id]; ok {
 		return v, nil
 	}
 	return nil, fmt.Errorf("not found: %s", id)
+}
+
+func TestSyncVulnerabilitiesForDepsPropagatesDetailErrors(t *testing.T) {
+	source := &mockSource{
+		batchRes: [][]vulns.Vulnerability{{{ID: "GHSA-DETAIL"}}},
+		getErrs:  map[string]error{"GHSA-DETAIL": errors.New("detail endpoint unavailable")},
+	}
+	deps := []database.Dependency{{
+		Ecosystem:    "npm",
+		Name:         "foo",
+		Requirement:  "1.0.0",
+		ManifestPath: "package-lock.json",
+		ManifestKind: "lockfile",
+	}}
+
+	db := newTestDB(t)
+	err := syncVulnerabilitiesForDeps(db, source, deps, true, true, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected vulnerability detail error")
+	}
+	for _, want := range []string{"GHSA-DETAIL", "detail endpoint unavailable"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	}
+
+	syncedAt, err := db.GetVulnsSyncedAt("pkg:npm/foo")
+	if err != nil {
+		t.Fatalf("GetVulnsSyncedAt: %v", err)
+	}
+	if !syncedAt.IsZero() {
+		t.Fatalf("failed package marked synced at %v", syncedAt)
+	}
 }
 
 func newTestDB(t *testing.T) *database.DB {

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -178,6 +178,7 @@ Commands support multiple output formats (text, JSON, SARIF) and respect termina
 - Pager follows git precedence: `GIT_PAGER` env, `core.pager` config, `PAGER` env, then `less`
 - Color respects `NO_COLOR` environment variable and `color.pkgs` git config
 - TTY detection disables colors and paging when not connected to a terminal
+- JSON output from `licenses`, `outdated`, `deprecated`, and `vulns scan` wraps result rows with per-ecosystem source status and partial-failure warnings
 
 ## Performance
 

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -879,6 +879,7 @@ func TestEcosystemSourceTimestamps(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	enrichedAt := time.Date(2026, time.August, 20, 10, 0, 0, 0, time.UTC)
+	updatedAt := enrichedAt.Add(time.Hour)
 	vulnsSyncedAt := enrichedAt.Add(2 * time.Hour)
 	_, err = db.Exec(`
 		INSERT INTO packages (
@@ -891,15 +892,15 @@ func TestEcosystemSourceTimestamps(t *testing.T) {
 		enrichedAt.Format(time.RFC3339),
 		vulnsSyncedAt.Format(time.RFC3339),
 		enrichedAt.Format(time.RFC3339),
-		enrichedAt.Format(time.RFC3339),
+		updatedAt.Format(time.RFC3339),
 	)
 	if err != nil {
 		t.Fatalf("insert package: %v", err)
 	}
 
 	gotEnrichedAt, ok := db.EcosystemSyncedAt("npm")
-	if !ok || !gotEnrichedAt.Equal(enrichedAt) {
-		t.Fatalf("EcosystemSyncedAt = %v, %v; want %v, true", gotEnrichedAt, ok, enrichedAt)
+	if !ok || !gotEnrichedAt.Equal(updatedAt) {
+		t.Fatalf("EcosystemSyncedAt = %v, %v; want %v, true", gotEnrichedAt, ok, updatedAt)
 	}
 	gotVulnsSyncedAt, ok := db.EcosystemVulnsSyncedAt("npm")
 	if !ok || !gotVulnsSyncedAt.Equal(vulnsSyncedAt) {

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -870,3 +870,42 @@ func TestSchemaIndexes(t *testing.T) {
 		}
 	}
 }
+
+func TestEcosystemSourceTimestamps(t *testing.T) {
+	db, err := database.Create(filepath.Join(t.TempDir(), "pkgs.sqlite3"))
+	if err != nil {
+		t.Fatalf("create database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	enrichedAt := time.Date(2026, time.August, 20, 10, 0, 0, 0, time.UTC)
+	vulnsSyncedAt := enrichedAt.Add(2 * time.Hour)
+	_, err = db.Exec(`
+		INSERT INTO packages (
+			purl, ecosystem, name, enriched_at, vulns_synced_at, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`,
+		"pkg:npm/example",
+		"npm",
+		"example",
+		enrichedAt.Format(time.RFC3339),
+		vulnsSyncedAt.Format(time.RFC3339),
+		enrichedAt.Format(time.RFC3339),
+		enrichedAt.Format(time.RFC3339),
+	)
+	if err != nil {
+		t.Fatalf("insert package: %v", err)
+	}
+
+	gotEnrichedAt, ok := db.EcosystemSyncedAt("npm")
+	if !ok || !gotEnrichedAt.Equal(enrichedAt) {
+		t.Fatalf("EcosystemSyncedAt = %v, %v; want %v, true", gotEnrichedAt, ok, enrichedAt)
+	}
+	gotVulnsSyncedAt, ok := db.EcosystemVulnsSyncedAt("npm")
+	if !ok || !gotVulnsSyncedAt.Equal(vulnsSyncedAt) {
+		t.Fatalf("EcosystemVulnsSyncedAt = %v, %v; want %v, true", gotVulnsSyncedAt, ok, vulnsSyncedAt)
+	}
+	if _, ok := db.EcosystemSyncedAt("cargo"); ok {
+		t.Fatal("EcosystemSyncedAt(cargo) reported cached data")
+	}
+}

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1847,11 +1847,12 @@ type CachedPackage struct {
 	EnrichedAt    time.Time `json:"enriched_at"`
 }
 
-// EcosystemSyncedAt returns the most recent package enrichment time for an ecosystem.
+// EcosystemSyncedAt returns the most recent package update time for an ecosystem
+// with package enrichment metadata.
 func (db *DB) EcosystemSyncedAt(ecosystem string) (time.Time, bool) {
 	var syncedAt sql.NullString
 	err := db.QueryRow(`
-		SELECT MAX(enriched_at)
+		SELECT MAX(updated_at)
 		FROM packages
 		WHERE ecosystem = ? AND enriched_at IS NOT NULL
 	`, ecosystem).Scan(&syncedAt)

--- a/internal/database/queries.go
+++ b/internal/database/queries.go
@@ -1842,7 +1842,39 @@ type CachedPackage struct {
 	Name          string    `json:"name"`
 	LatestVersion string    `json:"latest_version"`
 	License       string    `json:"license"`
+	RegistryURL   string    `json:"registry_url,omitempty"`
+	Source        string    `json:"source,omitempty"`
 	EnrichedAt    time.Time `json:"enriched_at"`
+}
+
+// EcosystemSyncedAt returns the most recent package enrichment time for an ecosystem.
+func (db *DB) EcosystemSyncedAt(ecosystem string) (time.Time, bool) {
+	var syncedAt sql.NullString
+	err := db.QueryRow(`
+		SELECT MAX(enriched_at)
+		FROM packages
+		WHERE ecosystem = ? AND enriched_at IS NOT NULL
+	`, ecosystem).Scan(&syncedAt)
+	if err != nil || !syncedAt.Valid {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, syncedAt.String)
+	return parsed, err == nil
+}
+
+// EcosystemVulnsSyncedAt returns the most recent vulnerability sync time for an ecosystem.
+func (db *DB) EcosystemVulnsSyncedAt(ecosystem string) (time.Time, bool) {
+	var syncedAt sql.NullString
+	err := db.QueryRow(`
+		SELECT MAX(vulns_synced_at)
+		FROM packages
+		WHERE ecosystem = ? AND vulns_synced_at IS NOT NULL
+	`, ecosystem).Scan(&syncedAt)
+	if err != nil || !syncedAt.Valid {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, syncedAt.String)
+	return parsed, err == nil
 }
 
 // CachedPackageFunding represents cached funding data for a package.
@@ -1922,7 +1954,7 @@ func (db *DB) getCachedPackages(purls []string, staleThreshold *time.Time) (map[
 			args = append(args, staleThreshold.Format(time.RFC3339))
 		}
 
-		query := `SELECT purl, ecosystem, name, latest_version, license, enriched_at
+		query := `SELECT purl, ecosystem, name, latest_version, license, registry_url, source, enriched_at
 			FROM packages
 			WHERE enriched_at IS NOT NULL AND purl IN (` + strings.Join(placeholders, ",") + `)` + freshnessFilter
 
@@ -1933,9 +1965,18 @@ func (db *DB) getCachedPackages(purls []string, staleThreshold *time.Time) (map[
 
 		for rows.Next() {
 			var cp CachedPackage
-			var latestVersion, license sql.NullString
+			var latestVersion, license, registryURL, source sql.NullString
 			var enrichedAt string
-			if err := rows.Scan(&cp.PURL, &cp.Ecosystem, &cp.Name, &latestVersion, &license, &enrichedAt); err != nil {
+			if err := rows.Scan(
+				&cp.PURL,
+				&cp.Ecosystem,
+				&cp.Name,
+				&latestVersion,
+				&license,
+				&registryURL,
+				&source,
+				&enrichedAt,
+			); err != nil {
 				_ = rows.Close()
 				return nil, err
 			}
@@ -1944,6 +1985,12 @@ func (db *DB) getCachedPackages(purls []string, staleThreshold *time.Time) (map[
 			}
 			if license.Valid {
 				cp.License = license.String
+			}
+			if registryURL.Valid {
+				cp.RegistryURL = registryURL.String
+			}
+			if source.Valid {
+				cp.Source = source.String
 			}
 			cp.EnrichedAt, _ = time.Parse(time.RFC3339, enrichedAt)
 			result[cp.PURL] = &cp


### PR DESCRIPTION
Closes #306

## Summary

- Wrap JSON output from `licenses`, `outdated`, `deprecated`, and `vulns scan` in a shared result envelope containing `results`, `sources` and optional `warnings`.
- Report source status by ecosystem and upstream as `ok`, `error`, or `unsupported`.
- Preserve successful partial results when one upstream fails.
- Return a non-zero exit status when all relevant sources fail or are unsupported.
- Include cache and fetch timestamps where available.

## Implementation

- Add shared generic `ResultEnvelope` and `SourceStatus` types with deterministic source ordering.
- Isolate package metadata and OSV lookups by ecosystem so one failure does not discard successful results from other ecosystems.
- Track package enrichment provenance and field-specific cache timestamps using `enriched_at` and `vulns_synced_at`.
- Replace silent deprecated-version lookup omissions with bounded concurrent lookups that retain individual errors.
- Report license package and version lookup failures without dropping available metadata.
- Distinguish unsupported OSV ecosystems from lookup failures and unavailable cached data.
- Update documentation and regression tests for the new JSON contract.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go tool golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`