### PR TITLE
Fix vulns blame branch snapshot selection

### DIFF
--- a/cmd/vulns.go
+++ b/cmd/vulns.go
@@ -1514,7 +1514,7 @@ func runVulnsBlame(cmd *cobra.Command, args []string) error {
 	if allTime {
 		vulns, err = getAllTimeVulns(db, branch.ID, ecosystem, ecosystemFilter)
 	} else {
-		vulns, err = getVulnsAtRef(repo, db, branch.ID, refHEAD, ecosystem, ecosystemFilter)
+		vulns, err = getVulnsAtCommit(db, branch.ID, branch.LastAnalyzedSHA, ecosystem, ecosystemFilter)
 	}
 	if err != nil {
 		return fmt.Errorf("getting vulnerabilities: %w", err)

--- a/cmd/vulns_blame_test.go
+++ b/cmd/vulns_blame_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"encoding/json"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -33,6 +34,63 @@ func TestVulnsBlameResolvesHEAD(t *testing.T) {
 	}
 
 	t.Fatalf("expected express vulnerability blame entry, got: %#v", entries)
+}
+
+func TestVulnsBlameUsesSelectedBranchTip(t *testing.T) {
+	repoDir := createTestRepo(t)
+	addFileAndCommit(t, repoDir, "README.md", "# Test repository\n", "Initial commit")
+
+	gitCmd := exec.Command("git", "checkout", "-b", "feature")
+	gitCmd.Dir = repoDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("creating feature branch: %v", err)
+	}
+	addFileAndCommit(t, repoDir, "package.json", packageJSON, "Add package.json")
+	addFileAndCommit(t, repoDir, "package-lock.json", packageLockJSON, "Add package-lock.json")
+
+	cleanup := chdir(t, repoDir)
+	defer cleanup()
+
+	if _, _, err := runCmd(t, "init", "--branch", "feature", "--no-hooks"); err != nil {
+		t.Fatalf("init feature failed: %v", err)
+	}
+	vuln := insertTestNPMVulnerability(t, repoDir, "GHSA-issue-346")
+
+	gitCmd = exec.Command("git", "checkout", "main")
+	gitCmd.Dir = repoDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("checking out main: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "explicit branch", args: []string{"vulns", "blame", "--branch", "feature", "--format", "json"}},
+		{name: "default database branch", args: []string{"vulns", "blame", "--format", "json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, _, err := runCmd(t, tt.args...)
+			if err != nil {
+				t.Fatalf("vulns blame failed: %v", err)
+			}
+
+			var entries []struct {
+				VulnID  string `json:"vuln_id"`
+				Package string `json:"package"`
+			}
+			if err := json.Unmarshal([]byte(stdout), &entries); err != nil {
+				t.Fatalf("parsing vulns blame output: %v", err)
+			}
+			for _, entry := range entries {
+				if entry.VulnID == vuln.ID && entry.Package == "express" {
+					return
+				}
+			}
+			t.Fatalf("expected express vulnerability from feature branch, got: %#v", entries)
+		})
+	}
 }
 
 func TestVulnsExposureResolvesHEAD(t *testing.T) {
@@ -75,13 +133,18 @@ func setupVulnerableNPMRepo(t *testing.T) database.Vulnerability {
 		t.Fatalf("init failed: %v", err)
 	}
 
+	return insertTestNPMVulnerability(t, repoDir, "GHSA-issue-299")
+}
+
+func insertTestNPMVulnerability(t *testing.T, repoDir, id string) database.Vulnerability {
+	t.Helper()
 	db, err := database.Open(filepath.Join(repoDir, ".git", "pkgs.sqlite3"))
 	if err != nil {
 		t.Fatalf("opening database: %v", err)
 	}
 
 	vuln := database.Vulnerability{
-		ID:        "GHSA-issue-299",
+		ID:        id,
 		Severity:  "high",
 		Summary:   "Test vulnerability",
 		FetchedAt: time.Now().Format(time.RFC3339),


### PR DESCRIPTION
Closes #346

## Summary

- Query the selected database branch's `LastAnalyzedSHA` in `git pkgs vulns blame`.
- Stop combining the selected branch ID with the currently checked-out repository `HEAD`.
- Ensure explicit and default branch selection returns vulnerabilities from the selected branch's indexed tip.

## Testing

Added end-to-end regression coverage that:

- Indexes a vulnerable dependency on a feature branch.
- Checks out a different branch.
- Verifies `vulns blame --branch feature` still reports the vulnerability.
- Verifies default database-branch selection also uses the indexed branch tip.
- Preserves the existing `HEAD` resolution and exposure tests.

## Verification

- `go test ./... -count=1`
- `go tool golangci-lint run ./...`
- `go mod tidy -diff`
- `git diff --check`