### PR TITLE
Attach manifest occurrences to SBOM components

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ git pkgs sbom -f xml               # XML instead of JSON
 git pkgs sbom --name my-project    # custom project name
 ```
 
-Includes package URLs (purls), versions, and licenses (fetched from registries). Use `--skip-enrichment` to omit license lookups.
+Includes package URLs (purls), versions, and licenses (fetched from registries). CycloneDX output also includes each component's manifest path, declared requirement, and dependency type as occurrence properties. SPDX output omits occurrence metadata because SPDX 2.3 has no package-properties field. Use `--skip-enrichment` to omit license lookups.
 
 ### Diff between commits or working tree
 

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -12,6 +12,7 @@ import (
 	"github.com/git-pkgs/git-pkgs/internal/git"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/sbom"
+	"github.com/git-pkgs/vers"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +68,8 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 	}
 
 	deps = filterByEcosystem(deps, ecosystem)
-	deps = selectSBOMDependencies(deps)
+	components := selectSBOMDependencies(deps)
+	deps = sbomComponentDependencies(components)
 
 	licenseMap := map[string]string{}
 	if !skipEnrichment {
@@ -96,7 +98,7 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", warning)
 	}
 
-	doc := buildSBOM(deps, licenseMap, projectName, projectVersion, projectLicenses)
+	doc := buildSBOM(components, licenseMap, projectName, projectVersion, projectLicenses)
 	return sbom.Encode(cmd.OutOrStdout(), doc, out)
 }
 
@@ -114,7 +116,7 @@ func sbomFormat(sbomType, format string) (sbom.Format, error) {
 }
 
 func buildSBOM(
-	deps []database.Dependency,
+	components []sbomComponent,
 	licenses map[string]string,
 	name, ver string,
 	projectLicenseData projectLicenses,
@@ -140,11 +142,20 @@ func buildSBOM(
 		},
 		Creators: []sbom.Creator{{Type: "Tool", Name: "git-pkgs-" + version}},
 	}
-	for _, d := range deps {
+	for _, component := range components {
+		d := component.primary
 		purlStr := sbomPURLForDependency(d)
 		p := sbom.Package{
 			Name:    d.Name,
 			Version: d.Requirement,
+		}
+		for i, occurrence := range component.occurrences {
+			prefix := fmt.Sprintf("git-pkgs:occurrence:%d:", i)
+			p.Properties = append(p.Properties,
+				sbom.Property{Name: prefix + "manifest_path", Value: occurrence.ManifestPath},
+				sbom.Property{Name: prefix + "requirement", Value: occurrence.Requirement},
+				sbom.Property{Name: prefix + "dependency_type", Value: occurrence.DependencyType},
+			)
 		}
 		if purlStr != "" {
 			p.ExternalRefs = []sbom.ExternalRef{{
@@ -175,7 +186,17 @@ func sbomPURLForDependency(dep database.Dependency) string {
 	return purl.MakePURLString(dep.Ecosystem, dep.Name, "")
 }
 
-func selectSBOMDependencies(deps []database.Dependency) []database.Dependency {
+type sbomComponent struct {
+	primary     database.Dependency
+	occurrences []database.Dependency
+}
+
+type sbomResolvedCandidate struct {
+	component int
+	direct    bool
+}
+
+func selectSBOMDependencies(deps []database.Dependency) []sbomComponent {
 	resolvedLocations := make(map[string]bool)
 	for _, dep := range deps {
 		if isResolvedDependency(dep) {
@@ -183,20 +204,110 @@ func selectSBOMDependencies(deps []database.Dependency) []database.Dependency {
 		}
 	}
 
-	selected := make([]database.Dependency, 0, len(deps))
-	seen := make(map[string]bool)
+	components := make([]sbomComponent, 0, len(deps))
+	componentByKey := make(map[string]int)
 	for _, dep := range deps {
 		if !isResolvedDependency(dep) && resolvedLocations[sbomDependencyLocation(dep)] {
 			continue
 		}
 		key := sbomDependencyKey(dep)
-		if seen[key] {
+		if _, ok := componentByKey[key]; ok {
 			continue
 		}
-		seen[key] = true
-		selected = append(selected, dep)
+		componentByKey[key] = len(components)
+		components = append(components, sbomComponent{primary: dep})
 	}
-	return selected
+
+	resolvedByLocation := make(map[string][]sbomResolvedCandidate)
+	for _, dep := range deps {
+		if !isResolvedDependency(dep) {
+			continue
+		}
+		component, ok := componentByKey[sbomDependencyKey(dep)]
+		if !ok {
+			continue
+		}
+		location := sbomDependencyLocation(dep)
+		resolvedByLocation[location] = addSBOMResolvedCandidate(
+			resolvedByLocation[location], component, dep.Direct,
+		)
+	}
+
+	for _, dep := range deps {
+		if !isResolvedDependency(dep) && resolvedLocations[sbomDependencyLocation(dep)] {
+			for _, component := range matchingSBOMResolvedComponents(
+				dep,
+				resolvedByLocation[sbomDependencyLocation(dep)],
+				components,
+			) {
+				components[component].occurrences = append(components[component].occurrences, dep)
+			}
+			continue
+		}
+
+		component, ok := componentByKey[sbomDependencyKey(dep)]
+		if ok {
+			components[component].occurrences = append(components[component].occurrences, dep)
+		}
+	}
+
+	return components
+}
+
+func sbomComponentDependencies(components []sbomComponent) []database.Dependency {
+	deps := make([]database.Dependency, 0, len(components))
+	for _, component := range components {
+		deps = append(deps, component.primary)
+	}
+	return deps
+}
+
+func addSBOMResolvedCandidate(
+	candidates []sbomResolvedCandidate,
+	component int,
+	direct bool,
+) []sbomResolvedCandidate {
+	for i := range candidates {
+		if candidates[i].component == component {
+			candidates[i].direct = candidates[i].direct || direct
+			return candidates
+		}
+	}
+	return append(candidates, sbomResolvedCandidate{component: component, direct: direct})
+}
+
+func matchingSBOMResolvedComponents(
+	dep database.Dependency,
+	candidates []sbomResolvedCandidate,
+	components []sbomComponent,
+) []int {
+	matching := make([]sbomResolvedCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		version := components[candidate.component].primary.Requirement
+		matches, err := vers.Satisfies(version, dep.Requirement, strings.ToLower(dep.Ecosystem))
+		if err == nil && matches {
+			matching = append(matching, candidate)
+		}
+	}
+	if len(matching) > 0 {
+		candidates = matching
+	}
+
+	direct := make([]sbomResolvedCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.direct {
+			direct = append(direct, candidate)
+		}
+	}
+	if len(direct) > 0 {
+		candidates = direct
+	}
+
+	result := make([]int, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.component)
+	}
+	return result
 }
 
 func sbomDependencyKey(dep database.Dependency) string {

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -327,14 +327,15 @@ func matchingSBOMResolvedComponents(
 	candidates []sbomResolvedCandidate,
 	components []sbomComponent,
 ) []int {
-	candidates = nearestSBOMResolvedCandidates(path.Dir(dep.ManifestPath), candidates)
+	manifestDirectory := path.Clean(path.Dir(dep.ManifestPath))
+	candidates = nearestSBOMResolvedCandidates(manifestDirectory, candidates)
 	if len(candidates) == 0 {
 		return nil
 	}
 
 	direct := make([]sbomResolvedCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
-		if candidate.direct {
+		if candidate.direct && path.Clean(candidate.directory) == manifestDirectory {
 			direct = append(direct, candidate)
 		}
 	}

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -98,7 +99,14 @@ func runSBOM(cmd *cobra.Command, args []string) error {
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", warning)
 	}
 
-	doc := buildSBOM(components, licenseMap, projectName, projectVersion, projectLicenses)
+	doc := buildSBOM(
+		components,
+		licenseMap,
+		projectName,
+		projectVersion,
+		projectLicenses,
+		out != sbom.FormatSPDXJSON,
+	)
 	return sbom.Encode(cmd.OutOrStdout(), doc, out)
 }
 
@@ -120,6 +128,7 @@ func buildSBOM(
 	licenses map[string]string,
 	name, ver string,
 	projectLicenseData projectLicenses,
+	includeOccurrenceProperties bool,
 ) *sbom.SBOM {
 	s := sbom.New(sbom.TypeCycloneDX)
 	extractedLicenses := make([]sbom.ExtractedLicense, 0, len(projectLicenseData.Files))
@@ -149,13 +158,15 @@ func buildSBOM(
 			Name:    d.Name,
 			Version: d.Requirement,
 		}
-		for i, occurrence := range component.occurrences {
-			prefix := fmt.Sprintf("git-pkgs:occurrence:%d:", i)
-			p.Properties = append(p.Properties,
-				sbom.Property{Name: prefix + "manifest_path", Value: occurrence.ManifestPath},
-				sbom.Property{Name: prefix + "requirement", Value: occurrence.Requirement},
-				sbom.Property{Name: prefix + "dependency_type", Value: occurrence.DependencyType},
-			)
+		if includeOccurrenceProperties {
+			for i, occurrence := range component.occurrences {
+				prefix := fmt.Sprintf("git-pkgs:occurrence:%d:", i)
+				p.Properties = append(p.Properties,
+					sbom.Property{Name: prefix + "manifest_path", Value: occurrence.ManifestPath},
+					sbom.Property{Name: prefix + "requirement", Value: occurrence.Requirement},
+					sbom.Property{Name: prefix + "dependency_type", Value: occurrence.DependencyType},
+				)
+			}
 		}
 		if purlStr != "" {
 			p.ExternalRefs = []sbom.ExternalRef{{
@@ -189,25 +200,20 @@ func sbomPURLForDependency(dep database.Dependency) string {
 type sbomComponent struct {
 	primary     database.Dependency
 	occurrences []database.Dependency
+	order       int
 }
 
 type sbomResolvedCandidate struct {
 	component int
 	direct    bool
+	directory string
 }
 
 func selectSBOMDependencies(deps []database.Dependency) []sbomComponent {
-	resolvedLocations := make(map[string]bool)
-	for _, dep := range deps {
-		if isResolvedDependency(dep) {
-			resolvedLocations[sbomDependencyLocation(dep)] = true
-		}
-	}
-
 	components := make([]sbomComponent, 0, len(deps))
 	componentByKey := make(map[string]int)
 	for _, dep := range deps {
-		if !isResolvedDependency(dep) && resolvedLocations[sbomDependencyLocation(dep)] {
+		if !isResolvedDependency(dep) {
 			continue
 		}
 		key := sbomDependencyKey(dep)
@@ -215,10 +221,10 @@ func selectSBOMDependencies(deps []database.Dependency) []sbomComponent {
 			continue
 		}
 		componentByKey[key] = len(components)
-		components = append(components, sbomComponent{primary: dep})
+		components = append(components, sbomComponent{primary: dep, order: len(deps)})
 	}
 
-	resolvedByLocation := make(map[string][]sbomResolvedCandidate)
+	resolvedByPackage := make(map[string][]sbomResolvedCandidate)
 	for _, dep := range deps {
 		if !isResolvedDependency(dep) {
 			continue
@@ -227,31 +233,66 @@ func selectSBOMDependencies(deps []database.Dependency) []sbomComponent {
 		if !ok {
 			continue
 		}
-		location := sbomDependencyLocation(dep)
-		resolvedByLocation[location] = addSBOMResolvedCandidate(
-			resolvedByLocation[location], component, dep.Direct,
+		packageKey := sbomDependencyPackageKey(dep)
+		resolvedByPackage[packageKey] = addSBOMResolvedCandidate(
+			resolvedByPackage[packageKey],
+			component,
+			dep.Direct,
+			path.Dir(dep.ManifestPath),
 		)
 	}
 
-	for _, dep := range deps {
-		if !isResolvedDependency(dep) && resolvedLocations[sbomDependencyLocation(dep)] {
-			for _, component := range matchingSBOMResolvedComponents(
+	for order, dep := range deps {
+		if !isResolvedDependency(dep) {
+			matched := matchingSBOMResolvedComponents(
 				dep,
-				resolvedByLocation[sbomDependencyLocation(dep)],
+				resolvedByPackage[sbomDependencyPackageKey(dep)],
 				components,
-			) {
-				components[component].occurrences = append(components[component].occurrences, dep)
+			)
+			if len(matched) == 0 {
+				component := ensureSBOMComponent(&components, componentByKey, dep, len(deps))
+				appendSBOMOccurrence(&components[component], dep, order)
+				continue
+			}
+			for _, component := range matched {
+				appendSBOMOccurrence(&components[component], dep, order)
 			}
 			continue
 		}
 
 		component, ok := componentByKey[sbomDependencyKey(dep)]
 		if ok {
-			components[component].occurrences = append(components[component].occurrences, dep)
+			appendSBOMOccurrence(&components[component], dep, order)
 		}
 	}
+	sort.SliceStable(components, func(i, j int) bool {
+		return components[i].order < components[j].order
+	})
 
 	return components
+}
+
+func ensureSBOMComponent(
+	components *[]sbomComponent,
+	componentByKey map[string]int,
+	dep database.Dependency,
+	defaultOrder int,
+) int {
+	key := sbomDependencyKey(dep)
+	if component, ok := componentByKey[key]; ok {
+		return component
+	}
+	component := len(*components)
+	componentByKey[key] = component
+	*components = append(*components, sbomComponent{primary: dep, order: defaultOrder})
+	return component
+}
+
+func appendSBOMOccurrence(component *sbomComponent, dep database.Dependency, order int) {
+	component.occurrences = append(component.occurrences, dep)
+	if order < component.order {
+		component.order = order
+	}
 }
 
 func sbomComponentDependencies(components []sbomComponent) []database.Dependency {
@@ -266,14 +307,19 @@ func addSBOMResolvedCandidate(
 	candidates []sbomResolvedCandidate,
 	component int,
 	direct bool,
+	directory string,
 ) []sbomResolvedCandidate {
 	for i := range candidates {
-		if candidates[i].component == component {
+		if candidates[i].component == component && candidates[i].directory == directory {
 			candidates[i].direct = candidates[i].direct || direct
 			return candidates
 		}
 	}
-	return append(candidates, sbomResolvedCandidate{component: component, direct: direct})
+	return append(candidates, sbomResolvedCandidate{
+		component: component,
+		direct:    direct,
+		directory: directory,
+	})
 }
 
 func matchingSBOMResolvedComponents(
@@ -281,15 +327,28 @@ func matchingSBOMResolvedComponents(
 	candidates []sbomResolvedCandidate,
 	components []sbomComponent,
 ) []int {
+	candidates = nearestSBOMResolvedCandidates(path.Dir(dep.ManifestPath), candidates)
+	if len(candidates) == 0 {
+		return nil
+	}
+
 	matching := make([]sbomResolvedCandidate, 0, len(candidates))
+	constraintSupported := false
 	for _, candidate := range candidates {
 		version := components[candidate.component].primary.Requirement
 		matches, err := vers.Satisfies(version, dep.Requirement, strings.ToLower(dep.Ecosystem))
-		if err == nil && matches {
+		if err != nil {
+			continue
+		}
+		constraintSupported = true
+		if matches {
 			matching = append(matching, candidate)
 		}
 	}
-	if len(matching) > 0 {
+	if constraintSupported {
+		if len(matching) == 0 {
+			return nil
+		}
 		candidates = matching
 	}
 
@@ -304,10 +363,51 @@ func matchingSBOMResolvedComponents(
 	}
 
 	result := make([]int, 0, len(candidates))
+	seen := make(map[int]bool)
 	for _, candidate := range candidates {
+		if seen[candidate.component] {
+			continue
+		}
+		seen[candidate.component] = true
 		result = append(result, candidate.component)
 	}
 	return result
+}
+
+func nearestSBOMResolvedCandidates(
+	manifestDirectory string,
+	candidates []sbomResolvedCandidate,
+) []sbomResolvedCandidate {
+	nearestDepth := -1
+	nearest := make([]sbomResolvedCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !sbomDirectoryContains(candidate.directory, manifestDirectory) {
+			continue
+		}
+		depth := sbomDirectoryDepth(candidate.directory)
+		switch {
+		case depth > nearestDepth:
+			nearestDepth = depth
+			nearest = append(nearest[:0], candidate)
+		case depth == nearestDepth:
+			nearest = append(nearest, candidate)
+		}
+	}
+	return nearest
+}
+
+func sbomDirectoryContains(parent, child string) bool {
+	parent = path.Clean(parent)
+	child = path.Clean(child)
+	return parent == "." || parent == child || strings.HasPrefix(child, parent+"/")
+}
+
+func sbomDirectoryDepth(directory string) int {
+	directory = path.Clean(directory)
+	if directory == "." {
+		return 0
+	}
+	return strings.Count(directory, "/") + 1
 }
 
 func sbomDependencyKey(dep database.Dependency) string {
@@ -318,8 +418,8 @@ func sbomDependencyKey(dep database.Dependency) string {
 		strings.ToLower(dep.Name) + "\x00" + dep.Requirement
 }
 
-func sbomDependencyLocation(dep database.Dependency) string {
-	return strings.ToLower(dep.Ecosystem) + "\x00" + strings.ToLower(dep.Name) + "\x00" + path.Dir(dep.ManifestPath)
+func sbomDependencyPackageKey(dep database.Dependency) string {
+	return strings.ToLower(dep.Ecosystem) + "\x00" + strings.ToLower(dep.Name)
 }
 
 func enrichLicenses(db *database.DB, deps []database.Dependency) (map[string]string, int, error) {

--- a/cmd/sbom.go
+++ b/cmd/sbom.go
@@ -332,6 +332,16 @@ func matchingSBOMResolvedComponents(
 		return nil
 	}
 
+	direct := make([]sbomResolvedCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.direct {
+			direct = append(direct, candidate)
+		}
+	}
+	if len(direct) > 0 {
+		candidates = direct
+	}
+
 	matching := make([]sbomResolvedCandidate, 0, len(candidates))
 	constraintSupported := false
 	for _, candidate := range candidates {
@@ -350,16 +360,6 @@ func matchingSBOMResolvedComponents(
 			return nil
 		}
 		candidates = matching
-	}
-
-	direct := make([]sbomResolvedCandidate, 0, len(candidates))
-	for _, candidate := range candidates {
-		if candidate.direct {
-			direct = append(direct, candidate)
-		}
-	}
-	if len(direct) > 0 {
-		candidates = direct
 	}
 
 	result := make([]int, 0, len(candidates))

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -243,6 +243,82 @@ func TestSBOMCommandAssociatesWorkspaceManifestWithRootLockfile(t *testing.T) {
   }
 }`, "add workspace lockfile")
 
+	document := runSBOMCommandForTest(t, repoDir)
+	var lodashPackages []sbom.Package
+	for _, pkg := range document.Packages {
+		if pkg.Name == "lodash" {
+			lodashPackages = append(lodashPackages, pkg)
+		}
+	}
+	if len(lodashPackages) != 1 {
+		t.Fatalf("lodash components = %d, want 1", len(lodashPackages))
+	}
+	lodash := lodashPackages[0]
+	if lodash.PURL() != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("lodash PURL = %q, want resolved version", lodash.PURL())
+	}
+	if !sbomPropertiesContain(lodash.Properties, "manifest_path", "packages/web/package.json") {
+		t.Fatalf("lodash properties = %+v, want workspace manifest occurrence", lodash.Properties)
+	}
+}
+
+func TestSBOMCommandDoesNotResolveDirectDeclarationToTransitiveVersion(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	commitSBOMFile(t, repository, repoDir, "package.json", `{
+  "name": "direct-precedence",
+  "version": "1.0.0",
+  "dependencies": {"foo": "^5.0.0"}
+}`, "add package manifest")
+	commitSBOMFile(t, repository, repoDir, "package-lock.json", `{
+  "name": "direct-precedence",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "direct-precedence",
+      "version": "1.0.0",
+      "dependencies": {"foo": "^5.0.0"}
+    },
+    "node_modules/foo": {
+      "version": "4.0.0"
+    },
+    "node_modules/bar": {
+      "version": "1.0.0",
+      "dependencies": {"foo": "5.1.0"}
+    },
+    "node_modules/bar/node_modules/foo": {
+      "version": "5.1.0"
+    }
+  }
+}`, "add package lockfile")
+
+	document := runSBOMCommandForTest(t, repoDir)
+	fooByVersion := make(map[string]sbom.Package)
+	for _, pkg := range document.Packages {
+		if pkg.Name == "foo" {
+			fooByVersion[pkg.Version] = pkg
+		}
+	}
+	if len(fooByVersion) != 3 {
+		t.Fatalf("foo components = %+v, want unresolved declaration and two resolved versions", fooByVersion)
+	}
+	declaration, ok := fooByVersion["^5.0.0"]
+	if !ok || declaration.PURL() != "pkg:npm/foo" ||
+		!sbomPropertiesContain(declaration.Properties, "manifest_path", "package.json") {
+		t.Fatalf("unresolved foo declaration = %+v, want package.json occurrence", declaration)
+	}
+	transitive, ok := fooByVersion["5.1.0"]
+	if !ok || sbomPropertiesContain(transitive.Properties, "manifest_path", "package.json") {
+		t.Fatalf("transitive foo component = %+v, must not contain package.json occurrence", transitive)
+	}
+}
+
+func runSBOMCommandForTest(t *testing.T, repoDir string) *sbom.SBOM {
+	t.Helper()
 	oldDirectory, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
@@ -277,22 +353,7 @@ func TestSBOMCommandAssociatesWorkspaceManifestWithRootLockfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse SBOM: %v\n%s", err, output.String())
 	}
-	var lodashPackages []sbom.Package
-	for _, pkg := range document.Packages {
-		if pkg.Name == "lodash" {
-			lodashPackages = append(lodashPackages, pkg)
-		}
-	}
-	if len(lodashPackages) != 1 {
-		t.Fatalf("lodash components = %d, want 1\n%s", len(lodashPackages), output.String())
-	}
-	lodash := lodashPackages[0]
-	if lodash.PURL() != "pkg:npm/lodash@4.17.21" {
-		t.Fatalf("lodash PURL = %q, want resolved version", lodash.PURL())
-	}
-	if !sbomPropertiesContain(lodash.Properties, "manifest_path", "packages/web/package.json") {
-		t.Fatalf("lodash properties = %+v, want workspace manifest occurrence", lodash.Properties)
-	}
+	return document
 }
 
 func sbomPropertiesContain(properties []sbom.Property, suffix, value string) bool {

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -83,7 +83,7 @@ func TestBuildSBOM(t *testing.T) {
 	}
 	licenses := map[string]string{"pkg:npm/lodash@4.17.21": "MIT"}
 
-	doc := buildSBOM(components, licenses, "demo", "1.0.0", projectLicenses{})
+	doc := buildSBOM(components, licenses, "demo", "1.0.0", projectLicenses{}, true)
 
 	if len(doc.Packages) != 2 {
 		t.Fatalf("Packages = %d, want 2", len(doc.Packages))
@@ -140,7 +140,7 @@ func TestEncodeSBOMOccurrencePropertiesCycloneDX(t *testing.T) {
 		DependencyType: "runtime",
 	}
 	document := buildSBOM([]sbomComponent{{primary: dep, occurrences: []database.Dependency{dep}}},
-		nil, "demo", "1.0.0", projectLicenses{})
+		nil, "demo", "1.0.0", projectLicenses{}, true)
 
 	var jsonOutput bytes.Buffer
 	if err := sbom.Encode(&jsonOutput, document, sbom.FormatCycloneDXJSON); err != nil {
@@ -181,6 +181,127 @@ func TestEncodeSBOMOccurrencePropertiesCycloneDX(t *testing.T) {
 		t.Fatalf("properties after CycloneDX XML encoding = %+v, want %+v",
 			properties, document.Packages[0].Properties)
 	}
+}
+
+func TestBuildSBOMOmitsOccurrencePropertiesForSPDX(t *testing.T) {
+	dep := database.Dependency{
+		Ecosystem:      "npm",
+		Name:           "lodash",
+		Requirement:    "4.17.21",
+		ManifestPath:   "package-lock.json",
+		ManifestKind:   manifestKindLockfile,
+		DependencyType: "runtime",
+	}
+	document := buildSBOM([]sbomComponent{{primary: dep, occurrences: []database.Dependency{dep}}},
+		nil, "demo", "1.0.0", projectLicenses{}, false)
+
+	if len(document.Packages) != 1 || len(document.Packages[0].Properties) != 0 {
+		t.Fatalf("SPDX package properties = %+v, want none", document.Packages)
+	}
+	var output bytes.Buffer
+	if err := sbom.Encode(&output, document, sbom.FormatSPDXJSON); err != nil {
+		t.Fatalf("Encode(SPDX JSON): %v", err)
+	}
+	if strings.Contains(output.String(), "git-pkgs:occurrence") {
+		t.Fatalf("SPDX output contains CycloneDX occurrence properties:\n%s", output.String())
+	}
+}
+
+func TestSBOMCommandAssociatesWorkspaceManifestWithRootLockfile(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	commitSBOMFile(t, repository, repoDir, "package.json", `{
+  "name": "workspace-root",
+  "private": true,
+  "workspaces": ["packages/*"]
+}`, "add workspace root")
+	commitSBOMFile(t, repository, repoDir, "packages/web/package.json", `{
+  "name": "web",
+  "version": "1.0.0",
+  "dependencies": {"lodash": "^4.17.0"}
+}`, "add workspace package")
+	commitSBOMFile(t, repository, repoDir, "package-lock.json", `{
+  "name": "workspace-root",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workspace-root",
+      "workspaces": ["packages/*"]
+    },
+    "packages/web": {
+      "name": "web",
+      "version": "1.0.0",
+      "dependencies": {"lodash": "^4.17.0"}
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21"
+    }
+  }
+}`, "add workspace lockfile")
+
+	oldDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(repoDir); err != nil {
+		t.Fatalf("Chdir(%s): %v", repoDir, err)
+	}
+	defer func() {
+		if err := os.Chdir(oldDirectory); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	}()
+
+	command := NewRootCmd()
+	command.SetArgs([]string{"init", "--no-hooks"})
+	command.SetOut(&bytes.Buffer{})
+	command.SetErr(&bytes.Buffer{})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("git pkgs init: %v", err)
+	}
+
+	var output bytes.Buffer
+	command = NewRootCmd()
+	command.SetArgs([]string{"sbom", "--skip-enrichment", "--format", "json"})
+	command.SetOut(&output)
+	command.SetErr(&bytes.Buffer{})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("git pkgs sbom: %v", err)
+	}
+
+	document, err := sbom.Parse(output.Bytes())
+	if err != nil {
+		t.Fatalf("parse SBOM: %v\n%s", err, output.String())
+	}
+	var lodashPackages []sbom.Package
+	for _, pkg := range document.Packages {
+		if pkg.Name == "lodash" {
+			lodashPackages = append(lodashPackages, pkg)
+		}
+	}
+	if len(lodashPackages) != 1 {
+		t.Fatalf("lodash components = %d, want 1\n%s", len(lodashPackages), output.String())
+	}
+	lodash := lodashPackages[0]
+	if lodash.PURL() != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("lodash PURL = %q, want resolved version", lodash.PURL())
+	}
+	if !sbomPropertiesContain(lodash.Properties, "manifest_path", "packages/web/package.json") {
+		t.Fatalf("lodash properties = %+v, want workspace manifest occurrence", lodash.Properties)
+	}
+}
+
+func sbomPropertiesContain(properties []sbom.Property, suffix, value string) bool {
+	for _, property := range properties {
+		if strings.HasSuffix(property.Name, ":"+suffix) && property.Value == value {
+			return true
+		}
+	}
+	return false
 }
 
 func TestProjectLicenseAtRevision(t *testing.T) {
@@ -370,7 +491,7 @@ func testRootLicenses() (*sbom.SBOM, projectLicenses) {
 			Text: "Custom file terms\n",
 		}},
 	}
-	document := buildSBOM(nil, nil, "demo", "1.0.0", licenses)
+	document := buildSBOM(nil, nil, "demo", "1.0.0", licenses, true)
 	return document, licenses
 }
 
@@ -584,6 +705,32 @@ func TestSelectSBOMDependenciesRetainsWorkspaceOccurrences(t *testing.T) {
 	wantOccurrences := []database.Dependency{apiDeclaration, apiResolved, webDeclaration, webResolved}
 	if !slices.Equal(components[0].occurrences, wantOccurrences) {
 		t.Fatalf("occurrences = %+v, want %+v", components[0].occurrences, wantOccurrences)
+	}
+}
+
+func TestSelectSBOMDependenciesKeepsUnmatchedValidConstraintUnresolved(t *testing.T) {
+	declaration := database.Dependency{
+		Ecosystem:    "npm",
+		Name:         "lodash",
+		Requirement:  "^5.0.0",
+		PURL:         "pkg:npm/lodash",
+		ManifestPath: "package.json",
+		ManifestKind: manifestKindManifest,
+	}
+	resolved := declaration
+	resolved.Requirement = "4.17.21"
+	resolved.ManifestPath = "package-lock.json"
+	resolved.ManifestKind = manifestKindLockfile
+
+	components := selectSBOMDependencies([]database.Dependency{declaration, resolved})
+	if len(components) != 2 {
+		t.Fatalf("components = %d, want unresolved declaration and resolved lockfile", len(components))
+	}
+	if components[0].primary != declaration || !slices.Equal(components[0].occurrences, []database.Dependency{declaration}) {
+		t.Fatalf("unresolved component = %+v, want declaration only", components[0])
+	}
+	if components[1].primary != resolved || !slices.Equal(components[1].occurrences, []database.Dependency{resolved}) {
+		t.Fatalf("resolved component = %+v, want lockfile occurrence only", components[1])
 	}
 }
 

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -53,19 +53,37 @@ func (c *sbomEnrichmentClient) GetVersion(_ context.Context, purlStr string) (*e
 }
 
 func TestBuildSBOM(t *testing.T) {
-	deps := []database.Dependency{
-		{
-			Ecosystem:    "npm",
-			Name:         "lodash",
-			Requirement:  "4.17.21",
-			PURL:         "pkg:npm/lodash",
-			ManifestKind: manifestKindLockfile,
-		},
-		{Ecosystem: "npm", Name: "react", Requirement: "18.2.0"},
+	lodashDep := database.Dependency{
+		Ecosystem:      "npm",
+		Name:           "lodash",
+		Requirement:    "4.17.21",
+		PURL:           "pkg:npm/lodash",
+		ManifestPath:   "package-lock.json",
+		ManifestKind:   manifestKindLockfile,
+		DependencyType: "runtime",
+	}
+	lodashDeclaration := database.Dependency{
+		Ecosystem:      "npm",
+		Name:           "lodash",
+		Requirement:    "^4.17.0",
+		PURL:           "pkg:npm/lodash",
+		ManifestPath:   "package.json",
+		ManifestKind:   manifestKindManifest,
+		DependencyType: "runtime",
+	}
+	reactDep := database.Dependency{
+		Ecosystem:    "npm",
+		Name:         "react",
+		Requirement:  "18.2.0",
+		ManifestPath: "package.json",
+	}
+	components := []sbomComponent{
+		{primary: lodashDep, occurrences: []database.Dependency{lodashDeclaration, lodashDep}},
+		{primary: reactDep, occurrences: []database.Dependency{reactDep}},
 	}
 	licenses := map[string]string{"pkg:npm/lodash@4.17.21": "MIT"}
 
-	doc := buildSBOM(deps, licenses, "demo", "1.0.0", projectLicenses{})
+	doc := buildSBOM(components, licenses, "demo", "1.0.0", projectLicenses{})
 
 	if len(doc.Packages) != 2 {
 		t.Fatalf("Packages = %d, want 2", len(doc.Packages))
@@ -79,6 +97,17 @@ func TestBuildSBOM(t *testing.T) {
 	}
 	if lodash.LicenseDeclared != licenses["pkg:npm/lodash@4.17.21"] {
 		t.Errorf("lodash license = %q", lodash.LicenseDeclared)
+	}
+	wantProperties := []sbom.Property{
+		{Name: "git-pkgs:occurrence:0:manifest_path", Value: "package.json"},
+		{Name: "git-pkgs:occurrence:0:requirement", Value: "^4.17.0"},
+		{Name: "git-pkgs:occurrence:0:dependency_type", Value: "runtime"},
+		{Name: "git-pkgs:occurrence:1:manifest_path", Value: "package-lock.json"},
+		{Name: "git-pkgs:occurrence:1:requirement", Value: "4.17.21"},
+		{Name: "git-pkgs:occurrence:1:dependency_type", Value: "runtime"},
+	}
+	if !slices.Equal(lodash.Properties, wantProperties) {
+		t.Errorf("lodash properties = %+v, want %+v", lodash.Properties, wantProperties)
 	}
 	react := doc.Packages[1]
 	if react.PURL() == "" {
@@ -97,6 +126,60 @@ func TestBuildSBOM(t *testing.T) {
 		if !strings.Contains(buf.String(), "pkg:npm/lodash@4.17.21") {
 			t.Errorf("encoded output missing purl:\n%s", buf.String())
 		}
+	}
+}
+
+func TestEncodeSBOMOccurrencePropertiesCycloneDX(t *testing.T) {
+	dep := database.Dependency{
+		Ecosystem:      "npm",
+		Name:           "lodash",
+		Requirement:    "4.17.21",
+		PURL:           "pkg:npm/lodash",
+		ManifestPath:   "package-lock.json",
+		ManifestKind:   manifestKindLockfile,
+		DependencyType: "runtime",
+	}
+	document := buildSBOM([]sbomComponent{{primary: dep, occurrences: []database.Dependency{dep}}},
+		nil, "demo", "1.0.0", projectLicenses{})
+
+	var jsonOutput bytes.Buffer
+	if err := sbom.Encode(&jsonOutput, document, sbom.FormatCycloneDXJSON); err != nil {
+		t.Fatalf("Encode(CycloneDX JSON): %v", err)
+	}
+	parsed, err := sbom.Parse(jsonOutput.Bytes())
+	if err != nil {
+		t.Fatalf("Parse(CycloneDX JSON): %v\n%s", err, jsonOutput.String())
+	}
+	if len(parsed.Packages) != 1 || !slices.Equal(parsed.Packages[0].Properties, document.Packages[0].Properties) {
+		t.Fatalf("properties after CycloneDX JSON round trip = %+v, want %+v",
+			parsed.Packages, document.Packages[0].Properties)
+	}
+
+	var xmlOutput bytes.Buffer
+	if err := sbom.Encode(&xmlOutput, document, sbom.FormatCycloneDXXML); err != nil {
+		t.Fatalf("Encode(CycloneDX XML): %v", err)
+	}
+	var xmlDocument struct {
+		Components []struct {
+			Properties []struct {
+				Name  string `xml:"name,attr"`
+				Value string `xml:",chardata"`
+			} `xml:"properties>property"`
+		} `xml:"components>component"`
+	}
+	if err := xml.Unmarshal(xmlOutput.Bytes(), &xmlDocument); err != nil {
+		t.Fatalf("Unmarshal(CycloneDX XML): %v\n%s", err, xmlOutput.String())
+	}
+	if len(xmlDocument.Components) != 1 {
+		t.Fatalf("CycloneDX XML components = %d, want 1\n%s", len(xmlDocument.Components), xmlOutput.String())
+	}
+	properties := make([]sbom.Property, 0, len(xmlDocument.Components[0].Properties))
+	for _, property := range xmlDocument.Components[0].Properties {
+		properties = append(properties, sbom.Property(property))
+	}
+	if !slices.Equal(properties, document.Packages[0].Properties) {
+		t.Fatalf("properties after CycloneDX XML encoding = %+v, want %+v",
+			properties, document.Packages[0].Properties)
 	}
 }
 
@@ -451,11 +534,56 @@ func TestSelectSBOMDependenciesPrefersResolvedVersions(t *testing.T) {
 	if len(selected) != 2 {
 		t.Fatalf("selected dependencies = %d, want 2", len(selected))
 	}
-	if got := sbomPURLForDependency(selected[0]); got != "pkg:npm/ua-parser-js@1.0.41" {
+	if got := sbomPURLForDependency(selected[0].primary); got != "pkg:npm/ua-parser-js@1.0.41" {
 		t.Fatalf("first PURL = %q, want version 1.0.41", got)
 	}
-	if got := sbomPURLForDependency(selected[1]); got != "pkg:npm/ua-parser-js@2.0.10" {
+	if got := sbomPURLForDependency(selected[1].primary); got != "pkg:npm/ua-parser-js@2.0.10" {
 		t.Fatalf("second PURL = %q, want version 2.0.10", got)
+	}
+	if got := selected[0].occurrences; len(got) != 3 || got[0] != direct || got[1] != resolved || got[2] != resolved {
+		t.Fatalf("first component occurrences = %+v, want direct declaration and both matching lockfile rows", got)
+	}
+	if got := selected[1].occurrences; len(got) != 1 || got[0] != nested {
+		t.Fatalf("second component occurrences = %+v, want only nested lockfile row", got)
+	}
+}
+
+func TestSelectSBOMDependenciesRetainsWorkspaceOccurrences(t *testing.T) {
+	webDeclaration := database.Dependency{
+		Ecosystem:      "npm",
+		Name:           "lodash",
+		Requirement:    "^4.17.0",
+		PURL:           "pkg:npm/lodash",
+		ManifestPath:   "web/package.json",
+		ManifestKind:   manifestKindManifest,
+		DependencyType: "runtime",
+	}
+	apiDeclaration := webDeclaration
+	apiDeclaration.Requirement = "~4.17.15"
+	apiDeclaration.ManifestPath = "api/package.json"
+	webResolved := webDeclaration
+	webResolved.Requirement = "4.17.21"
+	webResolved.ManifestPath = "web/package-lock.json"
+	webResolved.ManifestKind = manifestKindLockfile
+	webResolved.Direct = true
+	apiResolved := webResolved
+	apiResolved.ManifestPath = "api/package-lock.json"
+
+	components := selectSBOMDependencies([]database.Dependency{
+		apiDeclaration,
+		apiResolved,
+		webDeclaration,
+		webResolved,
+	})
+	if len(components) != 1 {
+		t.Fatalf("components = %d, want 1", len(components))
+	}
+	if got := sbomPURLForDependency(components[0].primary); got != "pkg:npm/lodash@4.17.21" {
+		t.Fatalf("component PURL = %q, want resolved PURL", got)
+	}
+	wantOccurrences := []database.Dependency{apiDeclaration, apiResolved, webDeclaration, webResolved}
+	if !slices.Equal(components[0].occurrences, wantOccurrences) {
+		t.Fatalf("occurrences = %+v, want %+v", components[0].occurrences, wantOccurrences)
 	}
 }
 
@@ -469,7 +597,7 @@ func TestSelectSBOMDependenciesKeepsDependenciesWithoutPURL(t *testing.T) {
 		t.Fatalf("selected dependencies = %d, want 2", len(selected))
 	}
 	for _, selectedDep := range selected {
-		if got := sbomPURLForDependency(selectedDep); got != "" {
+		if got := sbomPURLForDependency(selectedDep.primary); got != "" {
 			t.Fatalf("PURL = %q, want empty", got)
 		}
 	}

--- a/cmd/sbom_test.go
+++ b/cmd/sbom_test.go
@@ -317,6 +317,69 @@ func TestSBOMCommandDoesNotResolveDirectDeclarationToTransitiveVersion(t *testin
 	}
 }
 
+func TestSBOMCommandScopesDirectPreferenceToLockfileDirectory(t *testing.T) {
+	repoDir := t.TempDir()
+	repository, err := gitgo.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	commitSBOMFile(t, repository, repoDir, "package.json", `{
+  "name": "workspace-root",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "dependencies": {"foo": "^4.0.0"}
+}`, "add workspace root")
+	commitSBOMFile(t, repository, repoDir, "packages/web/package.json", `{
+  "name": "web",
+  "version": "1.0.0",
+  "dependencies": {"foo": "^5.0.0"}
+}`, "add workspace package")
+	commitSBOMFile(t, repository, repoDir, "package-lock.json", `{
+  "name": "workspace-root",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "workspace-root",
+      "workspaces": ["packages/*"],
+      "dependencies": {"foo": "^4.0.0"}
+    },
+    "packages/web": {
+      "name": "web",
+      "version": "1.0.0",
+      "dependencies": {"foo": "^5.0.0"}
+    },
+    "node_modules/foo": {
+      "version": "4.0.0"
+    },
+    "packages/web/node_modules/foo": {
+      "version": "5.1.0"
+    }
+  }
+}`, "add workspace lockfile")
+
+	document := runSBOMCommandForTest(t, repoDir)
+	fooByVersion := make(map[string]sbom.Package)
+	for _, pkg := range document.Packages {
+		if pkg.Name == "foo" {
+			fooByVersion[pkg.Version] = pkg
+		}
+	}
+	if len(fooByVersion) != 2 {
+		t.Fatalf("foo components = %+v, want two resolved versions", fooByVersion)
+	}
+	root := fooByVersion["4.0.0"]
+	if !sbomPropertiesContain(root.Properties, "manifest_path", "package.json") ||
+		sbomPropertiesContain(root.Properties, "manifest_path", "packages/web/package.json") {
+		t.Fatalf("root foo properties = %+v, want only root declaration", root.Properties)
+	}
+	workspace := fooByVersion["5.1.0"]
+	if !sbomPropertiesContain(workspace.Properties, "manifest_path", "packages/web/package.json") ||
+		sbomPropertiesContain(workspace.Properties, "manifest_path", "package.json") {
+		t.Fatalf("workspace foo properties = %+v, want only workspace declaration", workspace.Properties)
+	}
+}
+
 func runSBOMCommandForTest(t *testing.T, repoDir string) *sbom.SBOM {
 	t.Helper()
 	oldDirectory, err := os.Getwd()

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/git-pkgs/git-pkgs
 
-go 1.26.5
-
-toolchain go1.26.6
+go 1.26.7
 
 require (
 	github.com/git-pkgs/changelog v0.2.0
@@ -14,7 +12,7 @@ require (
 	github.com/git-pkgs/registries v0.8.0
 	github.com/git-pkgs/resolve v0.2.2
 	github.com/git-pkgs/sarif v0.1.2
-	github.com/git-pkgs/sbom v0.1.6-0.20260827120627-232d3db4cafb
+	github.com/git-pkgs/sbom v0.1.6
 	github.com/git-pkgs/spdx v0.3.1
 	github.com/git-pkgs/vers v0.6.0
 	github.com/git-pkgs/vulns v0.2.2

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/git-pkgs/registries v0.8.0
 	github.com/git-pkgs/resolve v0.2.2
 	github.com/git-pkgs/sarif v0.1.2
-	github.com/git-pkgs/sbom v0.1.5
+	github.com/git-pkgs/sbom v0.1.6-0.20260827120627-232d3db4cafb
 	github.com/git-pkgs/spdx v0.3.1
 	github.com/git-pkgs/vers v0.6.0
 	github.com/git-pkgs/vulns v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/git-pkgs/resolve v0.2.2 h1:jjr6qa/8b/edg3tub5WYyYV04OpfWCuGZzgVYnfGl3
 github.com/git-pkgs/resolve v0.2.2/go.mod h1:KT894HOGMudjhSUWGHW1mC4r01eBaVaf0ujYhEHPMvo=
 github.com/git-pkgs/sarif v0.1.2 h1:4XN4OukEjrYhUz6kdXjhtjzrwKDcc6AuFnFRY3H6UK4=
 github.com/git-pkgs/sarif v0.1.2/go.mod h1:5I+Oc0unaVewVpNXPcVYrCB2Nw4icSdxiJnC3kmatNM=
-github.com/git-pkgs/sbom v0.1.6-0.20260827120627-232d3db4cafb h1:iRKnU0Vj7WUpkTPpXUjdZ1HQh+7hZ4Ih2+tM0QkmQ6c=
-github.com/git-pkgs/sbom v0.1.6-0.20260827120627-232d3db4cafb/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
+github.com/git-pkgs/sbom v0.1.6 h1:bHgk58NmpDZVNFe+6+kTEigrCaYkmpLjjDl8V0X9+RA=
+github.com/git-pkgs/sbom v0.1.6/go.mod h1:CHxXSiOfsMRzF7SfvlTlZ2xhJE+NbZ/GK/lFuEYGC3U=
 github.com/git-pkgs/spdx v0.3.1 h1:58JPY5X9pYpXvnzzZIgehItlBykeOOw52pNc4OBcS+c=
 github.com/git-pkgs/spdx v0.3.1/go.mod h1:cqRoZcvl530s/W+oGNvwjt4ODN8T1W6D/20MUZEFdto=
 github.com/git-pkgs/vers v0.6.0 h1:droJw8+oSyl8/UoDj/96B9ZPggmxJDTl/JeixzfKzSc=

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/git-pkgs/resolve v0.2.2 h1:jjr6qa/8b/edg3tub5WYyYV04OpfWCuGZzgVYnfGl3
 github.com/git-pkgs/resolve v0.2.2/go.mod h1:KT894HOGMudjhSUWGHW1mC4r01eBaVaf0ujYhEHPMvo=
 github.com/git-pkgs/sarif v0.1.2 h1:4XN4OukEjrYhUz6kdXjhtjzrwKDcc6AuFnFRY3H6UK4=
 github.com/git-pkgs/sarif v0.1.2/go.mod h1:5I+Oc0unaVewVpNXPcVYrCB2Nw4icSdxiJnC3kmatNM=
-github.com/git-pkgs/sbom v0.1.5 h1:qWyZlqaeroTcImKm5qt65ElAQTYCjnLlvflzAj4B2Po=
-github.com/git-pkgs/sbom v0.1.5/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
+github.com/git-pkgs/sbom v0.1.6-0.20260827120627-232d3db4cafb h1:iRKnU0Vj7WUpkTPpXUjdZ1HQh+7hZ4Ih2+tM0QkmQ6c=
+github.com/git-pkgs/sbom v0.1.6-0.20260827120627-232d3db4cafb/go.mod h1:42YiJ+W9jBsPZnYJQs6tUlOtWlC0vDBOtND8TMwE8ek=
 github.com/git-pkgs/spdx v0.3.1 h1:58JPY5X9pYpXvnzzZIgehItlBykeOOw52pNc4OBcS+c=
 github.com/git-pkgs/spdx v0.3.1/go.mod h1:cqRoZcvl530s/W+oGNvwjt4ODN8T1W6D/20MUZEFdto=
 github.com/git-pkgs/vers v0.6.0 h1:droJw8+oSyl8/UoDj/96B9ZPggmxJDTl/JeixzfKzSc=


### PR DESCRIPTION
Closes #307 
## Summary

- Retain every manifest and lockfile occurrence represented by a deduplicated SBOM component.
- Emit indexed occurrence properties containing:
  - `manifest_path`
  - `requirement`
  - `dependency_type`
- Preserve the existing preference for resolved versions as component primaries.
- Associate manifest ranges with compatible resolved components, preferring direct lockfile entries when available.
- Preserve deterministic component and occurrence ordering.
- Update `github.com/git-pkgs/sbom` to the merged commit from git-pkgs/sbom#14 so properties are encoded in CycloneDX JSON and XML.

## Dependency version

`github.com/git-pkgs/sbom` is currently pinned to the immutable pseudo-version for the merged git-pkgs/sbom#14 commit because `v0.1.6` has not yet been tagged.

The dependency can be changed to `v0.1.6` if that tag is published before this PR merges.

## Testing

Added regression coverage for:

- Indexed occurrence property generation.
- CycloneDX JSON and XML property encoding.
- Multiple declarations of one component across workspace manifests.
- Manifest range association when multiple resolved versions exist.
- Existing resolved-version preference and dependencies without PURLs.

## Verification

- `gofmt`
- `go test ./... -count=1`
- `go tool golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`

